### PR TITLE
Improve planet ownership and local-play UX

### DIFF
--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -285,9 +285,10 @@ pub fn start_scenario_loop(
             scenario.spacewars_panel_state(paused, benchmark_active, &performance_text),
         );
         set_ingame_menu(&window, paused);
+        let viewport = Viewport::from_window(window.window());
         present_frames(
             &window,
-            scenario.render_frames(renderer),
+            scenario.render_frames(renderer, viewport),
             scenario.frame_layout(),
             renderer,
             raster_scale,
@@ -492,6 +493,7 @@ fn step_scenario(
 
 fn show_running_launcher(window: &MainWindow) {
     window.set_primitives(ModelRc::new(VecModel::from(Vec::<ScenePrimitive>::new())));
+    window.set_vector_minimaps_visible(false);
     window.set_raster_visible(false);
     window.set_spacewars_ui_visible(false);
     window.set_ingame_menu_visible(false);
@@ -647,11 +649,11 @@ fn present_frames(
     let viewport = Viewport::from_window(window.window());
     let scene_item_count = match renderer {
         RenderBackend::Vector => {
-            let primitives =
-                render::scene_primitives_from_frames_with_layout(&frames, viewport, layout);
-            let scene_item_count = primitives.len();
+            let presentation =
+                render::scene_presentation_from_frames_with_layout(&frames, viewport, layout);
+            let scene_item_count = presentation.scene_item_count();
             window.set_raster_visible(false);
-            window.set_primitives(ModelRc::new(VecModel::from(primitives)));
+            set_vector_presentation(window, presentation);
             scene_item_count
         }
         RenderBackend::Raster => {
@@ -663,6 +665,7 @@ fn present_frames(
                 raster::RasterOptions::for_scale(raster_scale),
             );
             window.set_primitives(ModelRc::new(VecModel::from(Vec::new())));
+            window.set_vector_minimaps_visible(false);
             window.set_raster_frame(image);
             window.set_raster_visible(true);
             primitive_count
@@ -670,6 +673,31 @@ fn present_frames(
     };
     window.window().request_redraw();
     scene_item_count
+}
+
+fn set_vector_presentation(window: &MainWindow, presentation: render::VectorPresentation) {
+    window.set_primitives(ModelRc::new(VecModel::from(presentation.main_primitives)));
+    window.set_minimap_opacity(render::SPACEWARS_MINIMAP_OPACITY);
+
+    let mut minimaps = presentation.minimaps.into_iter();
+    let Some(player_1) = minimaps.next() else {
+        window.set_vector_minimaps_visible(false);
+        return;
+    };
+    let Some(player_2) = minimaps.next() else {
+        window.set_vector_minimaps_visible(false);
+        return;
+    };
+
+    window.set_p1_minimap_x(player_1.viewport.x);
+    window.set_p1_minimap_y(player_1.viewport.y);
+    window.set_p1_minimap_size(player_1.viewport.width);
+    window.set_p1_minimap_primitives(ModelRc::new(VecModel::from(player_1.primitives)));
+    window.set_p2_minimap_x(player_2.viewport.x);
+    window.set_p2_minimap_y(player_2.viewport.y);
+    window.set_p2_minimap_size(player_2.viewport.width);
+    window.set_p2_minimap_primitives(ModelRc::new(VecModel::from(player_2.primitives)));
+    window.set_vector_minimaps_visible(true);
 }
 
 pub fn run_spacewars_benchmark(
@@ -706,7 +734,7 @@ pub fn run_spacewars_benchmark(
             sample.step_time += step_started.elapsed();
 
             let render_started = Instant::now();
-            let frames = scenario.render_frames(options.renderer);
+            let frames = scenario.render_frames(options.renderer, BENCHMARK_VIEWPORT);
             sample.render_time += render_started.elapsed();
 
             let present_started = Instant::now();
@@ -752,13 +780,13 @@ fn present_frames_for_benchmark(
 ) -> PresentationStats {
     match renderer {
         RenderBackend::Vector => {
-            let primitives = render::scene_primitives_from_frames_with_layout(
+            let presentation = render::scene_presentation_from_frames_with_layout(
                 frames,
                 BENCHMARK_VIEWPORT,
                 layout,
             );
-            let scene_item_count = primitives.len();
-            black_box(primitives);
+            let scene_item_count = presentation.scene_item_count();
+            black_box(presentation);
             PresentationStats {
                 scene_items: scene_item_count,
                 raster_timings: raster::RasterTimings::default(),
@@ -1056,13 +1084,22 @@ impl HostedScenario {
         }
     }
 
-    pub(crate) fn render_frames(&self, renderer: RenderBackend) -> Vec<RenderFrame> {
+    pub(crate) fn render_frames(
+        &self,
+        renderer: RenderBackend,
+        viewport: Viewport,
+    ) -> Vec<RenderFrame> {
+        let player_view_aspect_ratio =
+            render::frame_viewports(viewport, 4, render::FrameLayout::SpacewarsLocalPlay)[0]
+                .aspect_ratio();
         match self {
             Self::Null(state) => vec![NullScenario::render_frame(state)],
             Self::Spacewars(state) if renderer == RenderBackend::Raster => {
-                SpacewarsScenario::render_raster_local_play_frames(state)
+                SpacewarsScenario::render_raster_local_play_frames(state, player_view_aspect_ratio)
             }
-            Self::Spacewars(state) => SpacewarsScenario::render_local_play_frames(state),
+            Self::Spacewars(state) => {
+                SpacewarsScenario::render_local_play_frames(state, player_view_aspect_ratio)
+            }
         }
     }
 
@@ -1310,7 +1347,8 @@ mod tests {
     #[test]
     fn spacewars_scenario_renders_original_style_local_play_frames_for_client() {
         let scenario = hosted_scenario("spacewars", 0).unwrap();
-        let frames = scenario.render_frames(RenderBackend::Vector);
+        let viewport = Viewport::new(1000.0, 700.0);
+        let frames = scenario.render_frames(RenderBackend::Vector, viewport);
 
         let HostedScenario::Spacewars(state) = &scenario else {
             panic!("spacewars scenario should not host null");
@@ -1325,6 +1363,19 @@ mod tests {
         assert_eq!(frames[2].camera.center.x, 1200.0);
         assert_eq!(frames[2].camera.center.y, 1200.0);
         assert_eq!(frames[3].camera, frames[2].camera);
+        let view_rectangle = frames[2]
+            .layers
+            .iter()
+            .find(|layer| layer.z == 8)
+            .and_then(|layer| layer.primitives.first())
+            .expect("overview should contain the player view rectangle");
+        let engine_common::RenderPrimitive::Polygon(view_rectangle) = view_rectangle else {
+            panic!("player view rectangle should be a polygon");
+        };
+        let visible_width = view_rectangle.points[1].x - view_rectangle.points[0].x;
+        let visible_height = view_rectangle.points[2].y - view_rectangle.points[1].y;
+        let expected_aspect_ratio = (viewport.width * 0.5) / viewport.height;
+        assert!((visible_width / visible_height - expected_aspect_ratio).abs() <= 1.0e-5);
         assert_eq!(
             scenario.frame_layout(),
             render::FrameLayout::SpacewarsLocalPlay

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -660,7 +660,7 @@ fn present_frames(
                 &frames,
                 scaled_viewport(viewport, raster_scale),
                 layout,
-                raster::RasterOptions::default(),
+                raster::RasterOptions::for_scale(raster_scale),
             );
             window.set_primitives(ModelRc::new(VecModel::from(Vec::new())));
             window.set_raster_frame(image);
@@ -770,7 +770,7 @@ fn present_frames_for_benchmark(
                 frames,
                 scaled_viewport(BENCHMARK_VIEWPORT, raster_scale),
                 layout,
-                raster::RasterOptions::default(),
+                raster::RasterOptions::for_scale(raster_scale),
             );
             black_box(result.image);
             PresentationStats {

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -31,6 +31,7 @@ pub(crate) enum GameKey {
     ReturnLauncher,
     P1Wing,
     P1Thrust,
+    P1Brake,
     P1Reverse,
     P1TurnLeft,
     P1TurnRight,
@@ -40,6 +41,7 @@ pub(crate) enum GameKey {
     P1ZoomOut,
     P2Wing,
     P2Thrust,
+    P2Brake,
     P2Reverse,
     P2TurnLeft,
     P2TurnRight,
@@ -117,6 +119,7 @@ impl ClientInput {
                 player: 0,
                 wing: GameKey::P1Wing,
                 thrust: GameKey::P1Thrust,
+                brake: GameKey::P1Brake,
                 reverse: GameKey::P1Reverse,
                 turn_left: GameKey::P1TurnLeft,
                 turn_right: GameKey::P1TurnRight,
@@ -132,6 +135,7 @@ impl ClientInput {
                 player: 1,
                 wing: GameKey::P2Wing,
                 thrust: GameKey::P2Thrust,
+                brake: GameKey::P2Brake,
                 reverse: GameKey::P2Reverse,
                 turn_left: GameKey::P2TurnLeft,
                 turn_right: GameKey::P2TurnRight,
@@ -164,18 +168,30 @@ impl ClientInput {
     }
 
     fn append_player_actions(&self, controls: PlayerControlMap, actions: &mut Vec<Action>) {
-        if self.pressed.contains(&controls.wing) {
+        let wing_control_active = if self.pressed.contains(&controls.wing) {
             actions.push(SpacewarsAction::close_wings(controls.player));
+            true
         } else if self.released.contains(&controls.wing) {
             actions.push(SpacewarsAction::open_wings(controls.player));
-        } else if self.pressed.contains(&controls.thrust) {
-            actions.push(SpacewarsAction::thrust(controls.player));
-        } else if self.pressed.contains(&controls.reverse) {
-            actions.push(SpacewarsAction::reverse(controls.player));
-        } else if self.released.contains(&controls.thrust)
-            || self.released.contains(&controls.reverse)
-        {
-            actions.push(SpacewarsAction::thrust_halt(controls.player));
+            true
+        } else {
+            false
+        };
+
+        if self.pressed.contains(&controls.brake) {
+            actions.push(SpacewarsAction::brake(controls.player));
+        } else if self.released.contains(&controls.brake) {
+            actions.push(SpacewarsAction::brake_halt(controls.player));
+        } else if !wing_control_active {
+            if self.pressed.contains(&controls.thrust) {
+                actions.push(SpacewarsAction::thrust(controls.player));
+            } else if self.pressed.contains(&controls.reverse) {
+                actions.push(SpacewarsAction::reverse(controls.player));
+            } else if self.released.contains(&controls.thrust)
+                || self.released.contains(&controls.reverse)
+            {
+                actions.push(SpacewarsAction::thrust_halt(controls.player));
+            }
         }
 
         if self.pressed.contains(&controls.turn_left) {
@@ -213,6 +229,7 @@ struct PlayerControlMap {
     player: usize,
     wing: GameKey,
     thrust: GameKey,
+    brake: GameKey,
     reverse: GameKey,
     turn_left: GameKey,
     turn_right: GameKey,
@@ -246,7 +263,8 @@ fn game_key_from_key_code(code: KeyCode) -> Option<GameKey> {
         KeyCode::KeyQ => Some(GameKey::ReturnLauncher),
         KeyCode::KeyJ => Some(GameKey::P1Wing),
         KeyCode::KeyW => Some(GameKey::P1Thrust),
-        KeyCode::KeyS => Some(GameKey::P1Reverse),
+        KeyCode::KeyS => Some(GameKey::P1Brake),
+        KeyCode::KeyX => Some(GameKey::P1Reverse),
         KeyCode::KeyA => Some(GameKey::P1TurnLeft),
         KeyCode::KeyD => Some(GameKey::P1TurnRight),
         KeyCode::Space => Some(GameKey::P1Laser),
@@ -255,7 +273,8 @@ fn game_key_from_key_code(code: KeyCode) -> Option<GameKey> {
         KeyCode::KeyI => Some(GameKey::P1ZoomOut),
         KeyCode::PageDown => Some(GameKey::P2Wing),
         KeyCode::Numpad8 => Some(GameKey::P2Thrust),
-        KeyCode::Numpad5 => Some(GameKey::P2Reverse),
+        KeyCode::Numpad5 => Some(GameKey::P2Brake),
+        KeyCode::Numpad2 => Some(GameKey::P2Reverse),
         KeyCode::Numpad4 => Some(GameKey::P2TurnLeft),
         KeyCode::Numpad6 => Some(GameKey::P2TurnRight),
         KeyCode::Delete => Some(GameKey::P2Laser),
@@ -319,7 +338,57 @@ mod tests {
     }
 
     #[test]
-    fn p2_controls_use_original_numpad_and_navigation_keys() {
+    fn brake_and_reverse_keys_use_distinct_keyboard_rows() {
+        assert_eq!(
+            game_key_from_key_code(KeyCode::KeyS),
+            Some(GameKey::P1Brake)
+        );
+        assert_eq!(
+            game_key_from_key_code(KeyCode::KeyX),
+            Some(GameKey::P1Reverse)
+        );
+        assert_eq!(
+            game_key_from_key_code(KeyCode::Numpad5),
+            Some(GameKey::P2Brake)
+        );
+        assert_eq!(
+            game_key_from_key_code(KeyCode::Numpad2),
+            Some(GameKey::P2Reverse)
+        );
+    }
+
+    #[test]
+    fn brake_has_propulsion_priority_and_remains_available_with_wings() {
+        let mut input = ClientInput::default();
+        input.press(GameKey::P1Wing);
+        input.press(GameKey::P1Thrust);
+        input.press(GameKey::P1Reverse);
+        input.press(GameKey::P1Brake);
+
+        let actions = decoded(&input.actions_for_spacewars());
+
+        assert!(has_action(&actions, 0, SpacewarsActionKind::CloseWings));
+        assert!(has_action(&actions, 0, SpacewarsActionKind::Brake));
+        assert!(!has_action(&actions, 0, SpacewarsActionKind::Thrust));
+        assert!(!has_action(&actions, 0, SpacewarsActionKind::Reverse));
+    }
+
+    #[test]
+    fn brake_release_emits_one_tick_brake_halt() {
+        let mut input = ClientInput::default();
+        input.press(GameKey::P1Brake);
+        input.actions_for_spacewars();
+
+        input.release(GameKey::P1Brake);
+        let actions = decoded(&input.actions_for_spacewars());
+        assert!(has_action(&actions, 0, SpacewarsActionKind::BrakeHalt));
+
+        let actions = decoded(&input.actions_for_spacewars());
+        assert!(!has_action(&actions, 0, SpacewarsActionKind::BrakeHalt));
+    }
+
+    #[test]
+    fn p2_controls_use_numpad_and_navigation_keys() {
         assert_eq!(
             game_key_from_key_code(KeyCode::PageDown),
             Some(GameKey::P2Wing)
@@ -330,6 +399,10 @@ mod tests {
         );
         assert_eq!(
             game_key_from_key_code(KeyCode::Numpad5),
+            Some(GameKey::P2Brake)
+        );
+        assert_eq!(
+            game_key_from_key_code(KeyCode::Numpad2),
             Some(GameKey::P2Reverse)
         );
         assert_eq!(

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -351,6 +351,7 @@ fn should_launch_directly(args: &Args) -> bool {
 
 fn show_launcher(window: &MainWindow, launch: &EffectiveLaunch, setup: &SpacewarsSettings) {
     window.set_primitives(ModelRc::new(VecModel::from(Vec::<ScenePrimitive>::new())));
+    window.set_vector_minimaps_visible(false);
     window.set_raster_visible(false);
     window.set_spacewars_ui_visible(false);
     window.set_ingame_menu_visible(false);

--- a/crates/engine-client/src/raster.rs
+++ b/crates/engine-client/src/raster.rs
@@ -39,15 +39,32 @@ const BACKGROUND: Rgba8Pixel = Rgba8Pixel {
     a: 255,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RasterOptions {
     pub overview_cache_period: u64,
+    pub overview_minimum_object_diameter: f32,
 }
 
 impl Default for RasterOptions {
     fn default() -> Self {
         Self {
             overview_cache_period: DEFAULT_OVERVIEW_CACHE_PERIOD,
+            overview_minimum_object_diameter: render::MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER,
+        }
+    }
+}
+
+impl RasterOptions {
+    pub fn for_scale(output_scale: f32) -> Self {
+        let output_scale = if output_scale.is_finite() {
+            output_scale.clamp(0.1, 3.0)
+        } else {
+            1.0
+        };
+        Self {
+            overview_minimum_object_diameter: render::MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER
+                * output_scale,
+            ..Self::default()
         }
     }
 }
@@ -334,10 +351,20 @@ fn draw_cached_overview(
         let started = Instant::now();
         let pixels = cache.pixels.make_mut_slice();
         clear_pixels(pixels);
+        let cache_viewport = Viewport::new(width as f32, height as f32);
         Canvas::new(width, height, pixels).draw_frame_filtered(
             frame,
-            Viewport::new(width as f32, height as f32),
-            is_cached_overview_primitive,
+            cache_viewport,
+            |z, primitive| {
+                is_cached_overview_primitive(z, primitive)
+                    && render::spacewars_overview_primitive_visible(
+                        frame.camera,
+                        cache_viewport,
+                        z,
+                        primitive,
+                        options.overview_minimum_object_diameter,
+                    )
+            },
         );
         cache.valid = true;
         timings.overview_refresh += started.elapsed();
@@ -354,7 +381,16 @@ fn draw_cached_overview(
     timings.overview_blit += started.elapsed();
 
     let started = Instant::now();
-    canvas.draw_frame_filtered(frame, viewport, is_live_overview_primitive);
+    canvas.draw_frame_filtered(frame, viewport, |z, primitive| {
+        is_live_overview_primitive(z, primitive)
+            && render::spacewars_overview_primitive_visible(
+                frame.camera,
+                viewport,
+                z,
+                primitive,
+                options.overview_minimum_object_diameter,
+            )
+    });
     timings.overview_live += started.elapsed();
 }
 
@@ -1647,5 +1683,61 @@ mod tests {
         );
 
         assert_eq!(primitive_count(&[frame]), 2);
+    }
+
+    #[test]
+    fn raster_scale_preserves_logical_overview_cutoff() {
+        assert_eq!(
+            RasterOptions::for_scale(2.0).overview_minimum_object_diameter,
+            render::MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER * 2.0
+        );
+        assert_eq!(
+            RasterOptions::for_scale(f32::NAN).overview_minimum_object_diameter,
+            render::MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER
+        );
+    }
+
+    #[test]
+    fn spacewars_raster_overview_skips_tiny_debris() {
+        let player_frames = [
+            RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0)),
+            RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0)),
+        ];
+        let mut tiny_overview = RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0));
+        tiny_overview.push_primitive(
+            SPACEWARS_DEBRIS_LAYER,
+            RenderPrimitive::Circle(RenderCircle::filled(
+                RenderPoint::ZERO,
+                0.1,
+                RenderColor::RED,
+            )),
+        );
+        let mut visible_overview = RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0));
+        visible_overview.push_primitive(
+            SPACEWARS_DEBRIS_LAYER,
+            RenderPrimitive::Circle(RenderCircle::filled(
+                RenderPoint::ZERO,
+                10.0,
+                RenderColor::BLUE,
+            )),
+        );
+        let frames = [
+            player_frames[0].clone(),
+            player_frames[1].clone(),
+            tiny_overview,
+            visible_overview,
+        ];
+
+        let image = image_from_frames_with_layout(
+            &frames,
+            Viewport::new(100.0, 100.0),
+            FrameLayout::SpacewarsLocalPlay,
+        );
+        let pixels = image.to_rgba8().expect("raster image should be rgba8");
+        let left_overview_center = pixels.as_slice()[79 * 100 + 18];
+        let right_overview_center = pixels.as_slice()[79 * 100 + 82];
+
+        assert_eq!(left_overview_center, BACKGROUND);
+        assert!(right_overview_center.b > BACKGROUND.b);
     }
 }

--- a/crates/engine-client/src/raster.rs
+++ b/crates/engine-client/src/raster.rs
@@ -149,7 +149,7 @@ pub struct RasterRenderer {
     height: u32,
     active_buffer: usize,
     frame_index: u64,
-    overview_cache: [Option<CachedRaster>; 2],
+    overview_buffers: OverviewBuffers,
     starfield_cache: StarfieldVisibilityCache,
 }
 
@@ -161,7 +161,7 @@ impl RasterRenderer {
             height: 0,
             active_buffer: 0,
             frame_index: 0,
-            overview_cache: [None, None],
+            overview_buffers: OverviewBuffers::default(),
             starfield_cache: StarfieldVisibilityCache::default(),
         }
     }
@@ -195,7 +195,7 @@ impl RasterRenderer {
 
         {
             let frame_index = self.frame_index;
-            let overview_cache = &mut self.overview_cache;
+            let overview_buffers = &mut self.overview_buffers;
             let starfield_cache = &mut self.starfield_cache;
             let pixels = self.buffers[buffer_index].make_mut_slice();
             let started = Instant::now();
@@ -215,7 +215,7 @@ impl RasterRenderer {
                     height,
                     options,
                     frame_index,
-                    overview_cache,
+                    overview_buffers,
                     starfield_cache,
                     &mut timings,
                 );
@@ -251,7 +251,7 @@ impl RasterRenderer {
         self.buffers = (0..BUFFER_COUNT)
             .map(|_| SharedPixelBuffer::new(width, height))
             .collect();
-        self.overview_cache = [None, None];
+        self.overview_buffers = OverviewBuffers::default();
         self.starfield_cache.clear();
     }
 }
@@ -260,6 +260,12 @@ impl Default for RasterRenderer {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[derive(Debug, Default)]
+struct OverviewBuffers {
+    cached: [Option<CachedRaster>; 2],
+    composite: [Option<CachedRaster>; 2],
 }
 
 #[derive(Debug)]
@@ -288,7 +294,7 @@ fn draw_spacewars_layout(
     height: u32,
     options: RasterOptions,
     frame_index: u64,
-    overview_cache: &mut [Option<CachedRaster>; 2],
+    overview_buffers: &mut OverviewBuffers,
     starfield_cache: &mut StarfieldVisibilityCache,
     timings: &mut RasterTimings,
 ) {
@@ -315,7 +321,7 @@ fn draw_spacewars_layout(
             overview,
             options,
             frame_index,
-            overview_cache,
+            overview_buffers,
             timings,
         );
     }
@@ -334,7 +340,7 @@ fn draw_cached_overview(
     overview: usize,
     options: RasterOptions,
     frame_index: u64,
-    overview_cache: &mut [Option<CachedRaster>; 2],
+    overview_buffers: &mut OverviewBuffers,
     timings: &mut RasterTimings,
 ) {
     let width = viewport.width.ceil().max(1.0) as u32;
@@ -342,7 +348,8 @@ fn draw_cached_overview(
     let period = options.overview_cache_period.max(1);
     let should_refresh = frame_index % period == 0;
 
-    let cache = overview_cache[overview].get_or_insert_with(|| CachedRaster::new(width, height));
+    let cache =
+        overview_buffers.cached[overview].get_or_insert_with(|| CachedRaster::new(width, height));
     if cache.width != width || cache.height != height {
         *cache = CachedRaster::new(width, height);
     }
@@ -371,27 +378,41 @@ fn draw_cached_overview(
     }
 
     let started = Instant::now();
-    canvas.blit(
-        cache.pixels.as_slice(),
-        cache.width,
-        cache.height,
-        viewport.x.round() as i32,
-        viewport.y.round() as i32,
+    let overlay = overview_buffers.composite[overview]
+        .get_or_insert_with(|| CachedRaster::new(width, height));
+    if overlay.width != width || overlay.height != height {
+        *overlay = CachedRaster::new(width, height);
+    }
+    overlay
+        .pixels
+        .make_mut_slice()
+        .copy_from_slice(cache.pixels.as_slice());
+    Canvas::new(width, height, overlay.pixels.make_mut_slice()).draw_frame_filtered(
+        frame,
+        Viewport::new(width as f32, height as f32),
+        |z, primitive| {
+            is_live_overview_primitive(z, primitive)
+                && render::spacewars_overview_primitive_visible(
+                    frame.camera,
+                    Viewport::new(width as f32, height as f32),
+                    z,
+                    primitive,
+                    options.overview_minimum_object_diameter,
+                )
+        },
     );
-    timings.overview_blit += started.elapsed();
+    timings.overview_live += started.elapsed();
 
     let started = Instant::now();
-    canvas.draw_frame_filtered(frame, viewport, |z, primitive| {
-        is_live_overview_primitive(z, primitive)
-            && render::spacewars_overview_primitive_visible(
-                frame.camera,
-                viewport,
-                z,
-                primitive,
-                options.overview_minimum_object_diameter,
-            )
-    });
-    timings.overview_live += started.elapsed();
+    canvas.blit_circle_with_opacity(
+        overlay.pixels.as_slice(),
+        overlay.width,
+        overlay.height,
+        viewport.x.round() as i32,
+        viewport.y.round() as i32,
+        render::SPACEWARS_MINIMAP_OPACITY,
+    );
+    timings.overview_blit += started.elapsed();
 }
 
 fn is_cached_overview_primitive(z: i32, primitive: &RenderPrimitive) -> bool {
@@ -695,13 +716,14 @@ impl<'a> Canvas<'a> {
         }
     }
 
-    fn blit(
+    fn blit_circle_with_opacity(
         &mut self,
         source: &[Rgba8Pixel],
         source_width: u32,
         source_height: u32,
         x: i32,
         y: i32,
+        opacity: f32,
     ) {
         if x >= self.width as i32 || y >= self.height as i32 {
             return;
@@ -717,13 +739,38 @@ impl<'a> Canvas<'a> {
         let copy_height = source_height
             .saturating_sub(source_y)
             .min(self.height.saturating_sub(start_y));
+        let center_x = source_width as f32 * 0.5;
+        let center_y = source_height as f32 * 0.5;
+        let radius_squared = center_x.min(center_y).powi(2);
 
         for row in 0..copy_height {
             let src_start = ((source_y + row) * source_width + source_x) as usize;
             let dst_start = ((start_y + row) * self.width + start_x) as usize;
             let len = copy_width as usize;
-            self.pixels[dst_start..dst_start + len]
-                .copy_from_slice(&source[src_start..src_start + len]);
+            for (column, (destination, source)) in self.pixels[dst_start..dst_start + len]
+                .iter_mut()
+                .zip(&source[src_start..src_start + len])
+                .enumerate()
+            {
+                let source_pixel_x = source_x as f32 + column as f32 + 0.5;
+                let source_pixel_y = source_y as f32 + row as f32 + 0.5;
+                let distance_x = source_pixel_x - center_x;
+                let distance_y = source_pixel_y - center_y;
+                if distance_x * distance_x + distance_y * distance_y > radius_squared {
+                    continue;
+                }
+                let alpha = (source.a as f32 * opacity.clamp(0.0, 1.0)).round() as u8;
+                blend_pixel(
+                    destination,
+                    RasterColor {
+                        pixel: Rgba8Pixel {
+                            a: alpha,
+                            ..*source
+                        },
+                        opaque: alpha >= 250,
+                    },
+                );
+            }
         }
     }
 }
@@ -1734,10 +1781,61 @@ mod tests {
             FrameLayout::SpacewarsLocalPlay,
         );
         let pixels = image.to_rgba8().expect("raster image should be rgba8");
-        let left_overview_center = pixels.as_slice()[79 * 100 + 18];
-        let right_overview_center = pixels.as_slice()[79 * 100 + 82];
+        let viewports = render::frame_viewports(
+            Viewport::new(100.0, 100.0),
+            frames.len(),
+            FrameLayout::SpacewarsLocalPlay,
+        );
+        let overview_center = |viewport: Viewport| {
+            let x = (viewport.x + viewport.width * 0.5).round() as usize;
+            let y = (viewport.y + viewport.height * 0.5).round() as usize;
+            pixels.as_slice()[y * 100 + x]
+        };
+        let left_overview_center = overview_center(viewports[2]);
+        let right_overview_center = overview_center(viewports[3]);
 
         assert_eq!(left_overview_center, BACKGROUND);
         assert!(right_overview_center.b > BACKGROUND.b);
+    }
+
+    #[test]
+    fn spacewars_raster_minimap_blends_over_player_view() {
+        let mut player = RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0));
+        player.push_primitive(
+            0,
+            RenderPrimitive::Circle(RenderCircle::filled(
+                RenderPoint::ZERO,
+                100.0,
+                RenderColor::RED,
+            )),
+        );
+        let frames = [
+            player.clone(),
+            player,
+            RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0)),
+            RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0)),
+        ];
+
+        let image = image_from_frames_with_layout(
+            &frames,
+            Viewport::new(100.0, 100.0),
+            FrameLayout::SpacewarsLocalPlay,
+        );
+        let pixels = image.to_rgba8().expect("raster image should be rgba8");
+        let minimap = render::frame_viewports(
+            Viewport::new(100.0, 100.0),
+            frames.len(),
+            FrameLayout::SpacewarsLocalPlay,
+        )[2];
+        let x = (minimap.x + minimap.width * 0.5).round() as usize;
+        let y = (minimap.y + minimap.height * 0.5).round() as usize;
+        let blended = pixels.as_slice()[y * 100 + x];
+        let corner_x = minimap.x.ceil() as usize;
+        let corner_y = minimap.y.ceil() as usize;
+        let unobscured_corner = pixels.as_slice()[corner_y * 100 + corner_x];
+
+        assert!(blended.r > BACKGROUND.r);
+        assert!(blended.r < 255);
+        assert_eq!(unobscured_corner.r, 255);
     }
 }

--- a/crates/engine-client/src/render.rs
+++ b/crates/engine-client/src/render.rs
@@ -19,9 +19,13 @@ use crate::{PrimitiveKind, ScenePrimitive};
 const TRANSPARENT: RenderColor = RenderColor::CLEAR;
 const DEFAULT_VIEWPORT_WIDTH: f32 = 1280.0;
 const DEFAULT_VIEWPORT_HEIGHT: f32 = 720.0;
-const SPACEWARS_TOP_ROW_HEIGHT_RATIO: f32 = 0.58;
-const SPACEWARS_CENTER_PANEL_WIDTH_RATIO: f32 = 0.28;
+const SPACEWARS_MINIMAP_HEIGHT_RATIO: f32 = 0.3;
+const SPACEWARS_MINIMAP_HALF_WIDTH_RATIO: f32 = 0.4;
+const SPACEWARS_MINIMAP_MARGIN_RATIO: f32 = 0.02;
+const SPACEWARS_MINIMAP_MIN_MARGIN: f32 = 4.0;
+const SPACEWARS_MINIMAP_MAX_MARGIN: f32 = 16.0;
 const SPACEWARS_DEBRIS_LAYER: i32 = 1;
+pub(crate) const SPACEWARS_MINIMAP_OPACITY: f32 = 0.74;
 pub(crate) const MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER: f32 = 2.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,7 +127,24 @@ pub fn scene_primitives_from_frames_with_layout(
             let minimum_object_diameter = (layout == FrameLayout::SpacewarsLocalPlay
                 && (2..4).contains(&index))
             .then_some(MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER);
+            let opacity = if layout == FrameLayout::SpacewarsLocalPlay && (2..4).contains(&index) {
+                SPACEWARS_MINIMAP_OPACITY
+            } else {
+                1.0
+            };
+            let clip_radius =
+                if layout == FrameLayout::SpacewarsLocalPlay && (2..4).contains(&index) {
+                    viewport.width * 0.5
+                } else {
+                    0.0
+                };
             scene_primitives_from_frame_with_minimum_size(frame, viewport, minimum_object_diameter)
+                .into_iter()
+                .map(move |mut primitive| {
+                    primitive.opacity = opacity;
+                    primitive.clip_radius = clip_radius;
+                    primitive
+                })
         })
         .collect()
 }
@@ -140,22 +161,33 @@ pub(crate) fn frame_viewports(
                 return viewport.split_horizontally(count);
             }
 
-            let top_height = viewport.height * SPACEWARS_TOP_ROW_HEIGHT_RATIO;
-            let bottom_height = viewport.height - top_height;
-            let top_width = viewport.width * 0.5;
-            let center_width = viewport.width * SPACEWARS_CENTER_PANEL_WIDTH_RATIO;
-            let side_width = (viewport.width - center_width) * 0.5;
-            let bottom_y = viewport.y + top_height;
+            let player_width = viewport.width * 0.5;
+            let minimap_size = (viewport.height * SPACEWARS_MINIMAP_HEIGHT_RATIO)
+                .min(player_width * SPACEWARS_MINIMAP_HALF_WIDTH_RATIO);
+            let minimap_margin = (viewport.height * SPACEWARS_MINIMAP_MARGIN_RATIO)
+                .clamp(SPACEWARS_MINIMAP_MIN_MARGIN, SPACEWARS_MINIMAP_MAX_MARGIN)
+                .min(((player_width - minimap_size) * 0.5).max(0.0));
+            let minimap_y = viewport.y + viewport.height - minimap_size - minimap_margin;
 
             let mut viewports = vec![
-                Viewport::with_origin(viewport.x, viewport.y, top_width, top_height),
-                Viewport::with_origin(viewport.x + top_width, viewport.y, top_width, top_height),
-                Viewport::with_origin(viewport.x, bottom_y, side_width, bottom_height),
+                Viewport::with_origin(viewport.x, viewport.y, player_width, viewport.height),
                 Viewport::with_origin(
-                    viewport.x + side_width + center_width,
-                    bottom_y,
-                    side_width,
-                    bottom_height,
+                    viewport.x + player_width,
+                    viewport.y,
+                    player_width,
+                    viewport.height,
+                ),
+                Viewport::with_origin(
+                    viewport.x + minimap_margin,
+                    minimap_y,
+                    minimap_size,
+                    minimap_size,
+                ),
+                Viewport::with_origin(
+                    viewport.x + viewport.width - minimap_size - minimap_margin,
+                    minimap_y,
+                    minimap_size,
+                    minimap_size,
                 ),
             ];
 
@@ -541,6 +573,8 @@ fn text_primitive(text: &RenderText, camera: Camera2, viewport: Viewport) -> Sce
         font_size: text.size,
         text_x: x,
         text_y: y,
+        opacity: 1.0,
+        clip_radius: 0.0,
     }
 }
 
@@ -562,6 +596,8 @@ fn path_primitive(commands: String, style: PathStyle, viewport: Viewport) -> Sce
         font_size: 0.0,
         text_x: 0.0,
         text_y: 0.0,
+        opacity: 1.0,
+        clip_radius: 0.0,
     }
 }
 
@@ -655,7 +691,7 @@ mod tests {
     }
 
     #[test]
-    fn spacewars_local_play_layout_uses_original_style_viewport_bands() {
+    fn spacewars_local_play_layout_uses_full_height_views_and_floating_minimaps() {
         let frames = [
             frame_with_triangle(RenderColor::RED),
             frame_with_triangle(RenderColor::GREEN),
@@ -673,19 +709,23 @@ mod tests {
         assert_close(primitives[0].x, 0.0);
         assert_close(primitives[0].y, 0.0);
         assert_close(primitives[0].width, 500.0);
-        assert_close(primitives[0].height, 406.0);
+        assert_close(primitives[0].height, 700.0);
         assert_close(primitives[1].x, 500.0);
         assert_close(primitives[1].y, 0.0);
         assert_close(primitives[1].width, 500.0);
-        assert_close(primitives[1].height, 406.0);
-        assert_close(primitives[2].x, 0.0);
-        assert_close(primitives[2].y, 406.0);
-        assert_close(primitives[2].width, 360.0);
-        assert_close(primitives[2].height, 294.0);
-        assert_close(primitives[3].x, 640.0);
-        assert_close(primitives[3].y, 406.0);
-        assert_close(primitives[3].width, 360.0);
-        assert_close(primitives[3].height, 294.0);
+        assert_close(primitives[1].height, 700.0);
+        assert_close(primitives[2].x, 14.0);
+        assert_close(primitives[2].y, 486.0);
+        assert_close(primitives[2].width, 200.0);
+        assert_close(primitives[2].height, 200.0);
+        assert_close(primitives[2].opacity, SPACEWARS_MINIMAP_OPACITY);
+        assert_close(primitives[2].clip_radius, 100.0);
+        assert_close(primitives[3].x, 786.0);
+        assert_close(primitives[3].y, 486.0);
+        assert_close(primitives[3].width, 200.0);
+        assert_close(primitives[3].height, 200.0);
+        assert_close(primitives[3].opacity, SPACEWARS_MINIMAP_OPACITY);
+        assert_close(primitives[3].clip_radius, 100.0);
     }
 
     #[test]

--- a/crates/engine-client/src/render.rs
+++ b/crates/engine-client/src/render.rs
@@ -21,6 +21,8 @@ const DEFAULT_VIEWPORT_WIDTH: f32 = 1280.0;
 const DEFAULT_VIEWPORT_HEIGHT: f32 = 720.0;
 const SPACEWARS_TOP_ROW_HEIGHT_RATIO: f32 = 0.58;
 const SPACEWARS_CENTER_PANEL_WIDTH_RATIO: f32 = 0.28;
+const SPACEWARS_DEBRIS_LAYER: i32 = 1;
+pub(crate) const MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER: f32 = 2.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FrameLayout {
@@ -116,7 +118,13 @@ pub fn scene_primitives_from_frames_with_layout(
             frames.len(),
             layout,
         ))
-        .flat_map(|(frame, viewport)| scene_primitives_from_frame(frame, viewport))
+        .enumerate()
+        .flat_map(|(index, (frame, viewport))| {
+            let minimum_object_diameter = (layout == FrameLayout::SpacewarsLocalPlay
+                && (2..4).contains(&index))
+            .then_some(MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER);
+            scene_primitives_from_frame_with_minimum_size(frame, viewport, minimum_object_diameter)
+        })
         .collect()
 }
 
@@ -174,12 +182,32 @@ pub(crate) fn frame_viewports(
 
 /// Convert a scenario frame into ordered Slint scene primitives.
 pub fn scene_primitives_from_frame(frame: &RenderFrame, viewport: Viewport) -> Vec<ScenePrimitive> {
+    scene_primitives_from_frame_with_minimum_size(frame, viewport, None)
+}
+
+fn scene_primitives_from_frame_with_minimum_size(
+    frame: &RenderFrame,
+    viewport: Viewport,
+    minimum_object_diameter: Option<f32>,
+) -> Vec<ScenePrimitive> {
     let viewport = viewport.with_default_if_empty();
     let mut output = Vec::new();
     let mut batch = PathBatch::default();
 
     for layer in frame.ordered_layers() {
         for primitive in &layer.primitives {
+            if minimum_object_diameter.is_some_and(|minimum| {
+                !spacewars_overview_primitive_visible(
+                    frame.camera,
+                    viewport,
+                    layer.z,
+                    primitive,
+                    minimum,
+                )
+            }) {
+                continue;
+            }
+
             match primitive {
                 RenderPrimitive::Circle(circle) => {
                     if let Some(fragment) = circle_fragment(circle, frame.camera, viewport) {
@@ -206,6 +234,55 @@ pub fn scene_primitives_from_frame(frame: &RenderFrame, viewport: Viewport) -> V
     }
 
     output
+}
+
+pub(crate) fn spacewars_overview_primitive_visible(
+    camera: Camera2,
+    viewport: Viewport,
+    layer: i32,
+    primitive: &RenderPrimitive,
+    minimum_object_diameter: f32,
+) -> bool {
+    if layer != SPACEWARS_DEBRIS_LAYER || minimum_object_diameter <= 0.0 {
+        return true;
+    }
+
+    projected_primitive_extent(camera, viewport, primitive) >= minimum_object_diameter
+}
+
+fn projected_primitive_extent(
+    camera: Camera2,
+    viewport: Viewport,
+    primitive: &RenderPrimitive,
+) -> f32 {
+    if camera.height <= 0.0 {
+        return 0.0;
+    }
+    let scale = viewport.with_default_if_empty().height / camera.height;
+    let world_extent = match primitive {
+        RenderPrimitive::Circle(circle) => circle.radius.max(0.0) * 2.0,
+        RenderPrimitive::Line(line) => {
+            let dx = line.end.x - line.start.x;
+            let dy = line.end.y - line.start.y;
+            (dx * dx + dy * dy).sqrt()
+        }
+        RenderPrimitive::Polygon(polygon) => {
+            let Some(first) = polygon.points.first() else {
+                return 0.0;
+            };
+            let (mut min_x, mut max_x) = (first.x, first.x);
+            let (mut min_y, mut max_y) = (first.y, first.y);
+            for point in &polygon.points[1..] {
+                min_x = min_x.min(point.x);
+                max_x = max_x.max(point.x);
+                min_y = min_y.min(point.y);
+                max_y = max_y.max(point.y);
+            }
+            (max_x - min_x).max(max_y - min_y)
+        }
+        RenderPrimitive::Text(_) => f32::INFINITY,
+    };
+    world_extent * scale
 }
 
 pub fn debug_frame(elapsed: Duration, stress_triangles: usize) -> RenderFrame {
@@ -609,6 +686,91 @@ mod tests {
         assert_close(primitives[3].y, 406.0);
         assert_close(primitives[3].width, 360.0);
         assert_close(primitives[3].height, 294.0);
+    }
+
+    #[test]
+    fn spacewars_overview_culls_only_subpixel_debris() {
+        let camera = Camera2::new(RenderPoint::ZERO, 100.0);
+        let viewport = Viewport::new(100.0, 100.0);
+        let tiny_debris = RenderPrimitive::Circle(RenderCircle::filled(
+            RenderPoint::ZERO,
+            0.9,
+            RenderColor::WHITE,
+        ));
+        let visible_debris = RenderPrimitive::Circle(RenderCircle::filled(
+            RenderPoint::ZERO,
+            1.0,
+            RenderColor::WHITE,
+        ));
+
+        assert!(!spacewars_overview_primitive_visible(
+            camera,
+            viewport,
+            SPACEWARS_DEBRIS_LAYER,
+            &tiny_debris,
+            MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER,
+        ));
+        assert!(spacewars_overview_primitive_visible(
+            camera,
+            viewport,
+            SPACEWARS_DEBRIS_LAYER,
+            &visible_debris,
+            MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER,
+        ));
+        assert!(spacewars_overview_primitive_visible(
+            camera,
+            viewport,
+            0,
+            &tiny_debris,
+            MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER,
+        ));
+    }
+
+    #[test]
+    fn spacewars_layout_applies_debris_cutoff_only_to_overviews() {
+        let mut player = RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0));
+        player.push_primitive(
+            SPACEWARS_DEBRIS_LAYER,
+            RenderPrimitive::Circle(RenderCircle::filled(
+                RenderPoint::ZERO,
+                0.1,
+                RenderColor::RED,
+            )),
+        );
+        let mut tiny_overview = RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0));
+        tiny_overview.push_primitive(
+            SPACEWARS_DEBRIS_LAYER,
+            RenderPrimitive::Circle(RenderCircle::filled(
+                RenderPoint::ZERO,
+                0.1,
+                RenderColor::GREEN,
+            )),
+        );
+        let mut visible_overview = RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0));
+        visible_overview.push_primitive(
+            SPACEWARS_DEBRIS_LAYER,
+            RenderPrimitive::Circle(RenderCircle::filled(
+                RenderPoint::ZERO,
+                1.0,
+                RenderColor::BLUE,
+            )),
+        );
+        let frames = [
+            player,
+            RenderFrame::new(Camera2::new(RenderPoint::ZERO, 100.0)),
+            tiny_overview,
+            visible_overview,
+        ];
+
+        let primitives = scene_primitives_from_frames_with_layout(
+            &frames,
+            Viewport::new(1000.0, 700.0),
+            FrameLayout::SpacewarsLocalPlay,
+        );
+
+        assert_eq!(primitives.len(), 2);
+        assert_eq!(primitives[0].fill, brush(RenderColor::RED));
+        assert_eq!(primitives[1].fill, brush(RenderColor::BLUE));
     }
 
     fn frame_with_triangle(color: RenderColor) -> RenderFrame {

--- a/crates/engine-client/src/render.rs
+++ b/crates/engine-client/src/render.rs
@@ -34,6 +34,27 @@ pub enum FrameLayout {
     SpacewarsLocalPlay,
 }
 
+pub struct VectorPresentation {
+    pub main_primitives: Vec<ScenePrimitive>,
+    pub minimaps: Vec<VectorMinimap>,
+}
+
+impl VectorPresentation {
+    pub fn scene_item_count(&self) -> usize {
+        self.main_primitives.len()
+            + self
+                .minimaps
+                .iter()
+                .map(|minimap| minimap.primitives.len())
+                .sum::<usize>()
+    }
+}
+
+pub struct VectorMinimap {
+    pub viewport: Viewport,
+    pub primitives: Vec<ScenePrimitive>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Viewport {
     pub x: f32,
@@ -98,55 +119,49 @@ pub fn scene_primitives_from_frames(
     frames: &[RenderFrame],
     viewport: Viewport,
 ) -> Vec<ScenePrimitive> {
-    scene_primitives_from_frames_with_layout(frames, viewport, FrameLayout::EqualHorizontal)
+    scene_presentation_from_frames_with_layout(frames, viewport, FrameLayout::EqualHorizontal)
+        .main_primitives
 }
 
-/// Convert scenario frames into ordered Slint scene primitives using a client layout.
-pub fn scene_primitives_from_frames_with_layout(
+/// Convert scenario frames into Slint scene primitives and grouped minimaps.
+pub fn scene_presentation_from_frames_with_layout(
     frames: &[RenderFrame],
     viewport: Viewport,
     layout: FrameLayout,
-) -> Vec<ScenePrimitive> {
-    if frames.is_empty() {
-        return Vec::new();
-    }
+) -> VectorPresentation {
+    let viewport = viewport.with_default_if_empty();
+    let mut presentation = VectorPresentation {
+        main_primitives: Vec::new(),
+        minimaps: Vec::new(),
+    };
+    let uses_minimap_groups = layout == FrameLayout::SpacewarsLocalPlay && frames.len() >= 4;
 
-    if frames.len() == 1 {
-        return scene_primitives_from_frame(&frames[0], viewport);
-    }
-
-    frames
+    for (index, (frame, frame_viewport)) in frames
         .iter()
-        .zip(frame_viewports(
-            viewport.with_default_if_empty(),
-            frames.len(),
-            layout,
-        ))
+        .zip(frame_viewports(viewport, frames.len(), layout))
         .enumerate()
-        .flat_map(|(index, (frame, viewport))| {
+    {
+        if uses_minimap_groups && (2..4).contains(&index) {
             let minimum_object_diameter = (layout == FrameLayout::SpacewarsLocalPlay
                 && (2..4).contains(&index))
             .then_some(MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER);
-            let opacity = if layout == FrameLayout::SpacewarsLocalPlay && (2..4).contains(&index) {
-                SPACEWARS_MINIMAP_OPACITY
-            } else {
-                1.0
-            };
-            let clip_radius =
-                if layout == FrameLayout::SpacewarsLocalPlay && (2..4).contains(&index) {
-                    viewport.width * 0.5
-                } else {
-                    0.0
-                };
-            scene_primitives_from_frame_with_minimum_size(frame, viewport, minimum_object_diameter)
-                .into_iter()
-                .map(move |mut primitive| {
-                    primitive.opacity = opacity;
-                    primitive.clip_radius = clip_radius;
-                    primitive
-                })
-        })
-        .collect()
+            let local_viewport = Viewport::new(frame_viewport.width, frame_viewport.height);
+            presentation.minimaps.push(VectorMinimap {
+                viewport: frame_viewport,
+                primitives: scene_primitives_from_frame_with_minimum_size(
+                    frame,
+                    local_viewport,
+                    minimum_object_diameter,
+                ),
+            });
+        } else {
+            presentation
+                .main_primitives
+                .extend(scene_primitives_from_frame(frame, frame_viewport));
+        }
+    }
+
+    presentation
 }
 
 pub(crate) fn frame_viewports(
@@ -573,8 +588,6 @@ fn text_primitive(text: &RenderText, camera: Camera2, viewport: Viewport) -> Sce
         font_size: text.size,
         text_x: x,
         text_y: y,
-        opacity: 1.0,
-        clip_radius: 0.0,
     }
 }
 
@@ -596,8 +609,6 @@ fn path_primitive(commands: String, style: PathStyle, viewport: Viewport) -> Sce
         font_size: 0.0,
         text_x: 0.0,
         text_y: 0.0,
-        opacity: 1.0,
-        clip_radius: 0.0,
     }
 }
 
@@ -699,33 +710,42 @@ mod tests {
             frame_with_triangle(RenderColor::YELLOW),
         ];
 
-        let primitives = scene_primitives_from_frames_with_layout(
+        let presentation = scene_presentation_from_frames_with_layout(
             &frames,
             Viewport::new(1000.0, 700.0),
             FrameLayout::SpacewarsLocalPlay,
         );
 
-        assert_eq!(primitives.len(), 4);
-        assert_close(primitives[0].x, 0.0);
-        assert_close(primitives[0].y, 0.0);
-        assert_close(primitives[0].width, 500.0);
-        assert_close(primitives[0].height, 700.0);
-        assert_close(primitives[1].x, 500.0);
-        assert_close(primitives[1].y, 0.0);
-        assert_close(primitives[1].width, 500.0);
-        assert_close(primitives[1].height, 700.0);
-        assert_close(primitives[2].x, 14.0);
-        assert_close(primitives[2].y, 486.0);
-        assert_close(primitives[2].width, 200.0);
-        assert_close(primitives[2].height, 200.0);
-        assert_close(primitives[2].opacity, SPACEWARS_MINIMAP_OPACITY);
-        assert_close(primitives[2].clip_radius, 100.0);
-        assert_close(primitives[3].x, 786.0);
-        assert_close(primitives[3].y, 486.0);
-        assert_close(primitives[3].width, 200.0);
-        assert_close(primitives[3].height, 200.0);
-        assert_close(primitives[3].opacity, SPACEWARS_MINIMAP_OPACITY);
-        assert_close(primitives[3].clip_radius, 100.0);
+        assert_eq!(presentation.main_primitives.len(), 2);
+        assert_eq!(presentation.minimaps.len(), 2);
+        assert_close(presentation.main_primitives[0].x, 0.0);
+        assert_close(presentation.main_primitives[0].y, 0.0);
+        assert_close(presentation.main_primitives[0].width, 500.0);
+        assert_close(presentation.main_primitives[0].height, 700.0);
+        assert_close(presentation.main_primitives[1].x, 500.0);
+        assert_close(presentation.main_primitives[1].y, 0.0);
+        assert_close(presentation.main_primitives[1].width, 500.0);
+        assert_close(presentation.main_primitives[1].height, 700.0);
+
+        let left = &presentation.minimaps[0];
+        assert_close(left.viewport.x, 14.0);
+        assert_close(left.viewport.y, 486.0);
+        assert_close(left.viewport.width, 200.0);
+        assert_close(left.viewport.height, 200.0);
+        assert_close(left.primitives[0].x, 0.0);
+        assert_close(left.primitives[0].y, 0.0);
+        assert_close(left.primitives[0].width, 200.0);
+        assert_close(left.primitives[0].height, 200.0);
+
+        let right = &presentation.minimaps[1];
+        assert_close(right.viewport.x, 786.0);
+        assert_close(right.viewport.y, 486.0);
+        assert_close(right.viewport.width, 200.0);
+        assert_close(right.viewport.height, 200.0);
+        assert_close(right.primitives[0].x, 0.0);
+        assert_close(right.primitives[0].y, 0.0);
+        assert_close(right.primitives[0].width, 200.0);
+        assert_close(right.primitives[0].height, 200.0);
     }
 
     #[test]
@@ -802,15 +822,23 @@ mod tests {
             visible_overview,
         ];
 
-        let primitives = scene_primitives_from_frames_with_layout(
+        let presentation = scene_presentation_from_frames_with_layout(
             &frames,
             Viewport::new(1000.0, 700.0),
             FrameLayout::SpacewarsLocalPlay,
         );
 
-        assert_eq!(primitives.len(), 2);
-        assert_eq!(primitives[0].fill, brush(RenderColor::RED));
-        assert_eq!(primitives[1].fill, brush(RenderColor::BLUE));
+        assert_eq!(presentation.main_primitives.len(), 1);
+        assert_eq!(
+            presentation.main_primitives[0].fill,
+            brush(RenderColor::RED)
+        );
+        assert!(presentation.minimaps[0].primitives.is_empty());
+        assert_eq!(presentation.minimaps[1].primitives.len(), 1);
+        assert_eq!(
+            presentation.minimaps[1].primitives[0].fill,
+            brush(RenderColor::BLUE)
+        );
     }
 
     fn frame_with_triangle(color: RenderColor) -> RenderFrame {

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -24,8 +24,6 @@ export struct ScenePrimitive {
     font-size: length,
     text-x: length,
     text-y: length,
-    opacity: float,
-    clip-radius: length,
 }
 
 component ScenePrimitiveItem inherits Rectangle {
@@ -37,8 +35,6 @@ component ScenePrimitiveItem inherits Rectangle {
     height: primitive.height;
     clip: true;
     background: #00000000;
-    opacity: primitive.opacity;
-    border-radius: primitive.clip-radius;
 
     Path {
         visible: primitive.kind == PrimitiveKind.path;
@@ -61,6 +57,18 @@ component ScenePrimitiveItem inherits Rectangle {
         text: primitive.text;
         color: primitive.color;
         font-size: primitive.font-size;
+    }
+}
+
+component MinimapPanel inherits Rectangle {
+    in property <[ScenePrimitive]> primitives;
+
+    background: #050514;
+    clip: true;
+    border-radius: self.width / 2;
+
+    for primitive in root.primitives: ScenePrimitiveItem {
+        primitive: primitive;
     }
 }
 
@@ -108,6 +116,16 @@ component PlayerStatusPanel inherits Rectangle {
 export component MainWindow inherits Window {
     in property <bool> app-full-screen: false;
     in property <[ScenePrimitive]> primitives;
+    in property <[ScenePrimitive]> p1-minimap-primitives;
+    in property <[ScenePrimitive]> p2-minimap-primitives;
+    in property <bool> vector-minimaps-visible: false;
+    in property <float> minimap-opacity: 0.74;
+    in property <length> p1-minimap-x: 0px;
+    in property <length> p1-minimap-y: 0px;
+    in property <length> p1-minimap-size: 0px;
+    in property <length> p2-minimap-x: 0px;
+    in property <length> p2-minimap-y: 0px;
+    in property <length> p2-minimap-size: 0px;
     in property <bool> raster-visible: false;
     in property <image> raster-frame;
     in-out property <bool> launcher-visible: false;
@@ -191,6 +209,27 @@ export component MainWindow inherits Window {
 
     for primitive in root.primitives: ScenePrimitiveItem {
         primitive: primitive;
+    }
+
+    MinimapPanel {
+        visible: root.vector-minimaps-visible;
+        x: root.p1-minimap-x;
+        y: root.p1-minimap-y;
+        width: root.p1-minimap-size;
+        height: root.p1-minimap-size;
+        // Group opacity makes Slint composite the backdrop and all primitives once.
+        opacity: root.minimap-opacity;
+        primitives: root.p1-minimap-primitives;
+    }
+
+    MinimapPanel {
+        visible: root.vector-minimaps-visible;
+        x: root.p2-minimap-x;
+        y: root.p2-minimap-y;
+        width: root.p2-minimap-size;
+        height: root.p2-minimap-size;
+        opacity: root.minimap-opacity;
+        primitives: root.p2-minimap-primitives;
     }
 
     Rectangle {

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -24,6 +24,8 @@ export struct ScenePrimitive {
     font-size: length,
     text-x: length,
     text-y: length,
+    opacity: float,
+    clip-radius: length,
 }
 
 component ScenePrimitiveItem inherits Rectangle {
@@ -35,6 +37,8 @@ component ScenePrimitiveItem inherits Rectangle {
     height: primitive.height;
     clip: true;
     background: #00000000;
+    opacity: primitive.opacity;
+    border-radius: primitive.clip-radius;
 
     Path {
         visible: primitive.kind == PrimitiveKind.path;
@@ -65,30 +69,28 @@ component PlayerStatusPanel inherits Rectangle {
     in property <string> status-text;
     in property <float> status-fraction;
     in property <brush> player-color;
+    in property <bool> align-right: false;
 
-    background: #00000000;
+    background: #080a12d8;
+    border-color: root.player-color;
+    border-width: 1px;
 
     Text {
-        x: 0px;
-        y: 0px;
-        text: root.player-name;
+        x: 12px;
+        y: 8px;
+        width: parent.width - 24px;
+        height: 20px;
+        text: root.player-name + "  ·  " + root.status-text;
         color: root.player-color;
-        font-size: 14px;
-    }
-
-    Text {
-        x: 0px;
-        y: 20px;
-        text: root.status-text;
-        color: #e6edf7;
-        font-size: 12px;
+        font-size: 13px;
+        horizontal-alignment: root.align-right ? right : left;
     }
 
     Rectangle {
-        x: 0px;
-        y: 40px;
-        width: parent.width;
-        height: 8px;
+        x: 12px;
+        y: 34px;
+        width: parent.width - 24px;
+        height: 10px;
         background: #242733;
         border-color: #7d8494;
         border-width: 1px;
@@ -193,48 +195,62 @@ export component MainWindow inherits Window {
 
     Rectangle {
         visible: root.spacewars-ui-visible;
-        x: root.width * 0.36;
-        y: root.height * 0.58;
-        width: root.width * 0.28;
-        height: root.height * 0.42;
-        background: #080a12dd;
-        border-color: #596273;
+        x: root.width / 2 - 1px;
+        width: 2px;
+        height: root.height;
+        background: #59627388;
+    }
+
+    PlayerStatusPanel {
+        visible: root.spacewars-ui-visible;
+        x: 16px;
+        y: 16px;
+        width: root.width * 0.31;
+        height: 54px;
+        player-name: root.p1-name;
+        status-text: root.p1-status;
+        status-fraction: root.p1-status-fraction;
+        player-color: root.p1-color;
+    }
+
+    PlayerStatusPanel {
+        visible: root.spacewars-ui-visible;
+        x: root.width - self.width - 16px;
+        y: 16px;
+        width: root.width * 0.31;
+        height: 54px;
+        player-name: root.p2-name;
+        status-text: root.p2-status;
+        status-fraction: root.p2-status-fraction;
+        player-color: root.p2-color;
+        align-right: true;
+    }
+
+    Rectangle {
+        visible: root.spacewars-ui-visible;
+        x: root.width * 0.37;
+        y: root.height - self.height - 14px;
+        width: root.width * 0.26;
+        height: 82px;
+        background: #080a12d0;
+        border-color: #596273aa;
         border-width: 1px;
 
-        PlayerStatusPanel {
-            x: 12px;
-            y: 12px;
-            width: parent.width - 24px;
-            height: 54px;
-            player-name: root.p1-name;
-            status-text: root.p1-status;
-            status-fraction: root.p1-status-fraction;
-            player-color: root.p1-color;
-        }
-
-        PlayerStatusPanel {
-            x: 12px;
-            y: 74px;
-            width: parent.width - 24px;
-            height: 54px;
-            player-name: root.p2-name;
-            status-text: root.p2-status;
-            status-fraction: root.p2-status-fraction;
-            player-color: root.p2-color;
-        }
-
         Text {
-            x: 12px;
-            y: 142px;
+            x: 10px;
+            y: 6px;
+            width: parent.width - 20px;
+            height: 18px;
             text: root.planet-score-label;
             color: #e6edf7;
             font-size: 12px;
+            horizontal-alignment: center;
         }
 
         Rectangle {
-            x: 12px;
-            y: 164px;
-            width: parent.width - 24px;
+            x: 10px;
+            y: 27px;
+            width: parent.width - 20px;
             height: 12px;
             background: #666b76;
             border-color: #a0a6b2;
@@ -294,19 +310,25 @@ export component MainWindow inherits Window {
         }
 
         Text {
-            x: 12px;
-            y: 194px;
+            x: 8px;
+            y: 44px;
+            width: parent.width - 16px;
+            height: 17px;
             text: root.spacewars-message-text;
             color: #f6f2a6;
-            font-size: 16px;
+            font-size: 11px;
+            horizontal-alignment: center;
         }
 
         Text {
-            x: 12px;
-            y: 220px;
+            x: 8px;
+            y: 62px;
+            width: parent.width - 16px;
+            height: 14px;
             text: root.spacewars-performance-text;
             color: #c7d0dc;
-            font-size: 12px;
+            font-size: 9px;
+            horizontal-alignment: center;
         }
     }
 

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -355,7 +355,7 @@ export component MainWindow inherits Window {
                     x: 0px;
                     y: 0px;
                     width: parent.width;
-                    text: "Player 1: W thrust, S reverse, A/D turn, J wings, Space laser, K cannon";
+                    text: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon";
                     color: #e6edf7;
                     font-size: 13px;
                     wrap: word-wrap;
@@ -365,7 +365,7 @@ export component MainWindow inherits Window {
                     x: 0px;
                     y: 54px;
                     width: parent.width;
-                    text: "Player 2: Numpad 8 thrust, Numpad 5 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon";
+                    text: "Player 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon";
                     color: #e6edf7;
                     font-size: 13px;
                     wrap: word-wrap;
@@ -919,7 +919,7 @@ export component MainWindow inherits Window {
                     x: 0px;
                     y: 0px;
                     width: parent.width;
-                    text: "Player 1: W thrust, S reverse, A/D turn, J wings, Space laser, K cannon";
+                    text: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon";
                     color: #e6edf7;
                     font-size: 13px;
                     wrap: word-wrap;
@@ -929,7 +929,7 @@ export component MainWindow inherits Window {
                     x: 0px;
                     y: 54px;
                     width: parent.width;
-                    text: "Player 2: Numpad 8 thrust, Numpad 5 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon";
+                    text: "Player 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon";
                     color: #e6edf7;
                     font-size: 13px;
                     wrap: word-wrap;

--- a/docs/design/reboot-rust-slint.md
+++ b/docs/design/reboot-rust-slint.md
@@ -383,7 +383,7 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - Select Slint's winit backend by default so the client can observe physical `Numpad*` keys for Player 2; still honor an explicit `SLINT_BACKEND` override.
 - Preserve original wing semantics: hold the wing key to close, release it to open. Do not turn this into a toggle.
 - Define scenario actions for thrust, reverse, turn left/right, wing open/close, internal brake, and placeholder weapon actions.
-- Keep brake unbound in the client for now; `Ship.brake()` exists in the original source, but no keyboard caller was found.
+- Expose braking separately from reverse thrust: Player 1 uses `S` to brake and `X` to reverse, while Player 2 uses Numpad 5 to brake and Numpad 2 to reverse.
 - Keep exhaust trails, weapons, collision, and damage out of this slice.
 - Acceptance: two ships can fly inside a bounded universe with deterministic state tests for thrust, turn, wing transitions, and max-speed behavior.
 

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -76,7 +76,6 @@ const SPACEPORT_EJECT_MAX_SPEED: f32 = 200.0;
 const SPACEPORT_REENTRY_LOCKOUT_SECS: f32 = 0.75;
 const DEFAULT_PLAYER_VIEW_HEIGHT: f32 = 320.0;
 const MIN_PLAYER_VIEW_HEIGHT: f32 = 15.0;
-const PLAYER_VIEW_ASPECT_RATIO: f32 = 640.0 / 417.6;
 const DEBRIS_DEATH_SHRINK_FACTOR: f32 = 0.01;
 const DEBRIS_DEATH_LIFE_FACTOR: f32 = 0.8;
 const DEBRIS_BODY_DAMAGE_SCALAR: f32 = 0.05;
@@ -915,7 +914,10 @@ impl SpacewarsScenario {
             .collect()
     }
 
-    pub fn render_raster_local_play_frames(state: &SpacewarsState) -> Vec<RenderFrame> {
+    pub fn render_raster_local_play_frames(
+        state: &SpacewarsState,
+        player_view_aspect_ratio: f32,
+    ) -> Vec<RenderFrame> {
         let mut frames = (0..state.ships.len())
             .map(|player| {
                 render_state_with_camera(
@@ -925,15 +927,26 @@ impl SpacewarsScenario {
                 )
             })
             .collect::<Vec<_>>();
-        frames.push(render_raster_overview_state(state, 0));
-        frames.push(render_raster_overview_state(state, 1));
+        frames.push(render_raster_overview_state(
+            state,
+            0,
+            player_view_aspect_ratio,
+        ));
+        frames.push(render_raster_overview_state(
+            state,
+            1,
+            player_view_aspect_ratio,
+        ));
         frames
     }
 
-    pub fn render_local_play_frames(state: &SpacewarsState) -> Vec<RenderFrame> {
+    pub fn render_local_play_frames(
+        state: &SpacewarsState,
+        player_view_aspect_ratio: f32,
+    ) -> Vec<RenderFrame> {
         let mut frames = Self::render_player_frames(state);
-        frames.push(render_overview_state(state, 0));
-        frames.push(render_overview_state(state, 1));
+        frames.push(render_overview_state(state, 0, player_view_aspect_ratio));
+        frames.push(render_overview_state(state, 1, player_view_aspect_ratio));
         frames
     }
 }
@@ -3974,23 +3987,31 @@ fn render_state(state: &SpacewarsState) -> RenderFrame {
     )
 }
 
-fn render_overview_state(state: &SpacewarsState, player: usize) -> RenderFrame {
+fn render_overview_state(
+    state: &SpacewarsState,
+    player: usize,
+    player_view_aspect_ratio: f32,
+) -> RenderFrame {
     let radius = state.config.universe_radius as f32;
     let center = Vec2::new(radius, radius);
     render_state_with_camera(
         state,
         Camera2::new(render_point(center), radius * 2.2),
-        RenderOptions::overview(player),
+        RenderOptions::overview(player, player_view_aspect_ratio),
     )
 }
 
-fn render_raster_overview_state(state: &SpacewarsState, player: usize) -> RenderFrame {
+fn render_raster_overview_state(
+    state: &SpacewarsState,
+    player: usize,
+    player_view_aspect_ratio: f32,
+) -> RenderFrame {
     let radius = state.config.universe_radius as f32;
     let center = Vec2::new(radius, radius);
     render_state_with_camera(
         state,
         Camera2::new(render_point(center), radius * 2.2),
-        RenderOptions::raster_overview(player),
+        RenderOptions::raster_overview(player, player_view_aspect_ratio),
     )
 }
 
@@ -4108,8 +4129,8 @@ fn render_state_with_camera(
         }
     }
 
-    if let Some(player) = options.player_view {
-        render_player_view_rectangle(&mut frame, state, player);
+    if let Some((player, aspect_ratio)) = options.player_view {
+        render_player_view_rectangle(&mut frame, state, player, aspect_ratio);
     }
 
     frame
@@ -4123,7 +4144,7 @@ struct RenderOptions {
     show_particles: bool,
     show_planet_ownership_halo: bool,
     debris_style: DebrisRenderStyle,
-    player_view: Option<usize>,
+    player_view: Option<(usize, f32)>,
 }
 
 impl RenderOptions {
@@ -4139,7 +4160,7 @@ impl RenderOptions {
         }
     }
 
-    fn overview(player: usize) -> Self {
+    fn overview(player: usize, player_view_aspect_ratio: f32) -> Self {
         Self {
             show_ship_labels: false,
             show_starfield: false,
@@ -4147,7 +4168,7 @@ impl RenderOptions {
             show_particles: false,
             show_planet_ownership_halo: true,
             debris_style: DebrisRenderStyle::SimpleMarks,
-            player_view: Some(player),
+            player_view: Some((player, player_view_aspect_ratio)),
         }
     }
 
@@ -4163,7 +4184,7 @@ impl RenderOptions {
         }
     }
 
-    fn raster_overview(player: usize) -> Self {
+    fn raster_overview(player: usize, player_view_aspect_ratio: f32) -> Self {
         Self {
             show_ship_labels: false,
             show_starfield: false,
@@ -4171,7 +4192,7 @@ impl RenderOptions {
             show_particles: false,
             show_planet_ownership_halo: true,
             debris_style: DebrisRenderStyle::SimpleMarks,
-            player_view: Some(player),
+            player_view: Some((player, player_view_aspect_ratio)),
         }
     }
 }
@@ -4182,7 +4203,12 @@ enum DebrisRenderStyle {
     SimpleMarks,
 }
 
-fn render_player_view_rectangle(frame: &mut RenderFrame, state: &SpacewarsState, player: usize) {
+fn render_player_view_rectangle(
+    frame: &mut RenderFrame,
+    state: &SpacewarsState,
+    player: usize,
+    aspect_ratio: f32,
+) {
     let Some(ship) = state.ships.get(player) else {
         return;
     };
@@ -4192,7 +4218,12 @@ fn render_player_view_rectangle(frame: &mut RenderFrame, state: &SpacewarsState,
         .get(player)
         .copied()
         .unwrap_or(DEFAULT_PLAYER_VIEW_HEIGHT);
-    let view_width = view_height * PLAYER_VIEW_ASPECT_RATIO;
+    let aspect_ratio = if aspect_ratio.is_finite() && aspect_ratio > 0.0 {
+        aspect_ratio
+    } else {
+        1.0
+    };
+    let view_width = view_height * aspect_ratio;
     let half_width = view_width * 0.5;
     let half_height = view_height * 0.5;
 
@@ -4503,13 +4534,13 @@ fn render_planet_flags(frame: &mut RenderFrame, state: &SpacewarsState, planet: 
 }
 
 fn planet_flag_color(state: &SpacewarsState, planet: &PlanetState) -> Option<RenderColor> {
-    if let Some(capturing_player) = planet.capturing_player_id
-        && planet.owner_id != Some(capturing_player)
-    {
-        let progress = capture_progress(planet);
-        if progress > 0.0 {
-            let player = state.players.get(capturing_player)?;
-            return Some(with_intensity(render_color(player.color), progress));
+    if let Some(capturing_player) = planet.capturing_player_id {
+        if planet.owner_id != Some(capturing_player) {
+            let progress = capture_progress(planet);
+            if progress > 0.0 {
+                let player = state.players.get(capturing_player)?;
+                return Some(with_intensity(render_color(player.color), progress));
+            }
         }
     }
 
@@ -4565,27 +4596,27 @@ fn spaceport_color(
         );
     }
 
-    if let SpaceportStatus::Active(ship_index) = spaceport_status(state, planet_index)
-        && let Some(ship) = state.ships.get(ship_index)
-    {
-        let player_color = render_color(state.players[ship.owner_id].color);
-        if planet.owner_id != Some(ship.owner_id) && ship.form != ShipForm::EscapePod {
-            let progress = capture_progress(planet);
-            if progress > 0.0 {
-                return blend_color(
-                    RenderColor::rgba(1.0, 1.0, 1.0, 0.82),
-                    with_alpha(player_color, 0.82),
-                    progress,
-                );
-            }
-        } else if planet.owner_id == Some(ship.owner_id) && ship.form == ShipForm::EscapePod {
-            let progress = rebuild_progress(planet);
-            if progress > 0.0 {
-                return blend_color(
-                    with_alpha(dim(player_color, 0.55), 0.82),
-                    with_alpha(player_color, 0.92),
-                    progress,
-                );
+    if let SpaceportStatus::Active(ship_index) = spaceport_status(state, planet_index) {
+        if let Some(ship) = state.ships.get(ship_index) {
+            let player_color = render_color(state.players[ship.owner_id].color);
+            if planet.owner_id != Some(ship.owner_id) && ship.form != ShipForm::EscapePod {
+                let progress = capture_progress(planet);
+                if progress > 0.0 {
+                    return blend_color(
+                        RenderColor::rgba(1.0, 1.0, 1.0, 0.82),
+                        with_alpha(player_color, 0.82),
+                        progress,
+                    );
+                }
+            } else if planet.owner_id == Some(ship.owner_id) && ship.form == ShipForm::EscapePod {
+                let progress = rebuild_progress(planet);
+                if progress > 0.0 {
+                    return blend_color(
+                        with_alpha(dim(player_color, 0.55), 0.82),
+                        with_alpha(player_color, 0.92),
+                        progress,
+                    );
+                }
             }
         }
     }
@@ -5058,16 +5089,16 @@ mod tests {
                 let dy = y as f32 + 0.5 - cy;
                 let distance = (dx * dx + dy * dy).sqrt();
 
-                if let Some(fill) = circle.fill
-                    && distance <= radius
-                {
-                    blend_pixel(image, x, y, fill.color);
+                if let Some(fill) = circle.fill {
+                    if distance <= radius {
+                        blend_pixel(image, x, y, fill.color);
+                    }
                 }
 
-                if let Some(stroke) = circle.stroke
-                    && (distance - radius).abs() <= stroke_width * 0.5
-                {
-                    blend_pixel(image, x, y, stroke.color);
+                if let Some(stroke) = circle.stroke {
+                    if (distance - radius).abs() <= stroke_width * 0.5 {
+                        blend_pixel(image, x, y, stroke.color);
+                    }
                 }
             }
         }
@@ -6421,7 +6452,7 @@ mod tests {
         assert_eq!(center.fill, Some(Fill::new(expected_color)));
         assert!(center.stroke.is_none());
 
-        let overview = render_overview_state(&state, 0);
+        let overview = render_overview_state(&state, 0, 1.0);
         let overview_layer = overview
             .layers
             .iter()
@@ -6450,7 +6481,7 @@ mod tests {
         state.planets[0].taking_ownership_time = PLANET_CAPTURE_SECS * 0.5;
         let expected_color = with_intensity(render_color(state.players[0].color), 0.5);
 
-        let overview = render_overview_state(&state, 0);
+        let overview = render_overview_state(&state, 0, 1.0);
         let ownership_layer = overview
             .layers
             .iter()
@@ -6475,7 +6506,7 @@ mod tests {
         let mut state = init_deathmatch_no_asteroids();
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
 
-        let overview = render_overview_state(&state, 0);
+        let overview = render_overview_state(&state, 0, 1.0);
 
         assert!(
             overview
@@ -8119,6 +8150,7 @@ mod tests {
     #[test]
     fn local_play_frames_include_player_views_and_world_overviews() {
         let mut state = init_default(123);
+        let player_view_aspect_ratio = 0.75;
         state.debris.push(DebrisState::new(
             DebrisKind::Asteroid,
             Vec2::new(100.0, 100.0),
@@ -8127,7 +8159,7 @@ mod tests {
             ASTEROID_DAMAGE_SCALAR,
             Color::DIM_GREY,
         ));
-        let frames = SpacewarsScenario::render_local_play_frames(&state);
+        let frames = SpacewarsScenario::render_local_play_frames(&state, player_view_aspect_ratio);
 
         assert_eq!(frames.len(), 4);
         assert_eq!(
@@ -8176,13 +8208,16 @@ mod tests {
                     1.5
                 ))
             );
+            let width = rectangle.points[1].x - rectangle.points[0].x;
+            let height = rectangle.points[2].y - rectangle.points[1].y;
+            assert_close(width / height, player_view_aspect_ratio);
         }
     }
 
     #[test]
     fn raster_local_play_frames_use_simplified_overviews() {
         let state = SpacewarsScenario::init_benchmark(123);
-        let frames = SpacewarsScenario::render_raster_local_play_frames(&state);
+        let frames = SpacewarsScenario::render_raster_local_play_frames(&state, 0.75);
 
         assert_eq!(frames.len(), 4);
         assert_eq!(text_values(&frames[0]), Vec::<String>::new());

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -70,6 +70,9 @@ const SPACEPORT_CONTEST_EJECT_DELAY_SECS: f32 = 0.25;
 const SPACEPORT_EJECT_MARGIN: f32 = 5.0;
 const SPACEPORT_EJECT_SPEED: f32 = 120.0;
 const SPACEPORT_EJECT_TANGENTIAL_SPEED: f32 = 60.0;
+const SPACEPORT_EJECT_TARGET_SECS: f32 = 0.3;
+const SPACEPORT_EJECT_TIMEOUT_SECS: f32 = 0.5;
+const SPACEPORT_EJECT_MAX_SPEED: f32 = 200.0;
 const SPACEPORT_REENTRY_LOCKOUT_SECS: f32 = 0.75;
 const DEFAULT_PLAYER_VIEW_HEIGHT: f32 = 320.0;
 const MIN_PLAYER_VIEW_HEIGHT: f32 = 15.0;
@@ -409,6 +412,15 @@ enum SpaceportStatus {
     Contested,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct SpaceportEjection {
+    planet: usize,
+    outward: Vec2,
+    target_outward_speed: f32,
+    minimum_tangential_speed: f32,
+    elapsed: f32,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoundsDrawMode {
     High,
@@ -454,6 +466,9 @@ pub struct ShipState {
     current_max_omega: f32,
     cannon_cooldown_remaining: f32,
     spaceport_reentry_lockout: f32,
+    spaceport_ejection: Option<SpaceportEjection>,
+    queued_laser_fire: bool,
+    queued_cannon_fire: bool,
     delta_time: f32,
     death_impulse: Vec2,
 }
@@ -728,6 +743,7 @@ impl Scenario for SpacewarsScenario {
             ship.update(dt, state.seed, state.tick);
             contain_ship(ship, state.config.universe_radius as f32);
         }
+        finish_spaceport_ejections(state, dt);
         let new_shells = spawn_cannon_shells(state, dt);
         state.debris.extend(new_shells);
         update_ship_lasers(state);
@@ -2323,6 +2339,13 @@ fn detect_ship_collisions(state: &SpacewarsState) -> Vec<ShipCollision> {
 
     for a in 0..state.ships.len() {
         for b in a + 1..state.ships.len() {
+            // Dock occupants overlap by design; their launch vectors separate them while clearing.
+            if state.ships[a].spaceport_ejection.is_some()
+                || state.ships[b].spaceport_ejection.is_some()
+            {
+                continue;
+            }
+
             let (a_low, a_high) = &ship_bounds[a];
             let (b_low, b_high) = &ship_bounds[b];
             if !Bounds2::Circle(*a_low).intersects(&Bounds2::Circle(*b_low)) {
@@ -2474,6 +2497,17 @@ fn detect_body_contacts(state: &SpacewarsState) -> Vec<BodyContact> {
         let ship_high = Bounds2::List(ship_high_bounds(&triangles));
 
         for body in &bodies {
+            // The port is a temporary collision-safe corridor through its planet's body.
+            if matches!(
+                body.id,
+                BodyId::Planet(planet)
+                    if ship
+                        .spaceport_ejection
+                        .is_some_and(|ejection| ejection.planet == planet)
+            ) {
+                continue;
+            }
+
             if !ship_low.intersects(&Bounds2::Circle(body.low)) {
                 continue;
             }
@@ -2775,7 +2809,6 @@ fn eject_ships_from_spaceport(
     } else {
         outward_offset.normalized()
     };
-    let tangent = outward.rotate_radians(core::f32::consts::FRAC_PI_2);
     let mut ships = ship_indices
         .iter()
         .copied()
@@ -2794,18 +2827,67 @@ fn eject_ships_from_spaceport(
         };
         let ship = &mut state.ships[ship_index];
         let bounds = ship_low_bounds(&ship_triangles(ship));
-        let center_offset = bounds.center - ship.position;
-        let target_center = planet.position
-            + outward
-                * (planet.radius * BODY_BOUNDS_RADIUS_SCALE
-                    + bounds.radius
-                    + SPACEPORT_EJECT_MARGIN)
-            + tangent * (side * bounds.radius * 1.5);
+        let clearance_radius =
+            planet.radius * BODY_BOUNDS_RADIUS_SCALE + bounds.radius + SPACEPORT_EJECT_MARGIN;
+        let outward_distance = (bounds.center - planet.position).dot(outward);
+        let distance_to_clear = (clearance_radius - outward_distance).max(0.0);
+        let target_outward_speed = (distance_to_clear / SPACEPORT_EJECT_TARGET_SECS)
+            .clamp(SPACEPORT_EJECT_SPEED, SPACEPORT_EJECT_MAX_SPEED);
 
-        ship.position = target_center - center_offset;
-        ship.velocity =
-            outward * SPACEPORT_EJECT_SPEED + tangent * (side * SPACEPORT_EJECT_TANGENTIAL_SPEED);
+        ship.queued_laser_fire |= ship.laser_firing;
+        ship.queued_cannon_fire |= ship.cannon_firing;
+        ship.laser_beam = None;
+        ship.spaceport_ejection = Some(SpaceportEjection {
+            planet: planet_index,
+            outward,
+            target_outward_speed,
+            minimum_tangential_speed: side * SPACEPORT_EJECT_TANGENTIAL_SPEED,
+            elapsed: 0.0,
+        });
         ship.spaceport_reentry_lockout = SPACEPORT_REENTRY_LOCKOUT_SECS;
+        ship.maintain_spaceport_ejection_velocity();
+    }
+}
+
+fn finish_spaceport_ejections(state: &mut SpacewarsState, dt: f32) {
+    for ship_index in 0..state.ships.len() {
+        let Some(mut ejection) = state.ships[ship_index].spaceport_ejection else {
+            continue;
+        };
+        let Some(planet) = state.planets.get(ejection.planet).copied() else {
+            state.ships[ship_index].spaceport_ejection = None;
+            continue;
+        };
+
+        ejection.elapsed += dt;
+        let ship = &mut state.ships[ship_index];
+        ship.maintain_spaceport_ejection_velocity();
+        let bounds = ship_low_bounds(&ship_triangles(ship));
+        let clearance_radius =
+            planet.radius * BODY_BOUNDS_RADIUS_SCALE + bounds.radius + SPACEPORT_EJECT_MARGIN;
+        let cleared = bounds.center.distance_to(planet.position) >= clearance_radius;
+
+        if cleared {
+            ship.spaceport_ejection = None;
+            ship.spaceport_reentry_lockout = SPACEPORT_REENTRY_LOCKOUT_SECS;
+            continue;
+        }
+
+        if ejection.elapsed >= SPACEPORT_EJECT_TIMEOUT_SECS {
+            // Preserve lateral travel and correct only the remaining outward clearance.
+            let tangent = ejection
+                .outward
+                .rotate_radians(core::f32::consts::FRAC_PI_2);
+            let tangential_offset = (bounds.center - planet.position).dot(tangent);
+            let target_center =
+                planet.position + ejection.outward * clearance_radius + tangent * tangential_offset;
+            ship.position += target_center - bounds.center;
+            ship.spaceport_ejection = None;
+            ship.spaceport_reentry_lockout = SPACEPORT_REENTRY_LOCKOUT_SECS;
+            continue;
+        }
+
+        ship.spaceport_ejection = Some(ejection);
     }
 }
 
@@ -3329,6 +3411,9 @@ impl ShipState {
             current_max_omega: BASE_MAX_OMEGA,
             cannon_cooldown_remaining: 0.0,
             spaceport_reentry_lockout: 0.0,
+            spaceport_ejection: None,
+            queued_laser_fire: false,
+            queued_cannon_fire: false,
             delta_time,
             death_impulse: Vec2::ZERO,
         }
@@ -3460,10 +3545,18 @@ impl ShipState {
     fn update_cannon(&mut self, dt: f32, tick: u64) -> Option<DebrisState> {
         if self.form == ShipForm::EscapePod {
             self.cannon_cooldown_remaining = 0.0;
+            self.queued_cannon_fire = false;
             return None;
         }
 
-        let shell = if self.cannon_firing && self.cannon_cooldown_remaining <= 0.0 {
+        if self.spaceport_ejection.is_some() {
+            self.queued_cannon_fire |= self.cannon_firing;
+            self.cannon_cooldown_remaining = (self.cannon_cooldown_remaining - dt).max(0.0);
+            return None;
+        }
+
+        let should_fire = self.cannon_firing || self.queued_cannon_fire;
+        let shell = if should_fire && self.cannon_cooldown_remaining <= 0.0 {
             let mount_center = ship_mount_center(self);
             let shell = DebrisState::new_shell(
                 self.owner_id,
@@ -3474,6 +3567,7 @@ impl ShipState {
             );
             self.velocity -= self.direction * CANNON_RECOIL_SPEED;
             self.cannon_cooldown_remaining = CANNON_COOLDOWN_SECS;
+            self.queued_cannon_fire = false;
             Some(shell)
         } else {
             None
@@ -3487,10 +3581,19 @@ impl ShipState {
         if self.form == ShipForm::EscapePod {
             self.laser_beam = None;
             self.laser_firing = false;
+            self.queued_laser_fire = false;
             return;
         }
 
-        if !self.laser_firing {
+        if self.spaceport_ejection.is_some() {
+            self.queued_laser_fire |= self.laser_firing;
+            self.laser_beam = None;
+            return;
+        }
+
+        let should_fire = self.laser_firing || self.queued_laser_fire;
+        self.queued_laser_fire = false;
+        if !should_fire {
             self.laser_beam = None;
             return;
         }
@@ -3511,6 +3614,7 @@ impl ShipState {
 
     fn update(&mut self, dt: f32, seed: u64, tick: u64) {
         self.spaceport_reentry_lockout = (self.spaceport_reentry_lockout - dt).max(0.0);
+        self.maintain_spaceport_ejection_velocity();
 
         if self.form == ShipForm::EscapePod {
             self.update_escape_pod(dt, seed, tick);
@@ -3529,7 +3633,9 @@ impl ShipState {
     }
 
     fn update_escape_pod(&mut self, dt: f32, seed: u64, tick: u64) {
-        self.velocity *= POD_VELOCITY_DAMPING;
+        if self.spaceport_ejection.is_none() {
+            self.velocity *= POD_VELOCITY_DAMPING;
+        }
         self.update_exhaust_trails(dt);
         let mut exhaust_rng = exhaust_rng_for_tick(seed, tick, self.owner_id);
 
@@ -3538,6 +3644,34 @@ impl ShipState {
         self.rotation_radians += self.omega * dt;
         self.update_pod_thrust(&mut exhaust_rng, tick);
         self.update_turn();
+    }
+
+    fn maintain_spaceport_ejection_velocity(&mut self) {
+        let Some(ejection) = self.spaceport_ejection else {
+            return;
+        };
+
+        let tangent = ejection
+            .outward
+            .rotate_radians(core::f32::consts::FRAC_PI_2);
+        let outward_speed = self
+            .velocity
+            .dot(ejection.outward)
+            .max(ejection.target_outward_speed)
+            .min(SPACEPORT_EJECT_MAX_SPEED);
+        let mut tangential_speed = self.velocity.dot(tangent);
+        if ejection.minimum_tangential_speed > 0.0 {
+            tangential_speed = tangential_speed.max(ejection.minimum_tangential_speed);
+        } else if ejection.minimum_tangential_speed < 0.0 {
+            tangential_speed = tangential_speed.min(ejection.minimum_tangential_speed);
+        }
+
+        let tangential_limit = (SPACEPORT_EJECT_MAX_SPEED * SPACEPORT_EJECT_MAX_SPEED
+            - outward_speed * outward_speed)
+            .max(0.0)
+            .sqrt();
+        tangential_speed = tangential_speed.clamp(-tangential_limit, tangential_limit);
+        self.velocity = ejection.outward * outward_speed + tangent * tangential_speed;
     }
 
     fn rotate_ship(&mut self, rng: &mut SpacewarsRng, tick: u64, exhaust_scalar: f32) {
@@ -3756,6 +3890,8 @@ impl ShipState {
         self.laser_firing = false;
         self.cannon_firing = false;
         self.laser_beam = None;
+        self.queued_laser_fire = false;
+        self.queued_cannon_fire = false;
         self.cannon_cooldown_remaining = 0.0;
         self.wing_theta = 0.0;
         self.wing_state = WingState::Opened;
@@ -3779,6 +3915,8 @@ impl ShipState {
         self.laser_firing = false;
         self.cannon_firing = false;
         self.laser_beam = None;
+        self.queued_laser_fire = false;
+        self.queued_cannon_fire = false;
         self.cannon_cooldown_remaining = 0.0;
         self.wing_theta = 0.0;
         self.wing_state = WingState::Opened;
@@ -4819,6 +4957,17 @@ mod tests {
             .collect();
     }
 
+    fn step_until_spaceport_ejection_finishes(state: &mut SpacewarsState, ship: usize) {
+        for _ in 0..60 {
+            if state.ships[ship].spaceport_ejection.is_none() {
+                return;
+            }
+            step(state, &[]);
+        }
+
+        panic!("ship {ship} did not finish its spaceport ejection");
+    }
+
     fn circle_primitive_count(frame: &RenderFrame) -> usize {
         frame
             .layers
@@ -5799,7 +5948,7 @@ mod tests {
     }
 
     #[test]
-    fn contested_spaceport_ejects_both_ships_without_damage() {
+    fn contested_spaceport_starts_both_ships_ejecting_without_teleporting() {
         let mut forward = init_deathmatch_no_asteroids();
         forward.sun = None;
         forward.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
@@ -5819,6 +5968,7 @@ mod tests {
             .iter()
             .map(|ship| ship.life)
             .collect::<Vec<_>>();
+        let starting_positions = forward.ships.each_ref().map(|ship| ship.position);
 
         update_spaceports(&mut forward, SPACEPORT_CONTEST_EJECT_DELAY_SECS);
         update_spaceports(&mut reverse, SPACEPORT_CONTEST_EJECT_DELAY_SECS);
@@ -5836,17 +5986,132 @@ mod tests {
             let bounds = ship_low_bounds(&ship_triangles(ship));
             assert!(
                 bounds.center.distance_to(planet.position)
-                    > planet.radius * BODY_BOUNDS_RADIUS_SCALE + bounds.radius
+                    < planet.radius * BODY_BOUNDS_RADIUS_SCALE
+                        + bounds.radius
+                        + SPACEPORT_EJECT_MARGIN
             );
+            assert_eq!(ship.position, starting_positions[ship_index]);
             assert_close(ship.life, starting_life[ship_index]);
             assert_close(
                 ship.spaceport_reentry_lockout,
                 SPACEPORT_REENTRY_LOCKOUT_SECS,
             );
             assert_close(ship.velocity.dot(outward), SPACEPORT_EJECT_SPEED);
+            assert_eq!(
+                ship.spaceport_ejection.map(|ejection| ejection.planet),
+                Some(0)
+            );
         }
         assert!(forward.ships[0].velocity.dot(tangent) < 0.0);
         assert!(forward.ships[1].velocity.dot(tangent) > 0.0);
+    }
+
+    #[test]
+    fn spaceport_ejection_normalizes_ship_and_pod_outward_speed() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].owner_id = Some(0);
+        refresh_player_planet_counts(&mut state);
+        state.ships[0].change_to_escape_pod();
+        let port_center = spaceport_physics(0, &state.planets[0]).bounds.center;
+        let outward = (port_center - state.planets[0].position).normalized();
+        let starting_positions = [port_center, port_center];
+        for (ship, position) in state.ships.iter_mut().zip(starting_positions) {
+            ship.position = position;
+            ship.velocity = -outward * SPACEPORT_EJECT_MAX_SPEED;
+        }
+
+        eject_ships_from_spaceport(&mut state, 0, &[0, 1]);
+
+        for (ship, starting_position) in state.ships.iter().zip(starting_positions) {
+            assert_eq!(ship.position, starting_position);
+            assert_close(ship.velocity.dot(outward), SPACEPORT_EJECT_SPEED);
+            assert_close(
+                ship.spaceport_ejection
+                    .expect("ship should be ejecting")
+                    .target_outward_speed,
+                SPACEPORT_EJECT_SPEED,
+            );
+        }
+    }
+
+    #[test]
+    fn escape_pod_clears_spaceport_without_velocity_damping() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].owner_id = Some(0);
+        refresh_player_planet_counts(&mut state);
+        state.ships[0].change_to_escape_pod();
+        let port_center = spaceport_physics(0, &state.planets[0]).bounds.center;
+        state.ships[0].position = port_center;
+        state.ships[0].velocity = Vec2::ZERO;
+        state.ships[1].position = port_center;
+        land_ships_on_planet(&mut state, &[0, 1], 0);
+
+        update_spaceports(&mut state, 1.0 / 60.0);
+
+        assert!(state.ships[0].spaceport_ejection.is_some());
+        assert_eq!(state.ships[0].position, port_center);
+        let mut ejection_steps = 0;
+        while state.ships[0].spaceport_ejection.is_some() && ejection_steps < 60 {
+            step(&mut state, &[]);
+            ejection_steps += 1;
+        }
+
+        assert!(
+            ejection_steps < (SPACEPORT_EJECT_TIMEOUT_SECS * 60.0) as usize,
+            "pod should clear under the normalized launch velocity"
+        );
+        let pod = &state.ships[0];
+        let bounds = ship_low_bounds(&ship_triangles(pod));
+        assert!(
+            bounds.center.distance_to(state.planets[0].position)
+                >= state.planets[0].radius * BODY_BOUNDS_RADIUS_SCALE
+                    + bounds.radius
+                    + SPACEPORT_EJECT_MARGIN
+        );
+        assert_close(
+            pod.velocity
+                .dot((port_center - state.planets[0].position).normalized()),
+            SPACEPORT_EJECT_SPEED,
+        );
+    }
+
+    #[test]
+    fn spaceport_ejection_timeout_only_corrects_remaining_clearance() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        let port_center = spaceport_physics(0, &state.planets[0]).bounds.center;
+        let outward = (port_center - state.planets[0].position).normalized();
+        let tangent = outward.rotate_radians(core::f32::consts::FRAC_PI_2);
+        state.ships[0].position = port_center + tangent * 7.0;
+
+        eject_ships_from_spaceport(&mut state, 0, &[0]);
+        let start_bounds = ship_low_bounds(&ship_triangles(&state.ships[0]));
+        let start_tangential_offset =
+            (start_bounds.center - state.planets[0].position).dot(tangent);
+        finish_spaceport_ejections(&mut state, SPACEPORT_EJECT_TIMEOUT_SECS);
+
+        let ship = &state.ships[0];
+        let bounds = ship_low_bounds(&ship_triangles(ship));
+        assert_eq!(ship.spaceport_ejection, None);
+        assert!(
+            bounds.center.distance_to(state.planets[0].position)
+                >= state.planets[0].radius * BODY_BOUNDS_RADIUS_SCALE
+                    + bounds.radius
+                    + SPACEPORT_EJECT_MARGIN
+        );
+        assert_close(
+            (bounds.center - state.planets[0].position).dot(tangent),
+            start_tangential_offset,
+        );
+        assert_close(
+            ship.spaceport_reentry_lockout,
+            SPACEPORT_REENTRY_LOCKOUT_SECS,
+        );
     }
 
     #[test]
@@ -5865,23 +6130,45 @@ mod tests {
         }
         land_ships_on_planet(&mut state, &[0, 1], 0);
 
-        for _ in 0..20 {
+        let starting_life = state.ships.each_ref().map(|ship| ship.life);
+        let mut saw_ejection = false;
+        let mut ejection_steps = 0;
+        for _ in 0..60 {
             step(&mut state, &[]);
+            if state
+                .ships
+                .iter()
+                .any(|ship| ship.spaceport_ejection.is_some())
+            {
+                saw_ejection = true;
+                ejection_steps += 1;
+            } else if saw_ejection {
+                break;
+            }
         }
 
+        assert!(saw_ejection);
+        assert!(
+            ejection_steps < (SPACEPORT_EJECT_TIMEOUT_SECS * 60.0) as usize,
+            "normal ejection should clear without the timeout fallback"
+        );
         assert!(state.spaceport_contacts.is_empty());
-        for ship in &state.ships {
+        for (ship_index, ship) in state.ships.iter().enumerate() {
             let bounds = ship_low_bounds(&ship_triangles(ship));
             assert!(
                 bounds.center.distance_to(state.planets[0].position)
-                    > state.planets[0].radius * BODY_BOUNDS_RADIUS_SCALE + bounds.radius
+                    >= state.planets[0].radius * BODY_BOUNDS_RADIUS_SCALE
+                        + bounds.radius
+                        + SPACEPORT_EJECT_MARGIN
             );
+            assert_eq!(ship.spaceport_ejection, None);
             assert!(ship.spaceport_reentry_lockout > 0.0);
+            assert_close(ship.life, starting_life[ship_index]);
         }
     }
 
     #[test]
-    fn firing_laser_while_docked_ejects_before_beam_spawns() {
+    fn firing_laser_while_docked_queues_beam_until_ejection_finishes() {
         let mut state = init_deathmatch_no_asteroids();
         state.sun = None;
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
@@ -5895,6 +6182,11 @@ mod tests {
         land_ship_on_planet(&mut state, 0, 0);
 
         step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+
+        assert!(state.ships[0].spaceport_ejection.is_some());
+        assert_eq!(state.ships[0].laser_beam, None);
+        step(&mut state, &[SpacewarsAction::fire_laser_halt(0)]);
+        step_until_spaceport_ejection_finishes(&mut state, 0);
 
         let beam = state.ships[0]
             .laser_beam
@@ -5911,7 +6203,7 @@ mod tests {
     }
 
     #[test]
-    fn firing_cannon_while_docked_ejects_before_shell_spawns() {
+    fn firing_cannon_while_docked_queues_shell_until_ejection_finishes() {
         let mut state = init_deathmatch_no_asteroids();
         state.sun = None;
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
@@ -5925,6 +6217,16 @@ mod tests {
         land_ship_on_planet(&mut state, 0, 0);
 
         step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+
+        assert!(state.ships[0].spaceport_ejection.is_some());
+        assert!(
+            state
+                .debris
+                .iter()
+                .all(|debris| debris.kind != DebrisKind::Shell)
+        );
+        step(&mut state, &[SpacewarsAction::fire_cannon_halt(0)]);
+        step_until_spaceport_ejection_finishes(&mut state, 0);
 
         let shell = state
             .debris

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -28,6 +28,7 @@ const SUN_LAYER: i32 = -15;
 const PLANET_LAYER: i32 = -10;
 const SPACEPORT_LAYER: i32 = -5;
 const SPACEPORT_FEEDBACK_LAYER: i32 = -4;
+const PLANET_OWNERSHIP_LAYER: i32 = -3;
 const EXHAUST_LAYER: i32 = -1;
 const SHIP_LAYER: i32 = 0;
 const DEBRIS_LAYER: i32 = 1;
@@ -54,6 +55,13 @@ const SPACEPORT_OUTER_POINTS: usize = 15;
 const SPACEPORT_INNER_POINTS: usize = 7;
 const SPACEPORT_DAMPING: f32 = 0.94;
 const SPACEPORT_PULL_SCALE: f32 = 3.0;
+const FLAG_CENTER_RADIUS: f32 = 6.0;
+const FLAG_SCALE_FACTOR: f32 = 0.6;
+const FLAG_HEIGHT_FACTOR: f32 = 0.3;
+const FLAG_WIDTH_FACTOR: f32 = 0.45;
+const FLAG_STEM_FACTOR: f32 = 0.7;
+const FLAG_RADIUS_DIVISOR: f32 = 15.0;
+const OVERVIEW_OWNERSHIP_STROKE_WIDTH: f32 = 2.25;
 const PLANET_CAPTURE_SECS: f32 = 4.0;
 const POD_REBUILD_SECS: f32 = 8.0;
 const OWNED_SPACEPORT_HEAL_PER_SEC: f32 = 3.0;
@@ -3729,7 +3737,11 @@ fn render_state_with_camera(
             with_alpha(render_color(planet.color), 1.0),
             RenderColor::rgba(0.72, 0.78, 0.84, 1.0),
         );
+        if options.show_planet_ownership_halo {
+            render_planet_ownership_halo(&mut frame, state, planet);
+        }
         render_spaceport(&mut frame, state, planet);
+        render_planet_flags(&mut frame, state, planet);
     }
 
     if options.show_exhaust {
@@ -3776,6 +3788,7 @@ struct RenderOptions {
     show_starfield: bool,
     show_exhaust: bool,
     show_particles: bool,
+    show_planet_ownership_halo: bool,
     debris_style: DebrisRenderStyle,
     player_view: Option<usize>,
 }
@@ -3787,6 +3800,7 @@ impl RenderOptions {
             show_starfield: true,
             show_exhaust: true,
             show_particles: true,
+            show_planet_ownership_halo: false,
             debris_style: DebrisRenderStyle::Full,
             player_view: None,
         }
@@ -3796,9 +3810,10 @@ impl RenderOptions {
         Self {
             show_ship_labels: false,
             show_starfield: false,
-            show_exhaust: true,
-            show_particles: true,
-            debris_style: DebrisRenderStyle::Full,
+            show_exhaust: false,
+            show_particles: false,
+            show_planet_ownership_halo: true,
+            debris_style: DebrisRenderStyle::SimpleMarks,
             player_view: Some(player),
         }
     }
@@ -3809,6 +3824,7 @@ impl RenderOptions {
             show_starfield: true,
             show_exhaust: true,
             show_particles: true,
+            show_planet_ownership_halo: false,
             debris_style: DebrisRenderStyle::Full,
             player_view: None,
         }
@@ -3820,6 +3836,7 @@ impl RenderOptions {
             show_starfield: false,
             show_exhaust: false,
             show_particles: false,
+            show_planet_ownership_halo: true,
             debris_style: DebrisRenderStyle::SimpleMarks,
             player_view: Some(player),
         }
@@ -4069,6 +4086,105 @@ fn render_body(
             stroke: Some(Stroke::new(stroke, 1.25)),
         }),
     );
+}
+
+fn render_planet_ownership_halo(
+    frame: &mut RenderFrame,
+    state: &SpacewarsState,
+    planet: &PlanetState,
+) {
+    let Some(color) = planet
+        .owner_id
+        .and_then(|owner| state.players.get(owner))
+        .map(|player| with_alpha(render_color(player.color), 0.95))
+    else {
+        return;
+    };
+
+    frame.push_primitive(
+        PLANET_OWNERSHIP_LAYER,
+        RenderPrimitive::Circle(RenderCircle {
+            center: render_point(planet.position),
+            radius: planet.radius,
+            fill: None,
+            stroke: Some(Stroke::new(color, OVERVIEW_OWNERSHIP_STROKE_WIDTH)),
+        }),
+    );
+}
+
+fn render_planet_flags(frame: &mut RenderFrame, state: &SpacewarsState, planet: &PlanetState) {
+    let Some(color) = planet_flag_color(state, planet) else {
+        return;
+    };
+
+    frame.push_primitive(
+        PLANET_OWNERSHIP_LAYER,
+        RenderPrimitive::Circle(RenderCircle::filled(
+            render_point(planet.position),
+            FLAG_CENTER_RADIUS,
+            color,
+        )),
+    );
+
+    let flag_count = (planet.radius / FLAG_RADIUS_DIVISOR).floor() as usize;
+    if flag_count == 0 {
+        return;
+    }
+
+    let scale = planet.radius * FLAG_SCALE_FACTOR;
+    let stem_length = scale * FLAG_STEM_FACTOR;
+    let flag_height = scale * FLAG_HEIGHT_FACTOR;
+    let flag_width = scale * FLAG_WIDTH_FACTOR;
+
+    for index in 0..flag_count {
+        let theta = planet.wrapper_angle - core::f32::consts::FRAC_PI_4
+            + index as f32 * core::f32::consts::TAU / flag_count as f32;
+        let radial = Vec2::from_radians(theta);
+        let tangent = radial.rotate_radians(core::f32::consts::FRAC_PI_2);
+        let stem = planet.position + radial * stem_length;
+        let tip = stem + radial * flag_height;
+        let outer_side = tip + tangent * flag_width;
+        let inner_side = stem + tangent * flag_width;
+
+        frame.push_primitive(
+            PLANET_OWNERSHIP_LAYER,
+            RenderPrimitive::Polygon(RenderPolygon::filled(
+                vec![
+                    render_point(stem),
+                    render_point(tip),
+                    render_point(outer_side),
+                    render_point(inner_side),
+                ],
+                color,
+            )),
+        );
+        frame.push_primitive(
+            PLANET_OWNERSHIP_LAYER,
+            RenderPrimitive::Line(engine_common::RenderLine::new(
+                render_point(planet.position),
+                render_point(stem),
+                Stroke::new(color, 1.0),
+            )),
+        );
+    }
+}
+
+fn planet_flag_color(state: &SpacewarsState, planet: &PlanetState) -> Option<RenderColor> {
+    if let Some(ship) = landing_ship(state, planet)
+        && planet.owner_id != Some(ship.owner_id)
+        && ship.form != ShipForm::EscapePod
+    {
+        let progress = capture_progress(planet);
+        if progress > 0.0 {
+            let player = state.players.get(ship.owner_id)?;
+            return Some(with_intensity(render_color(player.color), progress));
+        }
+    }
+
+    planet
+        .owner_id
+        .and_then(|owner| state.players.get(owner))
+        .map(|player| render_color(player.color))
 }
 
 fn render_spaceport(frame: &mut RenderFrame, state: &SpacewarsState, planet: &PlanetState) {
@@ -4374,6 +4490,16 @@ fn dim(color: RenderColor, scale: f32) -> RenderColor {
         (color.g * scale).clamp(0.0, 1.0),
         (color.b * scale).clamp(0.0, 1.0),
         color.a,
+    )
+}
+
+fn with_intensity(color: RenderColor, intensity: f32) -> RenderColor {
+    let intensity = intensity.clamp(0.0, 1.0);
+    RenderColor::rgba(
+        color.r * intensity,
+        color.g * intensity,
+        color.b * intensity,
+        color.a * intensity,
     )
 }
 
@@ -5512,6 +5638,93 @@ mod tests {
         assert_close(actual.g, expected.g);
         assert_close(actual.b, expected.b);
         assert_close(actual.a, 0.82);
+    }
+
+    #[test]
+    fn owned_planet_renders_original_flags_and_overview_halo() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].owner_id = Some(0);
+        let expected_color = render_color(state.players[0].color);
+        let flag_count = (state.planets[0].radius / FLAG_RADIUS_DIVISOR).floor() as usize;
+
+        let player_frame = SpacewarsScenario::render_frame(&state);
+        let player_layer = player_frame
+            .layers
+            .iter()
+            .find(|layer| layer.z == PLANET_OWNERSHIP_LAYER)
+            .expect("owned planet should render an ownership layer");
+
+        assert_eq!(player_layer.primitives.len(), 1 + flag_count * 2);
+        let RenderPrimitive::Circle(center) = &player_layer.primitives[0] else {
+            panic!("first ownership primitive should be the flag center");
+        };
+        assert_eq!(center.radius, FLAG_CENTER_RADIUS);
+        assert_eq!(center.fill, Some(Fill::new(expected_color)));
+        assert!(center.stroke.is_none());
+
+        let overview = render_overview_state(&state, 0);
+        let overview_layer = overview
+            .layers
+            .iter()
+            .find(|layer| layer.z == PLANET_OWNERSHIP_LAYER)
+            .expect("owned planet overview should render ownership");
+
+        assert_eq!(overview_layer.primitives.len(), 2 + flag_count * 2);
+        let RenderPrimitive::Circle(halo) = &overview_layer.primitives[0] else {
+            panic!("first overview ownership primitive should be the halo");
+        };
+        assert!(halo.fill.is_none());
+        assert_eq!(
+            halo.stroke,
+            Some(Stroke::new(
+                with_alpha(expected_color, 0.95),
+                OVERVIEW_OWNERSHIP_STROKE_WIDTH
+            ))
+        );
+    }
+
+    #[test]
+    fn capturing_planet_fades_challenger_flags_without_owned_halo() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].landing_ship = Some(0);
+        state.planets[0].taking_ownership_time = PLANET_CAPTURE_SECS * 0.5;
+        let expected_color = with_intensity(render_color(state.players[0].color), 0.5);
+
+        let overview = render_overview_state(&state, 0);
+        let ownership_layer = overview
+            .layers
+            .iter()
+            .find(|layer| layer.z == PLANET_OWNERSHIP_LAYER)
+            .expect("capturing planet should render flags");
+
+        let circles = ownership_layer
+            .primitives
+            .iter()
+            .filter_map(|primitive| match primitive {
+                RenderPrimitive::Circle(circle) => Some(circle),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(circles.len(), 1, "unowned planet should not have a halo");
+        assert_eq!(circles[0].fill, Some(Fill::new(expected_color)));
+        assert_close(circles[0].fill.unwrap().color.a, 0.5);
+    }
+
+    #[test]
+    fn unowned_planet_does_not_render_ownership_primitives() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+
+        let overview = render_overview_state(&state, 0);
+
+        assert!(
+            overview
+                .layers
+                .iter()
+                .all(|layer| layer.z != PLANET_OWNERSHIP_LAYER)
+        );
     }
 
     #[test]
@@ -7073,7 +7286,15 @@ mod tests {
 
     #[test]
     fn local_play_frames_include_player_views_and_world_overviews() {
-        let state = init_default(123);
+        let mut state = init_default(123);
+        state.debris.push(DebrisState::new(
+            DebrisKind::Asteroid,
+            Vec2::new(100.0, 100.0),
+            Vec2::ZERO,
+            5.0,
+            ASTEROID_DAMAGE_SCALAR,
+            Color::DIM_GREY,
+        ));
         let frames = SpacewarsScenario::render_local_play_frames(&state);
 
         assert_eq!(frames.len(), 4);
@@ -7092,7 +7313,20 @@ mod tests {
         assert_eq!(text_values(&frames[2]), Vec::<String>::new());
         assert_eq!(text_values(&frames[3]), Vec::<String>::new());
         for (player, frame) in frames[2..].iter().enumerate() {
-            assert!(frame.layers.iter().all(|layer| layer.z != STARFIELD_LAYER));
+            assert!(frame.layers.iter().all(|layer| {
+                !matches!(layer.z, STARFIELD_LAYER | EXHAUST_LAYER | PARTICLE_LAYER)
+            }));
+            let debris_layer = frame
+                .layers
+                .iter()
+                .find(|layer| layer.z == DEBRIS_LAYER)
+                .expect("overview should retain simplified debris marks");
+            assert!(
+                debris_layer
+                    .primitives
+                    .iter()
+                    .all(|primitive| matches!(primitive, RenderPrimitive::Circle(_)))
+            );
             let view_layer = frame
                 .layers
                 .iter()

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -63,8 +63,14 @@ const FLAG_STEM_FACTOR: f32 = 0.7;
 const FLAG_RADIUS_DIVISOR: f32 = 15.0;
 const OVERVIEW_OWNERSHIP_STROKE_WIDTH: f32 = 2.25;
 const PLANET_CAPTURE_SECS: f32 = 4.0;
+const PLANET_CAPTURE_DECAY_RATE: f32 = 0.5;
 const POD_REBUILD_SECS: f32 = 8.0;
 const OWNED_SPACEPORT_HEAL_PER_SEC: f32 = 3.0;
+const SPACEPORT_CONTEST_EJECT_DELAY_SECS: f32 = 0.25;
+const SPACEPORT_EJECT_MARGIN: f32 = 5.0;
+const SPACEPORT_EJECT_SPEED: f32 = 120.0;
+const SPACEPORT_EJECT_TANGENTIAL_SPEED: f32 = 60.0;
+const SPACEPORT_REENTRY_LOCKOUT_SECS: f32 = 0.75;
 const DEFAULT_PLAYER_VIEW_HEIGHT: f32 = 320.0;
 const MIN_PLAYER_VIEW_HEIGHT: f32 = 15.0;
 const PLAYER_VIEW_ASPECT_RATIO: f32 = 640.0 / 417.6;
@@ -266,8 +272,9 @@ pub struct PlanetState {
     pub mass: f32,
     pub color: Color,
     pub owner_id: Option<usize>,
-    pub landing_ship: Option<usize>,
-    pub landing_ship_prev_round: Option<usize>,
+    pub capturing_player_id: Option<usize>,
+    pub previous_docked_ship: Option<usize>,
+    pub dock_contest_time: f32,
     pub taking_ownership_time: f32,
     pub building_new_ship_time: f32,
     pub orbit_radius: f32,
@@ -389,6 +396,19 @@ pub struct SpaceportContact {
     pub planet: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct SpaceportOccupancy {
+    ships: Vec<usize>,
+    owner_pods: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpaceportStatus {
+    Empty,
+    Active(usize),
+    Contested,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoundsDrawMode {
     High,
@@ -433,6 +453,7 @@ pub struct ShipState {
     thrust_power: f32,
     current_max_omega: f32,
     cannon_cooldown_remaining: f32,
+    spaceport_reentry_lockout: f32,
     delta_time: f32,
     death_impulse: Vec2,
 }
@@ -701,7 +722,7 @@ impl Scenario for SpacewarsScenario {
                 planet.update_orbit(sun.position, dt);
             }
         }
-        update_planet_landing_progress(state, dt);
+        update_spaceports(state, dt);
 
         for ship in &mut state.ships {
             ship.update(dt, state.seed, state.tick);
@@ -720,7 +741,6 @@ impl Scenario for SpacewarsScenario {
         let collision_events = resolve_body_collisions(state);
         state.body_collisions = collision_events.body_collisions;
         state.spaceport_contacts = collision_events.spaceport_contacts;
-        record_spaceport_landings(state);
         handle_ship_deaths(state);
         if state.tick % ASTEROID_GRAVITY_FRAME_MODULUS == 0 {
             apply_debris_gravity(state);
@@ -1051,8 +1071,9 @@ fn build_world(config: &SpacewarsConfig, seed: u64) -> (Option<SunState>, Vec<Pl
             mass: body_mass(radius),
             color: random_color(&mut rng),
             owner_id: None,
-            landing_ship: None,
-            landing_ship_prev_round: None,
+            capturing_player_id: None,
+            previous_docked_ship: None,
+            dock_contest_time: 0.0,
             taking_ownership_time: 0.0,
             building_new_ship_time: 0.0,
             orbit_radius,
@@ -2488,6 +2509,9 @@ fn spaceport_accepts_ship(
     spaceport: SpaceportPhysics,
 ) -> bool {
     let ship = &state.ships[ship_index];
+    if ship.spaceport_reentry_lockout > 0.0 {
+        return false;
+    }
     if ship.form != ShipForm::EscapePod {
         return true;
     }
@@ -2537,56 +2561,104 @@ fn resolve_spaceport_contact(ship: &mut ShipState, spaceport_center: Vec2) {
     ship.velocity += offset * (force / ship.mass());
 }
 
-fn update_planet_landing_progress(state: &mut SpacewarsState, dt: f32) {
+/// Process contacts saved by the previous physics tick before movement and weapons update.
+fn update_spaceports(state: &mut SpacewarsState, dt: f32) {
+    let occupancies = (0..state.planets.len())
+        .map(|planet| spaceport_occupancy(state, planet))
+        .collect::<Vec<_>>();
     let mut planet_counts_dirty = false;
 
-    for planet_index in 0..state.planets.len() {
-        let landing_ship = state.planets[planet_index].landing_ship;
-        let Some(ship_index) = landing_ship else {
-            state.planets[planet_index].landing_ship_prev_round = None;
-            state.planets[planet_index].taking_ownership_time = 0.0;
+    for (planet_index, occupancy) in occupancies.into_iter().enumerate() {
+        let firing_ships = occupancy
+            .ships
+            .iter()
+            .copied()
+            .filter(|ship| {
+                state
+                    .ships
+                    .get(*ship)
+                    .is_some_and(|ship| ship.laser_firing || ship.cannon_firing)
+            })
+            .collect::<Vec<_>>();
+        // Releasing here moves the muzzle beyond the planet before this tick spawns weapons.
+        if !firing_ships.is_empty() {
+            eject_ships_from_spaceport(state, planet_index, &firing_ships);
+            let planet = &mut state.planets[planet_index];
+            planet.previous_docked_ship = None;
+            planet.dock_contest_time = 0.0;
+            decay_planet_capture(planet, dt);
             continue;
-        };
+        }
 
-        let landed_continuously =
-            state.planets[planet_index].landing_ship_prev_round == landing_ship;
-        if landed_continuously && ship_index < state.ships.len() {
+        if spaceport_is_contested(state, &occupancy) {
+            let should_eject = {
+                let planet = &mut state.planets[planet_index];
+                planet.previous_docked_ship = None;
+                planet.dock_contest_time += dt;
+                decay_planet_capture(planet, dt);
+                planet.dock_contest_time >= SPACEPORT_CONTEST_EJECT_DELAY_SECS
+            };
+            if should_eject {
+                eject_ships_from_spaceport(state, planet_index, &occupancy.ships);
+                state.planets[planet_index].dock_contest_time = 0.0;
+            }
+            continue;
+        }
+
+        state.planets[planet_index].dock_contest_time = 0.0;
+
+        if let Some(&ship_index) = occupancy.ships.first() {
             let ship_owner_id = state.ships[ship_index].owner_id;
             let owned_by_ship = state.planets[planet_index].owner_id == Some(ship_owner_id);
-            let is_escape_pod = state.ships[ship_index].form == ShipForm::EscapePod;
+            if !owned_by_ship && !occupancy.owner_pods.is_empty() {
+                eject_ships_from_spaceport(state, planet_index, &occupancy.owner_pods);
+            }
 
-            if owned_by_ship && is_escape_pod {
+            let landed_continuously =
+                state.planets[planet_index].previous_docked_ship == Some(ship_index);
+            state.planets[planet_index].previous_docked_ship = Some(ship_index);
+
+            if owned_by_ship {
+                decay_planet_capture(&mut state.planets[planet_index], dt);
+                if landed_continuously {
+                    state.ships[ship_index].heal(OWNED_SPACEPORT_HEAL_PER_SEC * dt);
+                }
+            } else {
+                planet_counts_dirty |= advance_planet_capture(
+                    &mut state.planets[planet_index],
+                    ship_owner_id,
+                    landed_continuously,
+                    dt,
+                );
+            }
+            continue;
+        }
+
+        if let Some(&pod_index) = occupancy.owner_pods.first() {
+            let landed_continuously =
+                state.planets[planet_index].previous_docked_ship == Some(pod_index);
+            state.planets[planet_index].previous_docked_ship = Some(pod_index);
+            decay_planet_capture(&mut state.planets[planet_index], dt);
+
+            if landed_continuously {
                 let rebuild_progress = {
                     let planet = &mut state.planets[planet_index];
                     planet.building_new_ship_time += dt;
                     planet.building_new_ship_time / POD_REBUILD_SECS
                 };
-                state.ships[ship_index].set_escape_pod_rebuild_progress(rebuild_progress);
+                state.ships[pod_index].set_escape_pod_rebuild_progress(rebuild_progress);
 
                 if rebuild_progress >= 1.0 {
                     state.planets[planet_index].building_new_ship_time = 0.0;
-                    state.ships[ship_index].restore_from_escape_pod();
+                    state.ships[pod_index].restore_from_escape_pod();
                 }
-            } else if owned_by_ship {
-                state.ships[ship_index].heal(OWNED_SPACEPORT_HEAL_PER_SEC * dt);
-            } else if !is_escape_pod {
-                let captured = {
-                    let planet = &mut state.planets[planet_index];
-                    planet.taking_ownership_time += dt;
-                    if planet.taking_ownership_time >= PLANET_CAPTURE_SECS {
-                        planet.owner_id = Some(ship_owner_id);
-                        planet.taking_ownership_time = 0.0;
-                        true
-                    } else {
-                        false
-                    }
-                };
-                planet_counts_dirty |= captured;
             }
+            continue;
         }
 
-        state.planets[planet_index].landing_ship_prev_round = landing_ship;
-        state.planets[planet_index].landing_ship = None;
+        let planet = &mut state.planets[planet_index];
+        planet.previous_docked_ship = None;
+        decay_planet_capture(planet, dt);
     }
 
     if planet_counts_dirty {
@@ -2594,17 +2666,146 @@ fn update_planet_landing_progress(state: &mut SpacewarsState, dt: f32) {
     }
 }
 
-fn record_spaceport_landings(state: &mut SpacewarsState) {
-    let contacts = state.spaceport_contacts.clone();
+fn spaceport_occupancy(state: &SpacewarsState, planet_index: usize) -> SpaceportOccupancy {
+    let Some(planet) = state.planets.get(planet_index) else {
+        return SpaceportOccupancy::default();
+    };
+    let mut occupancy = SpaceportOccupancy::default();
 
-    for contact in contacts {
+    for contact in state
+        .spaceport_contacts
+        .iter()
+        .filter(|contact| contact.planet == planet_index)
+    {
         let Some(ship) = state.ships.get(contact.ship) else {
             continue;
         };
-        let Some(planet) = state.planets.get_mut(contact.planet) else {
+        if ship.spaceport_reentry_lockout > 0.0 {
             continue;
+        }
+
+        match ship.form {
+            ShipForm::Ship => occupancy.ships.push(contact.ship),
+            ShipForm::EscapePod if planet.owner_id == Some(ship.owner_id) => {
+                occupancy.owner_pods.push(contact.ship);
+            }
+            ShipForm::EscapePod => {}
+        }
+    }
+
+    let ship_key = |ship_index: &usize| (state.ships[*ship_index].owner_id, *ship_index);
+    occupancy.ships.sort_by_key(ship_key);
+    occupancy.ships.dedup();
+    occupancy.owner_pods.sort_by_key(ship_key);
+    occupancy.owner_pods.dedup();
+    occupancy
+}
+
+fn spaceport_is_contested(state: &SpacewarsState, occupancy: &SpaceportOccupancy) -> bool {
+    let Some(first) = occupancy.ships.first() else {
+        return false;
+    };
+    let first_owner = state.ships[*first].owner_id;
+    occupancy
+        .ships
+        .iter()
+        .skip(1)
+        .any(|ship| state.ships[*ship].owner_id != first_owner)
+}
+
+fn spaceport_status(state: &SpacewarsState, planet_index: usize) -> SpaceportStatus {
+    let occupancy = spaceport_occupancy(state, planet_index);
+    if spaceport_is_contested(state, &occupancy) {
+        SpaceportStatus::Contested
+    } else if let Some(ship) = occupancy.ships.first().or(occupancy.owner_pods.first()) {
+        SpaceportStatus::Active(*ship)
+    } else {
+        SpaceportStatus::Empty
+    }
+}
+
+fn decay_planet_capture(planet: &mut PlanetState, dt: f32) {
+    planet.taking_ownership_time =
+        (planet.taking_ownership_time - dt * PLANET_CAPTURE_DECAY_RATE).max(0.0);
+    if planet.taking_ownership_time <= REALLY_SMALL {
+        planet.taking_ownership_time = 0.0;
+        planet.capturing_player_id = None;
+    }
+}
+
+fn advance_planet_capture(
+    planet: &mut PlanetState,
+    player: usize,
+    landed_continuously: bool,
+    dt: f32,
+) -> bool {
+    if planet.capturing_player_id != Some(player) {
+        planet.capturing_player_id = Some(player);
+        planet.taking_ownership_time = 0.0;
+        return false;
+    }
+    if !landed_continuously {
+        return false;
+    }
+
+    planet.taking_ownership_time += dt;
+    if planet.taking_ownership_time < PLANET_CAPTURE_SECS {
+        return false;
+    }
+
+    planet.owner_id = Some(player);
+    planet.capturing_player_id = None;
+    planet.taking_ownership_time = 0.0;
+    planet.building_new_ship_time = 0.0;
+    true
+}
+
+fn eject_ships_from_spaceport(
+    state: &mut SpacewarsState,
+    planet_index: usize,
+    ship_indices: &[usize],
+) {
+    let Some(planet) = state.planets.get(planet_index).copied() else {
+        return;
+    };
+    let port_center = spaceport_physics(planet_index, &planet).bounds.center;
+    let outward_offset = port_center - planet.position;
+    let outward = if outward_offset.length_squared() <= REALLY_SMALL {
+        Vec2::X
+    } else {
+        outward_offset.normalized()
+    };
+    let tangent = outward.rotate_radians(core::f32::consts::FRAC_PI_2);
+    let mut ships = ship_indices
+        .iter()
+        .copied()
+        .filter(|ship| *ship < state.ships.len())
+        .collect::<Vec<_>>();
+    // Stable owner ordering makes the separation independent of collision iteration order.
+    ships.sort_by_key(|ship| (state.ships[*ship].owner_id, *ship));
+    ships.dedup();
+    let ship_count = ships.len();
+
+    for (rank, ship_index) in ships.into_iter().enumerate() {
+        let side = if ship_count <= 1 {
+            0.0
+        } else {
+            rank as f32 * 2.0 / (ship_count - 1) as f32 - 1.0
         };
-        planet.set_landing_ship(contact.ship, ship.owner_id);
+        let ship = &mut state.ships[ship_index];
+        let bounds = ship_low_bounds(&ship_triangles(ship));
+        let center_offset = bounds.center - ship.position;
+        let target_center = planet.position
+            + outward
+                * (planet.radius * BODY_BOUNDS_RADIUS_SCALE
+                    + bounds.radius
+                    + SPACEPORT_EJECT_MARGIN)
+            + tangent * (side * bounds.radius * 1.5);
+
+        ship.position = target_center - center_offset;
+        ship.velocity =
+            outward * SPACEPORT_EJECT_SPEED + tangent * (side * SPACEPORT_EJECT_TANGENTIAL_SPEED);
+        ship.spaceport_reentry_lockout = SPACEPORT_REENTRY_LOCKOUT_SECS;
     }
 }
 
@@ -2847,21 +3048,6 @@ impl PlanetState {
         self.orbit_angle += self.orbit_omega * dt;
         self.wrapper_angle += self.wrapper_omega * dt;
         self.position = sun_position + Vec2::from_radians(self.orbit_angle) * self.orbit_radius;
-    }
-
-    fn set_landing_ship(&mut self, ship_index: usize, ship_owner_id: usize) {
-        if self.landing_ship.is_none() {
-            self.landing_ship = Some(ship_index);
-        }
-
-        if self.owner_id == Some(ship_owner_id) {
-            self.landing_ship = Some(ship_index);
-            self.taking_ownership_time = 0.0;
-        }
-
-        if self.landing_ship_prev_round == Some(ship_index) {
-            self.landing_ship = Some(ship_index);
-        }
     }
 }
 
@@ -3142,6 +3328,7 @@ impl ShipState {
             thrust_power: SHIP_THRUST_FORCE / SHIP_MASS * delta_time,
             current_max_omega: BASE_MAX_OMEGA,
             cannon_cooldown_remaining: 0.0,
+            spaceport_reentry_lockout: 0.0,
             delta_time,
             death_impulse: Vec2::ZERO,
         }
@@ -3323,6 +3510,8 @@ impl ShipState {
     }
 
     fn update(&mut self, dt: f32, seed: u64, tick: u64) {
+        self.spaceport_reentry_lockout = (self.spaceport_reentry_lockout - dt).max(0.0);
+
         if self.form == ShipForm::EscapePod {
             self.update_escape_pod(dt, seed, tick);
             return;
@@ -3728,7 +3917,7 @@ fn render_state_with_camera(
         );
     }
 
-    for planet in &state.planets {
+    for (planet_index, planet) in state.planets.iter().enumerate() {
         render_body(
             &mut frame,
             PLANET_LAYER,
@@ -3740,7 +3929,7 @@ fn render_state_with_camera(
         if options.show_planet_ownership_halo {
             render_planet_ownership_halo(&mut frame, state, planet);
         }
-        render_spaceport(&mut frame, state, planet);
+        render_spaceport(&mut frame, state, planet_index, planet);
         render_planet_flags(&mut frame, state, planet);
     }
 
@@ -4170,13 +4359,12 @@ fn render_planet_flags(frame: &mut RenderFrame, state: &SpacewarsState, planet: 
 }
 
 fn planet_flag_color(state: &SpacewarsState, planet: &PlanetState) -> Option<RenderColor> {
-    if let Some(ship) = landing_ship(state, planet)
-        && planet.owner_id != Some(ship.owner_id)
-        && ship.form != ShipForm::EscapePod
+    if let Some(capturing_player) = planet.capturing_player_id
+        && planet.owner_id != Some(capturing_player)
     {
         let progress = capture_progress(planet);
         if progress > 0.0 {
-            let player = state.players.get(ship.owner_id)?;
+            let player = state.players.get(capturing_player)?;
             return Some(with_intensity(render_color(player.color), progress));
         }
     }
@@ -4187,7 +4375,12 @@ fn planet_flag_color(state: &SpacewarsState, planet: &PlanetState) -> Option<Ren
         .map(|player| render_color(player.color))
 }
 
-fn render_spaceport(frame: &mut RenderFrame, state: &SpacewarsState, planet: &PlanetState) {
+fn render_spaceport(
+    frame: &mut RenderFrame,
+    state: &SpacewarsState,
+    planet_index: usize,
+    planet: &PlanetState,
+) {
     let points = spaceport_points(planet)
         .into_iter()
         .map(render_point)
@@ -4197,12 +4390,12 @@ fn render_spaceport(frame: &mut RenderFrame, state: &SpacewarsState, planet: &Pl
         SPACEPORT_LAYER,
         RenderPrimitive::Polygon(RenderPolygon {
             points: points.clone(),
-            fill: Some(Fill::new(spaceport_color(state, planet))),
+            fill: Some(Fill::new(spaceport_color(state, planet_index, planet))),
             stroke: Some(Stroke::new(RenderColor::rgba(0.05, 0.08, 0.1, 0.8), 0.75)),
         }),
     );
 
-    let Some(stroke) = spaceport_feedback_stroke(state, planet) else {
+    let Some(stroke) = spaceport_feedback_stroke(state, planet_index, planet) else {
         return;
     };
     frame.push_primitive(
@@ -4215,8 +4408,22 @@ fn render_spaceport(frame: &mut RenderFrame, state: &SpacewarsState, planet: &Pl
     );
 }
 
-fn spaceport_color(state: &SpacewarsState, planet: &PlanetState) -> RenderColor {
-    if let Some(ship) = landing_ship(state, planet) {
+fn spaceport_color(
+    state: &SpacewarsState,
+    planet_index: usize,
+    planet: &PlanetState,
+) -> RenderColor {
+    if spaceport_status(state, planet_index) == SpaceportStatus::Contested {
+        return blend_color(
+            base_spaceport_color(state, planet),
+            RenderColor::rgba(1.0, 0.6, 0.08, 0.9),
+            0.35,
+        );
+    }
+
+    if let SpaceportStatus::Active(ship_index) = spaceport_status(state, planet_index)
+        && let Some(ship) = state.ships.get(ship_index)
+    {
         let player_color = render_color(state.players[ship.owner_id].color);
         if planet.owner_id != Some(ship.owner_id) && ship.form != ShipForm::EscapePod {
             let progress = capture_progress(planet);
@@ -4239,6 +4446,10 @@ fn spaceport_color(state: &SpacewarsState, planet: &PlanetState) -> RenderColor 
         }
     }
 
+    base_spaceport_color(state, planet)
+}
+
+fn base_spaceport_color(state: &SpacewarsState, planet: &PlanetState) -> RenderColor {
     planet
         .owner_id
         .and_then(|owner| state.players.get(owner))
@@ -4246,8 +4457,26 @@ fn spaceport_color(state: &SpacewarsState, planet: &PlanetState) -> RenderColor 
         .unwrap_or(RenderColor::rgba(1.0, 1.0, 1.0, 0.82))
 }
 
-fn spaceport_feedback_stroke(state: &SpacewarsState, planet: &PlanetState) -> Option<Stroke> {
-    let ship = landing_ship(state, planet)?;
+fn spaceport_feedback_stroke(
+    state: &SpacewarsState,
+    planet_index: usize,
+    planet: &PlanetState,
+) -> Option<Stroke> {
+    let status = spaceport_status(state, planet_index);
+    if status == SpaceportStatus::Contested {
+        let pulse = ((state.tick as f32 * 0.35).sin() + 1.0) * 0.5;
+        let color = blend_color(
+            RenderColor::rgba(1.0, 0.48, 0.02, 0.95),
+            RenderColor::rgba(1.0, 0.95, 0.7, 1.0),
+            pulse,
+        );
+        return Some(Stroke::new(color, 2.0 + pulse));
+    }
+
+    let SpaceportStatus::Active(ship_index) = status else {
+        return None;
+    };
+    let ship = state.ships.get(ship_index)?;
     let player_color = render_color(state.players[ship.owner_id].color);
     let progress = if planet.owner_id == Some(ship.owner_id) && ship.form == ShipForm::EscapePod {
         rebuild_progress(planet)
@@ -4259,12 +4488,6 @@ fn spaceport_feedback_stroke(state: &SpacewarsState, planet: &PlanetState) -> Op
 
     let width = 1.25 + progress * 1.25;
     Some(Stroke::new(with_alpha(player_color, 0.95), width))
-}
-
-fn landing_ship<'a>(state: &'a SpacewarsState, planet: &PlanetState) -> Option<&'a ShipState> {
-    planet
-        .landing_ship
-        .and_then(|ship_index| state.ships.get(ship_index))
 }
 
 fn capture_progress(planet: &PlanetState) -> f32 {
@@ -4571,8 +4794,9 @@ mod tests {
             mass: 0.0,
             color: Color::GREEN,
             owner_id: None,
-            landing_ship: None,
-            landing_ship_prev_round: None,
+            capturing_player_id: None,
+            previous_docked_ship: None,
+            dock_contest_time: 0.0,
             taking_ownership_time: 0.0,
             building_new_ship_time: 0.0,
             orbit_radius: 0.0,
@@ -4584,8 +4808,15 @@ mod tests {
     }
 
     fn land_ship_on_planet(state: &mut SpacewarsState, ship: usize, planet: usize) {
-        let ship_owner_id = state.ships[ship].owner_id;
-        state.planets[planet].set_landing_ship(ship, ship_owner_id);
+        state.spaceport_contacts = vec![SpaceportContact { ship, planet }];
+    }
+
+    fn land_ships_on_planet(state: &mut SpacewarsState, ships: &[usize], planet: usize) {
+        state.spaceport_contacts = ships
+            .iter()
+            .copied()
+            .map(|ship| SpaceportContact { ship, planet })
+            .collect();
     }
 
     fn circle_primitive_count(frame: &RenderFrame) -> usize {
@@ -4950,8 +5181,9 @@ mod tests {
             assert!(planet.radius >= MIN_PLANET_RADIUS);
             assert!(planet.radius < MAX_PLANET_RADIUS);
             assert_eq!(planet.owner_id, None);
-            assert_eq!(planet.landing_ship, None);
-            assert_eq!(planet.landing_ship_prev_round, None);
+            assert_eq!(planet.capturing_player_id, None);
+            assert_eq!(planet.previous_docked_ship, None);
+            assert_eq!(planet.dock_contest_time, 0.0);
             assert!(planet.orbit_radius + planet.radius < universe_radius);
             assert_close(
                 planet.position.distance_to(sun.position),
@@ -5489,7 +5721,7 @@ mod tests {
             offset * (offset.length() * SPACEPORT_PULL_SCALE / SHIP_MASS),
         );
         assert_eq!(state.ships[0].life, start_life);
-        assert_eq!(state.planets[0].landing_ship, Some(0));
+        assert_eq!(spaceport_status(&state, 0), SpaceportStatus::Active(0));
     }
 
     #[test]
@@ -5541,20 +5773,238 @@ mod tests {
     }
 
     #[test]
+    fn contested_spaceport_is_contact_order_independent_and_pauses_services() {
+        let mut forward = init_deathmatch_no_asteroids();
+        forward.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        forward.planets[0].owner_id = Some(0);
+        forward.planets[0].capturing_player_id = Some(1);
+        forward.planets[0].taking_ownership_time = 2.0;
+        forward.planets[0].building_new_ship_time = 3.0;
+        forward.ships[0].life = 10.0;
+        land_ships_on_planet(&mut forward, &[0, 1], 0);
+        let mut reverse = forward.clone();
+        land_ships_on_planet(&mut reverse, &[1, 0], 0);
+
+        update_spaceports(&mut forward, 0.1);
+        update_spaceports(&mut reverse, 0.1);
+
+        assert_eq!(forward.planets, reverse.planets);
+        assert_eq!(forward.ships, reverse.ships);
+        assert_eq!(spaceport_status(&forward, 0), SpaceportStatus::Contested);
+        assert_eq!(forward.planets[0].previous_docked_ship, None);
+        assert_close(forward.planets[0].dock_contest_time, 0.1);
+        assert_close(forward.planets[0].taking_ownership_time, 1.95);
+        assert_close(forward.planets[0].building_new_ship_time, 3.0);
+        assert_close(forward.ships[0].life, 10.0);
+    }
+
+    #[test]
+    fn contested_spaceport_ejects_both_ships_without_damage() {
+        let mut forward = init_deathmatch_no_asteroids();
+        forward.sun = None;
+        forward.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        forward.planets[0].owner_id = Some(0);
+        forward.planets[0].capturing_player_id = Some(1);
+        forward.planets[0].taking_ownership_time = 2.0;
+        let port_center = spaceport_physics(0, &forward.planets[0]).bounds.center;
+        for ship in &mut forward.ships {
+            ship.position = port_center;
+            ship.velocity = Vec2::ZERO;
+        }
+        land_ships_on_planet(&mut forward, &[0, 1], 0);
+        let mut reverse = forward.clone();
+        land_ships_on_planet(&mut reverse, &[1, 0], 0);
+        let starting_life = forward
+            .ships
+            .iter()
+            .map(|ship| ship.life)
+            .collect::<Vec<_>>();
+
+        update_spaceports(&mut forward, SPACEPORT_CONTEST_EJECT_DELAY_SECS);
+        update_spaceports(&mut reverse, SPACEPORT_CONTEST_EJECT_DELAY_SECS);
+
+        assert_eq!(forward.planets, reverse.planets);
+        assert_eq!(forward.ships, reverse.ships);
+        assert_eq!(forward.planets[0].previous_docked_ship, None);
+        assert_eq!(forward.planets[0].dock_contest_time, 0.0);
+        assert_close(forward.planets[0].taking_ownership_time, 1.875);
+
+        let planet = forward.planets[0];
+        let outward = (port_center - planet.position).normalized();
+        let tangent = outward.rotate_radians(core::f32::consts::FRAC_PI_2);
+        for (ship_index, ship) in forward.ships.iter().enumerate() {
+            let bounds = ship_low_bounds(&ship_triangles(ship));
+            assert!(
+                bounds.center.distance_to(planet.position)
+                    > planet.radius * BODY_BOUNDS_RADIUS_SCALE + bounds.radius
+            );
+            assert_close(ship.life, starting_life[ship_index]);
+            assert_close(
+                ship.spaceport_reentry_lockout,
+                SPACEPORT_REENTRY_LOCKOUT_SECS,
+            );
+            assert_close(ship.velocity.dot(outward), SPACEPORT_EJECT_SPEED);
+        }
+        assert!(forward.ships[0].velocity.dot(tangent) < 0.0);
+        assert!(forward.ships[1].velocity.dot(tangent) > 0.0);
+    }
+
+    #[test]
+    fn contested_spaceport_ejects_after_grace_period_in_full_steps() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].owner_id = Some(0);
+        let port_center = spaceport_physics(0, &state.planets[0]).bounds.center;
+        let outward = (port_center - state.planets[0].position).normalized();
+        let tangent = outward.rotate_radians(core::f32::consts::FRAC_PI_2);
+        for (index, ship) in state.ships.iter_mut().enumerate() {
+            let side = if index == 0 { -1.0 } else { 1.0 };
+            ship.position = port_center + tangent * (side * 8.0);
+            ship.velocity = Vec2::ZERO;
+        }
+        land_ships_on_planet(&mut state, &[0, 1], 0);
+
+        for _ in 0..20 {
+            step(&mut state, &[]);
+        }
+
+        assert!(state.spaceport_contacts.is_empty());
+        for ship in &state.ships {
+            let bounds = ship_low_bounds(&ship_triangles(ship));
+            assert!(
+                bounds.center.distance_to(state.planets[0].position)
+                    > state.planets[0].radius * BODY_BOUNDS_RADIUS_SCALE + bounds.radius
+            );
+            assert!(ship.spaceport_reentry_lockout > 0.0);
+        }
+    }
+
+    #[test]
+    fn firing_laser_while_docked_ejects_before_beam_spawns() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        let port_center = spaceport_physics(0, &state.planets[0]).bounds.center;
+        let outward = (port_center - state.planets[0].position).normalized();
+        state.ships[0].position = port_center;
+        state.ships[0].velocity = Vec2::ZERO;
+        state.ships[0].rotation_radians = rotation_for_direction(outward);
+        state.ships[0].direction = outward;
+        state.ships[1].position = Vec2::new(900.0, 900.0);
+        land_ship_on_planet(&mut state, 0, 0);
+
+        step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+
+        let beam = state.ships[0]
+            .laser_beam
+            .expect("released ship should fire its laser");
+        assert!(beam.head.distance_to(state.planets[0].position) > state.planets[0].radius);
+        assert!(
+            state
+                .laser_hits
+                .iter()
+                .all(|hit| hit.target != LaserTarget::Body(BodyId::Planet(0)))
+        );
+        assert!(state.ships[0].spaceport_reentry_lockout > 0.0);
+        assert!(state.spaceport_contacts.is_empty());
+    }
+
+    #[test]
+    fn firing_cannon_while_docked_ejects_before_shell_spawns() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        let port_center = spaceport_physics(0, &state.planets[0]).bounds.center;
+        let outward = (port_center - state.planets[0].position).normalized();
+        state.ships[0].position = port_center;
+        state.ships[0].velocity = Vec2::ZERO;
+        state.ships[0].rotation_radians = rotation_for_direction(outward);
+        state.ships[0].direction = outward;
+        state.ships[1].position = Vec2::new(900.0, 900.0);
+        land_ship_on_planet(&mut state, 0, 0);
+
+        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+
+        let shell = state
+            .debris
+            .iter()
+            .find(|debris| debris.kind == DebrisKind::Shell)
+            .expect("released ship should retain its cannon shell");
+        assert!(shell.position.distance_to(state.planets[0].position) > state.planets[0].radius);
+        assert!(
+            state
+                .debris_body_collisions
+                .iter()
+                .all(|contact| contact.body != BodyId::Planet(0))
+        );
+        assert!(state.ships[0].spaceport_reentry_lockout > 0.0);
+        assert!(state.spaceport_contacts.is_empty());
+    }
+
+    #[test]
+    fn owner_pod_does_not_block_hostile_capture_and_does_not_rebuild() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].owner_id = Some(0);
+        state.planets[0].capturing_player_id = Some(1);
+        state.planets[0].previous_docked_ship = Some(1);
+        state.planets[0].taking_ownership_time = 1.0;
+        state.planets[0].building_new_ship_time = 2.0;
+        state.ships[0].change_to_escape_pod();
+        let port_center = spaceport_physics(0, &state.planets[0]).bounds.center;
+        state.ships[0].position = port_center;
+        state.ships[1].position = port_center;
+        land_ships_on_planet(&mut state, &[0, 1], 0);
+
+        update_spaceports(&mut state, 1.0);
+
+        assert_eq!(state.planets[0].owner_id, Some(0));
+        assert_close(state.planets[0].taking_ownership_time, 2.0);
+        assert_close(state.planets[0].building_new_ship_time, 2.0);
+        assert_eq!(state.ships[0].form, ShipForm::EscapePod);
+        assert_close(
+            state.ships[0].spaceport_reentry_lockout,
+            SPACEPORT_REENTRY_LOCKOUT_SECS,
+        );
+        assert_eq!(state.ships[1].spaceport_reentry_lockout, 0.0);
+        assert_eq!(spaceport_status(&state, 0), SpaceportStatus::Active(1));
+    }
+
+    #[test]
+    fn interrupted_capture_progress_decays_and_eventually_clears() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].capturing_player_id = Some(1);
+        state.planets[0].taking_ownership_time = 2.0;
+
+        update_spaceports(&mut state, 1.0);
+
+        assert_close(state.planets[0].taking_ownership_time, 1.5);
+        assert_eq!(state.planets[0].capturing_player_id, Some(1));
+
+        update_spaceports(&mut state, 3.0);
+
+        assert_eq!(state.planets[0].taking_ownership_time, 0.0);
+        assert_eq!(state.planets[0].capturing_player_id, None);
+    }
+
+    #[test]
     fn landed_ship_captures_planet_after_original_hold_time() {
         let mut state = init_deathmatch_no_asteroids();
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
 
         for _ in 0..4 {
             land_ship_on_planet(&mut state, 0, 0);
-            update_planet_landing_progress(&mut state, 1.0);
+            update_spaceports(&mut state, 1.0);
         }
 
         assert_eq!(state.planets[0].owner_id, None);
         assert_eq!(state.players[0].planet_count, 0);
 
         land_ship_on_planet(&mut state, 0, 0);
-        update_planet_landing_progress(&mut state, 1.0);
+        update_spaceports(&mut state, 1.0);
 
         assert_eq!(state.planets[0].owner_id, Some(0));
         assert_eq!(state.players[0].planet_count, 1);
@@ -5570,11 +6020,11 @@ mod tests {
         state.ships[0].life = 10.0;
 
         land_ship_on_planet(&mut state, 0, 0);
-        update_planet_landing_progress(&mut state, 1.0);
+        update_spaceports(&mut state, 1.0);
         assert_eq!(state.ships[0].life, 10.0);
 
         land_ship_on_planet(&mut state, 0, 0);
-        update_planet_landing_progress(&mut state, 1.0);
+        update_spaceports(&mut state, 1.0);
 
         assert_close(state.ships[0].life, 13.0);
     }
@@ -5590,7 +6040,7 @@ mod tests {
 
         for _ in 0..480 {
             land_ship_on_planet(&mut state, 0, 0);
-            update_planet_landing_progress(&mut state, dt);
+            update_spaceports(&mut state, dt);
         }
 
         assert_eq!(state.ships[0].form, ShipForm::EscapePod);
@@ -5598,7 +6048,7 @@ mod tests {
         assert!(state.ships[0].life < state.ships[0].life_max);
 
         land_ship_on_planet(&mut state, 0, 0);
-        update_planet_landing_progress(&mut state, dt);
+        update_spaceports(&mut state, dt);
 
         assert_eq!(state.ships[0].form, ShipForm::Ship);
         assert_eq!(state.ships[0].life, state.ships[0].life_max);
@@ -5618,7 +6068,7 @@ mod tests {
 
         for _ in 0..360 {
             land_ship_on_planet(&mut state, 0, 0);
-            update_planet_landing_progress(&mut state, dt);
+            update_spaceports(&mut state, dt);
         }
 
         assert_eq!(state.planets[0].owner_id, None);
@@ -5632,7 +6082,7 @@ mod tests {
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
         state.planets[0].owner_id = Some(0);
         let expected = render_color(state.players[0].color);
-        let actual = spaceport_color(&state, &state.planets[0]);
+        let actual = spaceport_color(&state, 0, &state.planets[0]);
 
         assert_close(actual.r, expected.r);
         assert_close(actual.g, expected.g);
@@ -5688,7 +6138,7 @@ mod tests {
     fn capturing_planet_fades_challenger_flags_without_owned_halo() {
         let mut state = init_deathmatch_no_asteroids();
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
-        state.planets[0].landing_ship = Some(0);
+        state.planets[0].capturing_player_id = Some(0);
         state.planets[0].taking_ownership_time = PLANET_CAPTURE_SECS * 0.5;
         let expected_color = with_intensity(render_color(state.players[0].color), 0.5);
 
@@ -5731,8 +6181,9 @@ mod tests {
     fn capturing_spaceport_tints_toward_landing_player_color() {
         let mut state = init_deathmatch_no_asteroids();
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
-        state.planets[0].landing_ship = Some(0);
+        state.planets[0].capturing_player_id = Some(0);
         state.planets[0].taking_ownership_time = PLANET_CAPTURE_SECS * 0.5;
+        land_ship_on_planet(&mut state, 0, 0);
         let player_color = render_color(state.players[0].color);
         let expected = blend_color(
             RenderColor::rgba(1.0, 1.0, 1.0, 0.82),
@@ -5740,7 +6191,7 @@ mod tests {
             0.5,
         );
 
-        let actual = spaceport_color(&state, &state.planets[0]);
+        let actual = spaceport_color(&state, 0, &state.planets[0]);
 
         assert_close(actual.r, expected.r);
         assert_close(actual.g, expected.g);
@@ -5753,9 +6204,9 @@ mod tests {
         let mut state = init_deathmatch_no_asteroids();
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
         state.planets[0].owner_id = Some(0);
-        state.planets[0].landing_ship = Some(0);
         state.planets[0].building_new_ship_time = POD_REBUILD_SECS * 0.5;
         state.ships[0].change_to_escape_pod();
+        land_ship_on_planet(&mut state, 0, 0);
         let player_color = render_color(state.players[0].color);
         let expected = blend_color(
             with_alpha(dim(player_color, 0.55), 0.82),
@@ -5763,7 +6214,7 @@ mod tests {
             0.5,
         );
 
-        let actual = spaceport_color(&state, &state.planets[0]);
+        let actual = spaceport_color(&state, 0, &state.planets[0]);
 
         assert_close(actual.r, expected.r);
         assert_close(actual.g, expected.g);
@@ -5775,7 +6226,7 @@ mod tests {
     fn landed_spaceport_renders_feedback_outline() {
         let mut state = init_deathmatch_no_asteroids();
         state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
-        state.planets[0].landing_ship = Some(0);
+        land_ship_on_planet(&mut state, 0, 0);
         let frame = SpacewarsScenario::render_frame(&state);
         let feedback_layer = frame
             .layers
@@ -5797,6 +6248,36 @@ mod tests {
         assert_close(stroke.color.b, state.players[0].color.b);
         assert_close(stroke.color.a, 0.95);
         assert_close(stroke.width, 1.25);
+    }
+
+    #[test]
+    fn contested_spaceport_renders_pulsing_neutral_feedback() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.planets = vec![test_planet(Vec2::new(420.0, 450.0), 50.0)];
+        state.planets[0].owner_id = Some(0);
+        land_ships_on_planet(&mut state, &[1, 0], 0);
+
+        let frame = SpacewarsScenario::render_frame(&state);
+        let feedback_layer = frame
+            .layers
+            .iter()
+            .find(|layer| layer.z == SPACEPORT_FEEDBACK_LAYER)
+            .expect("contested spaceport should render feedback");
+        let RenderPrimitive::Polygon(polygon) = &feedback_layer.primitives[0] else {
+            panic!("feedback primitive should be a polygon");
+        };
+        let stroke = polygon
+            .stroke
+            .expect("contested feedback should render an outline");
+        let expected_color = blend_color(
+            RenderColor::rgba(1.0, 0.48, 0.02, 0.95),
+            RenderColor::rgba(1.0, 0.95, 0.7, 1.0),
+            0.5,
+        );
+
+        assert_eq!(spaceport_status(&state, 0), SpaceportStatus::Contested);
+        assert_eq!(stroke.color, expected_color);
+        assert_close(stroke.width, 2.5);
     }
 
     #[test]

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -3690,6 +3690,7 @@ impl ShipState {
     }
 
     fn update_wings(&mut self, dt: f32) {
+        let braking = self.thrust_behavior == ThrustBehavior::Brake;
         match self.wing_behavior {
             WingBehavior::None => {}
             WingBehavior::Close => {
@@ -3700,7 +3701,9 @@ impl ShipState {
                     self.wing_theta = MAX_WING_THETA;
                 }
                 self.update_wing_position();
-                self.thrust_behavior = ThrustBehavior::Full;
+                if !braking {
+                    self.thrust_behavior = ThrustBehavior::Full;
+                }
             }
             WingBehavior::Open => {
                 self.wing_theta -= dt * WING_DELTA_SPEED;
@@ -3712,22 +3715,27 @@ impl ShipState {
                 }
                 self.update_wing_position();
                 self.cap_speed(MAX_SPEED);
-                if self.wing_behavior == WingBehavior::None {
+                if self.wing_behavior == WingBehavior::None && !braking {
                     self.thrust_behavior = ThrustBehavior::None;
                 }
             }
         }
 
-        if self.wing_state == WingState::Closed && self.wing_behavior != WingBehavior::Open {
+        if self.wing_state == WingState::Closed
+            && self.wing_behavior != WingBehavior::Open
+            && !braking
+        {
             self.thrust_behavior = ThrustBehavior::Full;
         }
     }
 
     fn update_wing_position(&mut self) {
-        let max_velocity =
-            (self.wing_theta + 0.46) / MAX_WING_THETA * WING_CLOSED_SPEED + MAX_SPEED;
-        let speed = self.velocity.length();
-        self.velocity = self.velocity.normalized() * (speed * 0.8 + max_velocity * 0.15);
+        if self.thrust_behavior != ThrustBehavior::Brake {
+            let max_velocity =
+                (self.wing_theta + 0.46) / MAX_WING_THETA * WING_CLOSED_SPEED + MAX_SPEED;
+            let speed = self.velocity.length();
+            self.velocity = self.velocity.normalized() * (speed * 0.8 + max_velocity * 0.15);
+        }
         self.current_max_omega =
             ((1.0 - self.wing_theta / MAX_WING_THETA) * BASE_MAX_OMEGA).max(WING_CLOSED_MAX_OMEGA);
     }
@@ -3748,18 +3756,16 @@ impl ShipState {
                 self.fire_exhaust(self.direction, rng, tick);
             }
             ThrustBehavior::Brake => {
-                if self.wing_state == WingState::Opened {
-                    if self.velocity.length() > MAX_SPEED * 0.25 {
-                        self.velocity -= self.velocity.normalized() * self.thrust_power;
-                    } else {
-                        self.velocity *= 0.9;
-                    }
+                if self.velocity.length() > MAX_SPEED * 0.25 {
+                    self.velocity -= self.velocity.normalized() * self.thrust_power;
+                } else {
+                    self.velocity *= 0.9;
+                }
 
-                    if self.omega.abs() > 0.01 {
-                        self.omega -= self.omega.signum() * self.turn_power;
-                    } else {
-                        self.omega = 0.0;
-                    }
+                if self.omega.abs() > 0.01 {
+                    self.omega -= self.omega.signum() * self.turn_power;
+                } else {
+                    self.omega = 0.0;
                 }
             }
             ThrustBehavior::Reverse => {
@@ -6701,6 +6707,49 @@ mod tests {
             state.ships[0].position.y,
             450.0 + (SHIP_THRUST_FORCE / SHIP_MASS / 60.0) / 60.0,
         );
+    }
+
+    #[test]
+    fn brake_opposes_velocity_without_turning_into_reverse_thrust() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets.clear();
+        state.ships[0].velocity = Vec2::new(100.0, 0.0);
+        state.ships[0].direction = Vec2::Y;
+        let speed_delta = SHIP_THRUST_FORCE / SHIP_MASS / 60.0;
+
+        step(&mut state, &[SpacewarsAction::brake(0)]);
+
+        assert_vec_close(state.ships[0].velocity, Vec2::new(100.0 - speed_delta, 0.0));
+        for _ in 0..180 {
+            step(&mut state, &[SpacewarsAction::brake(0)]);
+        }
+        assert!(state.ships[0].velocity.x >= 0.0);
+        assert_close(state.ships[0].velocity.y, 0.0);
+        assert!(state.ships[0].velocity.length() < 0.001);
+    }
+
+    #[test]
+    fn brake_decelerates_with_sweep_wings_closed() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets.clear();
+        state.ships[0].wing_state = WingState::Closed;
+        state.ships[0].wing_behavior = WingBehavior::None;
+        state.ships[0].wing_theta = MAX_WING_THETA;
+        state.ships[0].velocity = Vec2::Y * WING_CLOSED_SPEED;
+        let speed_delta = SHIP_THRUST_FORCE / SHIP_MASS / 60.0;
+
+        step(
+            &mut state,
+            &[SpacewarsAction::close_wings(0), SpacewarsAction::brake(0)],
+        );
+
+        assert_close(
+            state.ships[0].velocity.length(),
+            WING_CLOSED_SPEED - speed_delta,
+        );
+        assert_eq!(state.ships[0].thrust_behavior, ThrustBehavior::Brake);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make captured planets visibly owned with flags, overview halos, and minimap debris filtering
- improve contested spaceports with a grace period, paused services, queued weapons, physical ejection, and re-entry protection
- separate braking from reverse thrust and update both player control schemes
- redesign local play around full-height player views, floating health panels, circular translucent minimaps, and a compact shared HUD
- keep vector and raster layouts aligned, including cached raster minimap compositing

## Validation

- `cargo test --workspace`
- `cargo fmt --all -- --check`
- live screenshot review in both vector and raster renderers