### PR TITLE
Add multiple-scenario framework and Pizza

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
  "engine-core",
  "png 0.17.16",
  "scenario-null",
+ "scenario-pizza",
  "scenario-spacewars",
  "slint",
  "slint-build",
@@ -4056,6 +4057,15 @@ name = "scenario-null"
 version = "0.1.0"
 dependencies = [
  "engine-common",
+]
+
+[[package]]
+name = "scenario-pizza"
+version = "0.1.0"
+dependencies = [
+ "engine-common",
+ "engine-core",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/engine-agent",
     "crates/engine-os-manager",
     "scenarios/null",
+    "scenarios/pizza",
     "scenarios/spacewars",
 ]
 
@@ -35,4 +36,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 engine-common = { path = "crates/engine-common" }
 engine-core = { path = "crates/engine-core" }
 scenario-null = { path = "scenarios/null" }
+scenario-pizza = { path = "scenarios/pizza" }
 scenario-spacewars = { path = "scenarios/spacewars" }

--- a/README.md
+++ b/README.md
@@ -9,9 +9,32 @@ Below is a zoomed out view of a CTF game mode.
 
 ## Status
 
-Initial implementation mostly complete.  Textures and sounds have yet to be done.
+The local launcher currently hosts two playable scenarios:
+
+- **Spacewars** — the two-player arcade reboot.
+- **Pizza** — a seeded interactive gravity-and-collision ball simulation. Click
+  empty space to make a ball, or grab and fling an existing one.
+
+Textures and sounds for Spacewars have yet to be done. The Pizza implementation
+starts with capped exact collision/gravity loops; quadtree and Barnes–Hut
+optimizations are intentionally deferred.
 
 See [`docs/design/reboot-rust-slint.md`](docs/design/reboot-rust-slint.md).
+
+## Run locally
+
+Start the launcher:
+
+```sh
+cargo run -p engine-client
+```
+
+Or start a scenario directly:
+
+```sh
+cargo run -p engine-client -- --scenario pizza
+cargo run -p engine-client -- --scenario spacewars
+```
 
 ## Raspberry Pi / kiosk launch
 

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 engine-common = { workspace = true }
 engine-core = { workspace = true }
 scenario-null = { workspace = true }
+scenario-pizza = { workspace = true }
 scenario-spacewars = { workspace = true }
 clap = { workspace = true }
 directories = { workspace = true }

--- a/crates/engine-client/src/client_scenarios/mod.rs
+++ b/crates/engine-client/src/client_scenarios/mod.rs
@@ -1,0 +1,204 @@
+//! Object-safe scenario adapters and the client's compile-time registry.
+
+use std::fmt;
+use std::time::Duration;
+
+use engine_common::{Action, RenderFrame, Settings, StepResult, TickModel};
+use engine_core::Color;
+use scenario_spacewars::SpacewarsBenchmarkCounts;
+
+use crate::input::ClientInput;
+use crate::render::{FrameLayout, Viewport};
+
+mod null;
+mod pizza;
+mod spacewars;
+
+#[cfg(test)]
+pub(crate) use pizza::PizzaClientScenario;
+#[cfg(test)]
+pub(crate) use spacewars::SpacewarsClientScenario;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RenderBackend {
+    #[default]
+    Vector,
+    Raster,
+}
+
+impl RenderBackend {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Vector => "vector",
+            Self::Raster => "raster",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScenarioStartMode {
+    Normal,
+    Benchmark,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScenarioCapabilities {
+    pub benchmark: bool,
+    pub pointer_input: bool,
+    pub player_zoom: bool,
+    pub game_over: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CenterPanelState {
+    pub player_1: PlayerPanelState,
+    pub player_2: PlayerPanelState,
+    pub planet_score_label: String,
+    pub player_1_planet_fraction: f32,
+    pub player_2_planet_fraction: f32,
+    pub player_1_planet_score: String,
+    pub free_planet_score: String,
+    pub player_2_planet_score: String,
+    pub message_text: String,
+    pub performance_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayerPanelState {
+    pub name: String,
+    pub status: String,
+    pub status_fraction: f32,
+    pub color: Color,
+}
+
+pub struct ScenarioRegistration {
+    pub id: &'static str,
+    pub launcher_visible: bool,
+    pub capabilities: ScenarioCapabilities,
+    pub controls_help: &'static str,
+    create: fn(u64, &Settings, Viewport, ScenarioStartMode) -> Box<dyn ClientScenario>,
+}
+
+impl ScenarioRegistration {
+    pub fn create(
+        &'static self,
+        seed: u64,
+        settings: &Settings,
+        viewport: Viewport,
+        mode: ScenarioStartMode,
+    ) -> Result<Box<dyn ClientScenario>, ScenarioCreateError> {
+        if mode == ScenarioStartMode::Benchmark && !self.capabilities.benchmark {
+            return Err(ScenarioCreateError::BenchmarkUnsupported { name: self.id });
+        }
+        Ok((self.create)(seed, settings, viewport, mode))
+    }
+}
+
+pub trait ClientScenario {
+    fn registration(&self) -> &'static ScenarioRegistration;
+    fn tick_model(&self) -> TickModel;
+    fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult;
+    fn map_keyboard_input(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action>;
+    fn render_frames(&self, renderer: RenderBackend, viewport: Viewport) -> Vec<RenderFrame>;
+    fn frame_layout(&self) -> FrameLayout;
+
+    fn set_viewport(&mut self, _viewport: Viewport) {}
+
+    fn center_panel_state(
+        &self,
+        _paused: bool,
+        _benchmark_active: bool,
+        _performance_text: &str,
+    ) -> Option<CenterPanelState> {
+        None
+    }
+
+    fn is_game_over(&self) -> bool {
+        false
+    }
+
+    fn zoom_player_in(&mut self, _player: usize) {}
+    fn zoom_player_out(&mut self, _player: usize) {}
+
+    fn benchmark_counts(&self) -> Option<SpacewarsBenchmarkCounts> {
+        None
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any;
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScenarioCreateError {
+    BenchmarkUnsupported { name: &'static str },
+}
+
+impl fmt::Display for ScenarioCreateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BenchmarkUnsupported { name } => {
+                write!(f, "scenario {name:?} does not support benchmark mode")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ScenarioCreateError {}
+
+static SCENARIOS: &[ScenarioRegistration] = &[
+    null::REGISTRATION,
+    pizza::REGISTRATION,
+    spacewars::REGISTRATION,
+];
+
+pub fn registrations() -> &'static [ScenarioRegistration] {
+    SCENARIOS
+}
+
+pub fn registration(name: &str) -> Option<&'static ScenarioRegistration> {
+    SCENARIOS
+        .iter()
+        .find(|registration| registration.id == name)
+}
+
+pub fn launcher_registrations() -> impl Iterator<Item = &'static ScenarioRegistration> {
+    SCENARIOS
+        .iter()
+        .filter(|registration| registration.launcher_visible)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_keeps_null_hostable_but_hidden() {
+        assert!(registration("null").is_some());
+        assert_eq!(
+            launcher_registrations()
+                .map(|registration| registration.id)
+                .collect::<Vec<_>>(),
+            vec!["pizza", "spacewars"]
+        );
+    }
+
+    #[test]
+    fn registry_rejects_unsupported_benchmarks() {
+        let registration = registration("pizza").unwrap();
+        let error = match registration.create(
+            0,
+            &Settings::default(),
+            Viewport::new(1280.0, 720.0),
+            ScenarioStartMode::Benchmark,
+        ) {
+            Ok(_) => panic!("pizza should not support benchmark mode"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error,
+            ScenarioCreateError::BenchmarkUnsupported { name: "pizza" }
+        );
+    }
+}

--- a/crates/engine-client/src/client_scenarios/null.rs
+++ b/crates/engine-client/src/client_scenarios/null.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+
+use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
+use scenario_null::{NullConfig, NullScenario, NullState};
+
+use super::{
+    ClientScenario, RenderBackend, ScenarioCapabilities, ScenarioRegistration, ScenarioStartMode,
+};
+use crate::input::ClientInput;
+use crate::render::{FrameLayout, Viewport};
+
+pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
+    id: "null",
+    launcher_visible: false,
+    capabilities: ScenarioCapabilities {
+        benchmark: false,
+        pointer_input: false,
+        player_zoom: false,
+        game_over: false,
+    },
+    controls_help: "No controls.",
+    create,
+};
+
+struct NullClientScenario {
+    state: NullState,
+}
+
+fn create(
+    seed: u64,
+    _settings: &Settings,
+    _viewport: Viewport,
+    _mode: ScenarioStartMode,
+) -> Box<dyn ClientScenario> {
+    Box::new(NullClientScenario {
+        state: NullScenario::init(NullConfig, seed),
+    })
+}
+
+impl ClientScenario for NullClientScenario {
+    fn registration(&self) -> &'static ScenarioRegistration {
+        &REGISTRATION
+    }
+
+    fn tick_model(&self) -> TickModel {
+        NullScenario::tick_model()
+    }
+
+    fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult {
+        NullScenario::step(&mut self.state, actions, dt)
+    }
+
+    fn map_keyboard_input(&self, _input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
+        Vec::new()
+    }
+
+    fn render_frames(&self, _renderer: RenderBackend, _viewport: Viewport) -> Vec<RenderFrame> {
+        vec![NullScenario::render_frame(&self.state)]
+    }
+
+    fn frame_layout(&self) -> FrameLayout {
+        FrameLayout::EqualHorizontal
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}

--- a/crates/engine-client/src/client_scenarios/pizza.rs
+++ b/crates/engine-client/src/client_scenarios/pizza.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
+use scenario_pizza::{PizzaBounds, PizzaConfig, PizzaScenario, PizzaState};
+
+use super::{
+    ClientScenario, RenderBackend, ScenarioCapabilities, ScenarioRegistration, ScenarioStartMode,
+};
+use crate::input::ClientInput;
+use crate::render::{FrameLayout, Viewport};
+
+pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
+    id: "pizza",
+    launcher_visible: true,
+    capabilities: ScenarioCapabilities {
+        benchmark: false,
+        pointer_input: true,
+        player_zoom: false,
+        game_over: false,
+    },
+    controls_help: "Pizza: click empty space to create a ball, or click an existing ball to grab it. Drag for a rubbery pull and release to fling.",
+    create,
+};
+
+pub(crate) struct PizzaClientScenario {
+    pub(crate) state: PizzaState,
+}
+
+fn create(
+    seed: u64,
+    settings: &Settings,
+    viewport: Viewport,
+    _mode: ScenarioStartMode,
+) -> Box<dyn ClientScenario> {
+    let setup = settings.pizza.normalized();
+    Box::new(PizzaClientScenario {
+        state: PizzaScenario::init(
+            PizzaConfig {
+                desired_ball_count: setup.desired_balls as usize,
+                ball_spawn_rate: setup.ball_spawn_rate,
+                bounds: PizzaBounds::from_aspect_ratio(viewport.aspect_ratio()),
+            },
+            seed,
+        ),
+    })
+}
+
+impl ClientScenario for PizzaClientScenario {
+    fn registration(&self) -> &'static ScenarioRegistration {
+        &REGISTRATION
+    }
+
+    fn tick_model(&self) -> TickModel {
+        PizzaScenario::tick_model()
+    }
+
+    fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult {
+        PizzaScenario::step(&mut self.state, actions, dt)
+    }
+
+    fn map_keyboard_input(&self, _input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
+        Vec::new()
+    }
+
+    fn render_frames(&self, _renderer: RenderBackend, _viewport: Viewport) -> Vec<RenderFrame> {
+        vec![PizzaScenario::render_frame(&self.state)]
+    }
+
+    fn frame_layout(&self) -> FrameLayout {
+        FrameLayout::EqualHorizontal
+    }
+
+    fn set_viewport(&mut self, viewport: Viewport) {
+        self.state.set_aspect_ratio(viewport.aspect_ratio());
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}

--- a/crates/engine-client/src/client_scenarios/spacewars.rs
+++ b/crates/engine-client/src/client_scenarios/spacewars.rs
@@ -1,0 +1,227 @@
+use std::time::Duration;
+
+use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
+use engine_core::SpacewarsConfig;
+use scenario_spacewars::{ShipForm, SpacewarsBenchmarkCounts, SpacewarsScenario, SpacewarsState};
+
+use super::{
+    CenterPanelState, ClientScenario, PlayerPanelState, RenderBackend, ScenarioCapabilities,
+    ScenarioRegistration, ScenarioStartMode,
+};
+use crate::input::ClientInput;
+use crate::render::{self, FrameLayout, Viewport};
+
+pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
+    id: "spacewars",
+    launcher_visible: true,
+    capabilities: ScenarioCapabilities {
+        benchmark: true,
+        pointer_input: false,
+        player_zoom: true,
+        game_over: true,
+    },
+    controls_help: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon, U/I zoom.\nPlayer 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon, Insert/Home zoom.",
+    create,
+};
+
+pub(crate) struct SpacewarsClientScenario {
+    pub(crate) state: Box<SpacewarsState>,
+}
+
+fn create(
+    seed: u64,
+    settings: &Settings,
+    _viewport: Viewport,
+    mode: ScenarioStartMode,
+) -> Box<dyn ClientScenario> {
+    let state = match mode {
+        ScenarioStartMode::Normal => {
+            SpacewarsScenario::init(spacewars_config_from_settings(settings), seed)
+        }
+        ScenarioStartMode::Benchmark => SpacewarsScenario::init_benchmark(seed),
+    };
+    Box::new(SpacewarsClientScenario {
+        state: Box::new(state),
+    })
+}
+
+impl ClientScenario for SpacewarsClientScenario {
+    fn registration(&self) -> &'static ScenarioRegistration {
+        &REGISTRATION
+    }
+
+    fn tick_model(&self) -> TickModel {
+        SpacewarsScenario::tick_model()
+    }
+
+    fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult {
+        SpacewarsScenario::step(&mut self.state, actions, dt)
+    }
+
+    fn map_keyboard_input(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action> {
+        if benchmark_active {
+            SpacewarsScenario::benchmark_actions(&self.state)
+        } else {
+            input.actions_for_spacewars()
+        }
+    }
+
+    fn render_frames(&self, renderer: RenderBackend, viewport: Viewport) -> Vec<RenderFrame> {
+        let player_view_aspect_ratio =
+            render::frame_viewports(viewport, 4, FrameLayout::SpacewarsLocalPlay)[0].aspect_ratio();
+        if renderer == RenderBackend::Raster {
+            SpacewarsScenario::render_raster_local_play_frames(
+                &self.state,
+                player_view_aspect_ratio,
+            )
+        } else {
+            SpacewarsScenario::render_local_play_frames(&self.state, player_view_aspect_ratio)
+        }
+    }
+
+    fn frame_layout(&self) -> FrameLayout {
+        FrameLayout::SpacewarsLocalPlay
+    }
+
+    fn center_panel_state(
+        &self,
+        paused: bool,
+        benchmark_active: bool,
+        performance_text: &str,
+    ) -> Option<CenterPanelState> {
+        Some(center_panel_state(
+            &self.state,
+            paused,
+            benchmark_active,
+            performance_text,
+        ))
+    }
+
+    fn is_game_over(&self) -> bool {
+        self.state.winner.is_some()
+    }
+
+    fn zoom_player_in(&mut self, player: usize) {
+        self.state.zoom_player_in(player);
+    }
+
+    fn zoom_player_out(&mut self, player: usize) {
+        self.state.zoom_player_out(player);
+    }
+
+    fn benchmark_counts(&self) -> Option<SpacewarsBenchmarkCounts> {
+        Some(SpacewarsScenario::benchmark_counts(&self.state))
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+fn spacewars_config_from_settings(settings: &Settings) -> SpacewarsConfig {
+    let setup = settings.spacewars.normalized();
+    let mut config = SpacewarsConfig {
+        universe_radius: setup.universe_radius,
+        use_planets: setup.use_planets,
+        asteroid_probability_per_sec: if setup.asteroids_enabled {
+            setup.asteroid_probability_per_sec
+        } else {
+            0.0
+        },
+        player_view_heights: [setup.player_1_view_height, setup.player_2_view_height],
+        ..SpacewarsConfig::default()
+    };
+    for player in &mut config.players {
+        player.health_percent = setup.player_health_percent;
+    }
+    config
+}
+
+fn center_panel_state(
+    state: &SpacewarsState,
+    paused: bool,
+    benchmark_active: bool,
+    performance_text: &str,
+) -> CenterPanelState {
+    let player_1_planets = state.players[0].planet_count;
+    let player_2_planets = state.players[1].planet_count;
+    let free_planets = state
+        .planets
+        .len()
+        .saturating_sub(player_1_planets + player_2_planets);
+    let total_planets = state.planets.len().max(1) as f32;
+
+    CenterPanelState {
+        player_1: player_panel_state(state, 0),
+        player_2: player_panel_state(state, 1),
+        planet_score_label: format!(
+            "Planets  P1 {player_1_planets} | Free {free_planets} | P2 {player_2_planets}"
+        ),
+        player_1_planet_fraction: player_1_planets as f32 / total_planets,
+        player_2_planet_fraction: player_2_planets as f32 / total_planets,
+        player_1_planet_score: planet_score_text(player_1_planets),
+        free_planet_score: planet_score_text(free_planets),
+        player_2_planet_score: planet_score_text(player_2_planets),
+        message_text: panel_message(state, paused, benchmark_active),
+        performance_text: performance_text.into(),
+    }
+}
+
+fn planet_score_text(count: usize) -> String {
+    if count == 0 {
+        String::new()
+    } else {
+        count.to_string()
+    }
+}
+
+fn panel_message(state: &SpacewarsState, paused: bool, benchmark_active: bool) -> String {
+    if let Some(winner) = state.winner.and_then(|winner| state.players.get(winner)) {
+        return format!("P{} Wins | R Restart | B Bench | Esc Launch", winner.id + 1);
+    }
+    if benchmark_active && paused {
+        "Bench Paused | P/Esc Resume | B Reset | Q Launch".into()
+    } else if benchmark_active {
+        "Bench | P/Esc Pause | B Reset | R Game".into()
+    } else if paused {
+        "Paused | P/Esc Resume | R Restart | B Bench | Q Launch".into()
+    } else {
+        "P/Esc Pause | R Restart | B Bench".into()
+    }
+}
+
+fn player_panel_state(state: &SpacewarsState, player_index: usize) -> PlayerPanelState {
+    let player = &state.players[player_index];
+    let ship = &state.ships[player_index];
+    if player.eliminated {
+        return PlayerPanelState {
+            name: format!("Player {}: {}", player.id + 1, player.name),
+            status: "Eliminated".into(),
+            status_fraction: 0.0,
+            color: player.color,
+        };
+    }
+
+    let status_fraction = if ship.life_max <= 0.0 {
+        0.0
+    } else {
+        (ship.life / ship.life_max).clamp(0.0, 1.0)
+    };
+    let percent = (status_fraction * 100.0).round() as u32;
+    let label = match ship.form {
+        ShipForm::Ship => "Ship Health",
+        ShipForm::EscapePod => "Pod Rebuild",
+    };
+    PlayerPanelState {
+        name: format!("Player {}: {}", player.id + 1, player.name),
+        status: format!("{label}: {percent}%"),
+        status_fraction,
+        color: player.color,
+    }
+}

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -9,14 +9,18 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use engine_common::{Action, RenderFrame, Scenario, StepResult, TickModel};
-use engine_core::{Color as CoreColor, SpacewarsConfig};
-use scenario_null::{NullConfig, NullScenario};
-use scenario_spacewars::{ShipForm, SpacewarsBenchmarkCounts, SpacewarsScenario, SpacewarsState};
+use engine_common::{Action, RenderFrame, Settings, StepResult, TickModel};
+use engine_core::Color as CoreColor;
+use scenario_spacewars::SpacewarsBenchmarkCounts;
 use slint::{
     Brush, Color as SlintColor, ComponentHandle, ModelRc, SharedString, Timer, TimerMode, VecModel,
 };
 
+pub use crate::client_scenarios::RenderBackend;
+use crate::client_scenarios::{
+    self, CenterPanelState, ClientScenario, ScenarioCreateError, ScenarioRegistration,
+    ScenarioStartMode,
+};
 use crate::input::{self, ClientInput};
 use crate::raster;
 use crate::render::{self, Viewport};
@@ -32,7 +36,7 @@ pub struct ScenarioLoopOptions {
     pub renderer: RenderBackend,
     pub raster_scale: f32,
     pub controls: Option<SharedScenarioControls>,
-    pub spacewars_config: SpacewarsConfig,
+    pub settings: Settings,
 }
 
 impl Default for ScenarioLoopOptions {
@@ -42,7 +46,7 @@ impl Default for ScenarioLoopOptions {
             renderer: RenderBackend::default(),
             raster_scale: 1.0,
             controls: None,
-            spacewars_config: SpacewarsConfig::default(),
+            settings: Settings::default(),
         }
     }
 }
@@ -106,24 +110,9 @@ pub struct BenchmarkOptions {
     pub raster_scale: f32,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum RenderBackend {
-    #[default]
-    Vector,
-    Raster,
-}
-
-impl RenderBackend {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Vector => "vector",
-            Self::Raster => "raster",
-        }
-    }
-}
-
 pub enum HostError {
     UnknownScenario { name: String },
+    BenchmarkUnsupported { name: String },
 }
 
 impl fmt::Debug for HostError {
@@ -142,6 +131,9 @@ impl fmt::Display for HostError {
                     scenario_names().join(", ")
                 )
             }
+            HostError::BenchmarkUnsupported { name } => {
+                write!(f, "scenario {name:?} does not support benchmark mode")
+            }
         }
     }
 }
@@ -156,12 +148,25 @@ pub fn validate_scenario(name: &str) -> Result<(), HostError> {
     }
 }
 
-pub fn scenario_names() -> &'static [&'static str] {
-    &["null", "spacewars"]
+pub fn scenario_names() -> Vec<&'static str> {
+    client_scenarios::registrations()
+        .iter()
+        .map(|registration| registration.id)
+        .collect()
+}
+
+pub fn launcher_scenario_names() -> Vec<&'static str> {
+    client_scenarios::launcher_registrations()
+        .map(|registration| registration.id)
+        .collect()
 }
 
 pub fn is_known_scenario(name: &str) -> bool {
-    scenario_names().contains(&name)
+    client_scenarios::registration(name).is_some()
+}
+
+pub fn scenario_registration(name: &str) -> Option<&'static ScenarioRegistration> {
+    client_scenarios::registration(name)
 }
 
 pub fn start_debug_render_loop(
@@ -169,7 +174,8 @@ pub fn start_debug_render_loop(
     stress_triangles: usize,
     renderer: RenderBackend,
 ) -> Timer {
-    set_spacewars_panel(window, None);
+    set_center_panel(window, None);
+    window.set_scenario_pointer_enabled(false);
 
     let timer = Timer::default();
     let weak_window = window.as_weak();
@@ -212,14 +218,23 @@ pub fn start_scenario_loop(
         renderer,
         raster_scale,
         controls,
-        spacewars_config,
+        settings,
     } = options;
     let scenario_name = scenario.to_string();
-    let mut scenario = if start_benchmark {
-        HostedScenario::new_spacewars_benchmark(seed)
+    let initial_viewport = Viewport::from_window(window.window());
+    let start_mode = if start_benchmark {
+        ScenarioStartMode::Benchmark
     } else {
-        HostedScenario::new(&scenario_name, seed, spacewars_config.clone())?
+        ScenarioStartMode::Normal
     };
+    let mut scenario = HostedScenario::new(
+        &scenario_name,
+        seed,
+        &settings,
+        initial_viewport,
+        start_mode,
+    )?;
+    scenario.set_viewport(initial_viewport);
     let tick_model = scenario.tick_model();
     let fixed_dt = fixed_step_duration(tick_model);
     let input = std::rc::Rc::new(std::cell::RefCell::new(ClientInput::default()));
@@ -234,6 +249,11 @@ pub fn start_scenario_loop(
     let mut benchmark_active = start_benchmark;
     let mut performance = PerformanceStats::new(tick_model, last_tick);
     let mut raster_renderer = raster::RasterRenderer::new();
+    let initial_frames = scenario.render_frames(renderer, initial_viewport);
+    let mut input_projections =
+        render::frame_projections(&initial_frames, initial_viewport, scenario.frame_layout());
+    let mut projection_viewport = initial_viewport;
+    window.set_scenario_pointer_enabled(scenario.registration().capabilities.pointer_input);
 
     if benchmark_active {
         tracing::info!(seed, "started visual Spacewars benchmark.");
@@ -250,6 +270,14 @@ pub fn start_scenario_loop(
         let now = Instant::now();
         let elapsed = now.saturating_duration_since(last_tick);
         last_tick = now;
+        let viewport = Viewport::from_window(window.window());
+        scenario.set_viewport(viewport);
+        if viewport != projection_viewport {
+            let projection_frames = scenario.render_frames(renderer, viewport);
+            input_projections =
+                render::frame_projections(&projection_frames, viewport, scenario.frame_layout());
+            projection_viewport = viewport;
+        }
 
         let mut input = input.borrow_mut();
         let step_result = step_scenario(
@@ -265,7 +293,9 @@ pub fn start_scenario_loop(
             &mut paused,
             &mut benchmark_active,
             window.get_ingame_controls_visible(),
-            &spacewars_config,
+            &settings,
+            viewport,
+            &input_projections,
         );
         if step_result.return_to_launcher {
             show_running_launcher(&window);
@@ -280,15 +310,18 @@ pub fn start_scenario_loop(
 
         performance.record_frame(now, step_result.updates);
         let performance_text = performance.display_text();
-        set_spacewars_panel(
+        set_center_panel(
             &window,
-            scenario.spacewars_panel_state(paused, benchmark_active, &performance_text),
+            scenario.center_panel_state(paused, benchmark_active, &performance_text),
         );
         set_ingame_menu(&window, paused);
-        let viewport = Viewport::from_window(window.window());
+        window.set_scenario_pointer_enabled(scenario.registration().capabilities.pointer_input);
+        let frames = scenario.render_frames(renderer, viewport);
+        input_projections = render::frame_projections(&frames, viewport, scenario.frame_layout());
+        projection_viewport = viewport;
         present_frames(
             &window,
-            scenario.render_frames(renderer, viewport),
+            frames,
             scenario.frame_layout(),
             renderer,
             raster_scale,
@@ -345,7 +378,9 @@ fn step_scenario(
     paused: &mut bool,
     benchmark_active: &mut bool,
     ingame_controls_visible: bool,
-    spacewars_config: &SpacewarsConfig,
+    settings: &Settings,
+    viewport: Viewport,
+    input_projections: &[render::FrameProjection],
 ) -> HostStepResult {
     if let Some(request) = controls.take_request() {
         match request {
@@ -365,19 +400,25 @@ fn step_scenario(
                     input,
                     paused,
                     benchmark_active,
-                    spacewars_config,
+                    settings,
+                    viewport,
                 );
                 return HostStepResult::default();
             }
             ScenarioControlRequest::Benchmark => {
-                start_benchmark_scenario(
-                    scenario,
-                    seed,
-                    accumulator,
-                    input,
-                    paused,
-                    benchmark_active,
-                );
+                if scenario.registration().capabilities.benchmark {
+                    start_benchmark_scenario(
+                        scenario,
+                        scenario_name,
+                        seed,
+                        accumulator,
+                        input,
+                        paused,
+                        benchmark_active,
+                        settings,
+                        viewport,
+                    );
+                }
                 return HostStepResult::default();
             }
             ScenarioControlRequest::ZoomIn { player } => {
@@ -392,7 +433,19 @@ fn step_scenario(
     }
 
     if input.take_benchmark_requested() {
-        start_benchmark_scenario(scenario, seed, accumulator, input, paused, benchmark_active);
+        if scenario.registration().capabilities.benchmark {
+            start_benchmark_scenario(
+                scenario,
+                scenario_name,
+                seed,
+                accumulator,
+                input,
+                paused,
+                benchmark_active,
+                settings,
+                viewport,
+            );
+        }
         return HostStepResult::default();
     }
 
@@ -405,7 +458,8 @@ fn step_scenario(
             input,
             paused,
             benchmark_active,
-            spacewars_config,
+            settings,
+            viewport,
         );
         return HostStepResult::default();
     }
@@ -472,7 +526,7 @@ fn step_scenario(
             *accumulator += elapsed;
             let mut steps = 0;
             while *accumulator >= dt && steps < MAX_FIXED_STEPS_PER_TICK {
-                let actions = scenario.actions(input, *benchmark_active);
+                let actions = scenario.actions(input, *benchmark_active, input_projections);
                 scenario.step(&actions, dt);
                 *accumulator -= dt;
                 steps += 1;
@@ -483,7 +537,7 @@ fn step_scenario(
             HostStepResult::updates(steps)
         }
         (TickModel::Variable | TickModel::EmulatorClock, _) => {
-            let actions = scenario.actions(input, *benchmark_active);
+            let actions = scenario.actions(input, *benchmark_active, input_projections);
             scenario.step(&actions, elapsed);
             HostStepResult::updates(1)
         }
@@ -496,6 +550,7 @@ fn show_running_launcher(window: &MainWindow) {
     window.set_vector_minimaps_visible(false);
     window.set_raster_visible(false);
     window.set_spacewars_ui_visible(false);
+    window.set_scenario_pointer_enabled(false);
     window.set_ingame_menu_visible(false);
     window.set_ingame_controls_visible(false);
     window.set_launcher_error_text(SharedString::from(""));
@@ -511,9 +566,16 @@ fn restart_scenario(
     input: &mut ClientInput,
     paused: &mut bool,
     benchmark_active: &mut bool,
-    spacewars_config: &SpacewarsConfig,
+    settings: &Settings,
+    viewport: Viewport,
 ) {
-    match HostedScenario::new(scenario_name, seed, spacewars_config.clone()) {
+    match HostedScenario::new(
+        scenario_name,
+        seed,
+        settings,
+        viewport,
+        ScenarioStartMode::Normal,
+    ) {
         Ok(reset) => {
             *scenario = reset;
             *accumulator = Duration::ZERO;
@@ -530,13 +592,25 @@ fn restart_scenario(
 
 fn start_benchmark_scenario(
     scenario: &mut HostedScenario,
+    scenario_name: &str,
     seed: u64,
     accumulator: &mut Duration,
     input: &mut ClientInput,
     paused: &mut bool,
     benchmark_active: &mut bool,
+    settings: &Settings,
+    viewport: Viewport,
 ) {
-    *scenario = HostedScenario::new_spacewars_benchmark(seed);
+    let Ok(benchmark) = HostedScenario::new(
+        scenario_name,
+        seed,
+        settings,
+        viewport,
+        ScenarioStartMode::Benchmark,
+    ) else {
+        return;
+    };
+    *scenario = benchmark;
     *accumulator = Duration::ZERO;
     *paused = false;
     *benchmark_active = true;
@@ -704,7 +778,14 @@ pub fn run_spacewars_benchmark(
     options: BenchmarkOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let seconds = options.seconds.max(1);
-    let mut scenario = HostedScenario::new_spacewars_benchmark(options.seed);
+    let mut scenario = HostedScenario::new(
+        "spacewars",
+        options.seed,
+        &Settings::default(),
+        BENCHMARK_VIEWPORT,
+        ScenarioStartMode::Benchmark,
+    )
+    .expect("registered Spacewars benchmark should construct");
     let tick_model = scenario.tick_model();
     let fixed_dt = fixed_step_duration(tick_model).unwrap_or(Duration::from_secs_f64(1.0 / 60.0));
     let mut input = ClientInput::default();
@@ -729,7 +810,7 @@ pub fn run_spacewars_benchmark(
             let frame_started = Instant::now();
 
             let step_started = Instant::now();
-            let actions = scenario.actions(&mut input, true);
+            let actions = scenario.actions(&mut input, true, &[]);
             scenario.step(&actions, fixed_dt);
             sample.step_time += step_started.elapsed();
 
@@ -979,109 +1060,87 @@ fn duration_ms(duration: Duration) -> f64 {
     duration.as_secs_f64() * 1000.0
 }
 
-pub(crate) enum HostedScenario {
-    Null(<NullScenario as Scenario>::State),
-    Spacewars(Box<<SpacewarsScenario as Scenario>::State>),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct SpacewarsPanelState {
-    player_1: PlayerPanelState,
-    player_2: PlayerPanelState,
-    planet_score_label: String,
-    player_1_planet_fraction: f32,
-    player_2_planet_fraction: f32,
-    player_1_planet_score: String,
-    free_planet_score: String,
-    player_2_planet_score: String,
-    message_text: String,
-    performance_text: String,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct PlayerPanelState {
-    name: String,
-    status: String,
-    status_fraction: f32,
-    color: CoreColor,
+pub(crate) struct HostedScenario {
+    inner: Box<dyn ClientScenario>,
 }
 
 impl HostedScenario {
     pub(crate) fn new(
         name: &str,
         seed: u64,
-        spacewars_config: SpacewarsConfig,
+        settings: &Settings,
+        viewport: Viewport,
+        mode: ScenarioStartMode,
     ) -> Result<Self, HostError> {
-        match name {
-            "null" => Ok(Self::Null(NullScenario::init(NullConfig, seed))),
-            "spacewars" => Ok(Self::Spacewars(Box::new(SpacewarsScenario::init(
-                spacewars_config,
-                seed,
-            )))),
-            _ => Err(HostError::UnknownScenario { name: name.into() }),
-        }
+        let registration = client_scenarios::registration(name)
+            .ok_or_else(|| HostError::UnknownScenario { name: name.into() })?;
+        let inner = registration
+            .create(seed, settings, viewport, mode)
+            .map_err(|error| match error {
+                ScenarioCreateError::BenchmarkUnsupported { .. } => {
+                    HostError::BenchmarkUnsupported { name: name.into() }
+                }
+            })?;
+        Ok(Self { inner })
     }
 
-    pub(crate) fn new_spacewars_benchmark(seed: u64) -> Self {
-        Self::Spacewars(Box::new(SpacewarsScenario::init_benchmark(seed)))
+    pub(crate) fn registration(&self) -> &'static ScenarioRegistration {
+        self.inner.registration()
     }
 
     pub(crate) fn tick_model(&self) -> TickModel {
-        match self {
-            Self::Null(_) => NullScenario::tick_model(),
-            Self::Spacewars(_) => SpacewarsScenario::tick_model(),
-        }
+        self.inner.tick_model()
     }
 
     pub(crate) fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult {
-        match self {
-            Self::Null(state) => NullScenario::step(state, actions, dt),
-            Self::Spacewars(state) => SpacewarsScenario::step(state, actions, dt),
-        }
+        self.inner.step(actions, dt)
     }
 
     pub(crate) fn zoom_player_in(&mut self, player: usize) {
-        if let Self::Spacewars(state) = self {
-            state.zoom_player_in(player);
-        }
+        self.inner.zoom_player_in(player);
     }
 
     pub(crate) fn zoom_player_out(&mut self, player: usize) {
-        if let Self::Spacewars(state) = self {
-            state.zoom_player_out(player);
-        }
+        self.inner.zoom_player_out(player);
     }
 
     fn is_game_over(&self) -> bool {
-        match self {
-            Self::Null(_) => false,
-            Self::Spacewars(state) => state.winner.is_some(),
-        }
+        self.inner.is_game_over()
     }
 
-    pub(crate) fn actions(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action> {
-        match self {
-            Self::Null(_) => Vec::new(),
-            Self::Spacewars(state) if benchmark_active => {
-                SpacewarsScenario::benchmark_actions(state)
-            }
-            Self::Spacewars(_) => input.actions_for_spacewars(),
+    pub(crate) fn actions(
+        &self,
+        input: &mut ClientInput,
+        benchmark_active: bool,
+        input_projections: &[render::FrameProjection],
+    ) -> Vec<Action> {
+        let mut actions = self.inner.map_keyboard_input(input, benchmark_active);
+        if self.registration().capabilities.pointer_input {
+            actions.extend(
+                input
+                    .take_pointer_events()
+                    .into_iter()
+                    .filter_map(|event| {
+                        render::unproject_pointer(input_projections, event.position, event.phase)
+                    })
+                    .map(Action::Pointer),
+            );
+        } else {
+            input.discard_pointer_events();
         }
+        actions
     }
 
     pub(crate) fn benchmark_counts(&self) -> SpacewarsBenchmarkCounts {
-        match self {
-            Self::Null(_) => SpacewarsBenchmarkCounts::default(),
-            Self::Spacewars(state) => SpacewarsScenario::benchmark_counts(state),
-        }
+        self.inner.benchmark_counts().unwrap_or_default()
     }
 
     #[cfg(test)]
     pub(crate) fn render_frame(&self) -> RenderFrame {
-        match self {
-            Self::Null(state) => NullScenario::render_frame(state),
-            Self::Spacewars(state) => SpacewarsScenario::render_frame(state),
-        }
+        self.render_frames(RenderBackend::Vector, BENCHMARK_VIEWPORT)
+            .into_iter()
+            .next()
+            .unwrap_or_default()
     }
 
     pub(crate) fn render_frames(
@@ -1089,139 +1148,39 @@ impl HostedScenario {
         renderer: RenderBackend,
         viewport: Viewport,
     ) -> Vec<RenderFrame> {
-        let player_view_aspect_ratio =
-            render::frame_viewports(viewport, 4, render::FrameLayout::SpacewarsLocalPlay)[0]
-                .aspect_ratio();
-        match self {
-            Self::Null(state) => vec![NullScenario::render_frame(state)],
-            Self::Spacewars(state) if renderer == RenderBackend::Raster => {
-                SpacewarsScenario::render_raster_local_play_frames(state, player_view_aspect_ratio)
-            }
-            Self::Spacewars(state) => {
-                SpacewarsScenario::render_local_play_frames(state, player_view_aspect_ratio)
-            }
-        }
+        self.inner.render_frames(renderer, viewport)
     }
 
     pub(crate) fn frame_layout(&self) -> render::FrameLayout {
-        match self {
-            Self::Null(_) => render::FrameLayout::EqualHorizontal,
-            Self::Spacewars(_) => render::FrameLayout::SpacewarsLocalPlay,
-        }
+        self.inner.frame_layout()
     }
 
-    fn spacewars_panel_state(
+    fn set_viewport(&mut self, viewport: Viewport) {
+        self.inner.set_viewport(viewport);
+    }
+
+    fn center_panel_state(
         &self,
         paused: bool,
         benchmark_active: bool,
         performance_text: &str,
-    ) -> Option<SpacewarsPanelState> {
-        match self {
-            Self::Null(_) => None,
-            Self::Spacewars(state) => Some(spacewars_panel_state(
-                state,
-                paused,
-                benchmark_active,
-                performance_text,
-            )),
-        }
+    ) -> Option<CenterPanelState> {
+        self.inner
+            .center_panel_state(paused, benchmark_active, performance_text)
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.inner.as_any()
+    }
+
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self.inner.as_any_mut()
     }
 }
 
-fn spacewars_panel_state(
-    state: &SpacewarsState,
-    paused: bool,
-    benchmark_active: bool,
-    performance_text: &str,
-) -> SpacewarsPanelState {
-    let player_1_planets = state.players[0].planet_count;
-    let player_2_planets = state.players[1].planet_count;
-    let free_planets = state
-        .planets
-        .len()
-        .saturating_sub(player_1_planets + player_2_planets);
-    let total_planets = state.planets.len().max(1) as f32;
-
-    SpacewarsPanelState {
-        player_1: player_panel_state(state, 0),
-        player_2: player_panel_state(state, 1),
-        planet_score_label: format!(
-            "Planets  P1 {player_1_planets} | Free {free_planets} | P2 {player_2_planets}"
-        ),
-        player_1_planet_fraction: player_1_planets as f32 / total_planets,
-        player_2_planet_fraction: player_2_planets as f32 / total_planets,
-        player_1_planet_score: planet_score_text(player_1_planets),
-        free_planet_score: planet_score_text(free_planets),
-        player_2_planet_score: planet_score_text(player_2_planets),
-        message_text: spacewars_panel_message(state, paused, benchmark_active),
-        performance_text: performance_text.into(),
-    }
-}
-
-fn planet_score_text(count: usize) -> String {
-    if count == 0 {
-        String::new()
-    } else {
-        count.to_string()
-    }
-}
-
-fn spacewars_panel_message(state: &SpacewarsState, paused: bool, benchmark_active: bool) -> String {
-    if let Some(winner) = state.winner.and_then(|winner| state.players.get(winner)) {
-        return format!("P{} Wins | R Restart | B Bench | Esc Launch", winner.id + 1);
-    }
-
-    if benchmark_active && paused {
-        "Bench Paused | P/Esc Resume | B Reset | Q Launch".into()
-    } else if benchmark_active {
-        "Bench | P/Esc Pause | B Reset | R Game".into()
-    } else if paused {
-        "Paused | P/Esc Resume | R Restart | B Bench | Q Launch".into()
-    } else {
-        "P/Esc Pause | R Restart | B Bench".into()
-    }
-}
-
-fn player_panel_state(state: &SpacewarsState, player_index: usize) -> PlayerPanelState {
-    let player = &state.players[player_index];
-    let ship = &state.ships[player_index];
-    if player.eliminated {
-        return PlayerPanelState {
-            name: format!("Player {}: {}", player.id + 1, player.name),
-            status: "Eliminated".into(),
-            status_fraction: 0.0,
-            color: player.color,
-        };
-    }
-
-    let status_fraction = ship_life_fraction(ship.life, ship.life_max);
-    let percent = display_percent(status_fraction);
-    let label = match ship.form {
-        ShipForm::Ship => "Ship Health",
-        ShipForm::EscapePod => "Pod Rebuild",
-    };
-
-    PlayerPanelState {
-        name: format!("Player {}: {}", player.id + 1, player.name),
-        status: format!("{label}: {percent}%"),
-        status_fraction,
-        color: player.color,
-    }
-}
-
-fn ship_life_fraction(life: f32, life_max: f32) -> f32 {
-    if life_max <= 0.0 {
-        return 0.0;
-    }
-
-    (life / life_max).clamp(0.0, 1.0)
-}
-
-fn display_percent(fraction: f32) -> u32 {
-    (fraction.clamp(0.0, 1.0) * 100.0).round() as u32
-}
-
-fn set_spacewars_panel(window: &MainWindow, state: Option<SpacewarsPanelState>) {
+fn set_center_panel(window: &MainWindow, state: Option<CenterPanelState>) {
     let Some(state) = state else {
         window.set_spacewars_ui_visible(false);
         return;
@@ -1258,9 +1217,66 @@ fn brush_from_core_color(color: CoreColor) -> Brush {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use engine_common::RenderPoint;
+    use engine_core::SpacewarsConfig;
+    use scenario_spacewars::{ShipForm, SpacewarsState};
+
+    use crate::client_scenarios::{PizzaClientScenario, SpacewarsClientScenario};
+    use crate::input::ScreenPointerEvent;
+
+    const TEST_VIEWPORT: Viewport = Viewport::new(1280.0, 720.0);
 
     fn hosted_scenario(name: &str, seed: u64) -> Result<HostedScenario, HostError> {
-        HostedScenario::new(name, seed, SpacewarsConfig::default())
+        HostedScenario::new(
+            name,
+            seed,
+            &Settings::default(),
+            TEST_VIEWPORT,
+            ScenarioStartMode::Normal,
+        )
+    }
+
+    fn settings_from_config(config: &SpacewarsConfig) -> Settings {
+        let mut settings = Settings::default();
+        settings.spacewars.universe_radius = config.universe_radius;
+        settings.spacewars.use_planets = config.use_planets;
+        settings.spacewars.asteroids_enabled = config.asteroid_probability_per_sec > 0.0;
+        settings.spacewars.asteroid_probability_per_sec = config.asteroid_probability_per_sec;
+        settings.spacewars.player_health_percent = config.players[0].health_percent;
+        settings.spacewars.player_1_view_height = config.player_view_heights[0];
+        settings.spacewars.player_2_view_height = config.player_view_heights[1];
+        settings
+    }
+
+    fn hosted_spacewars_with_config(
+        seed: u64,
+        config: &SpacewarsConfig,
+    ) -> Result<HostedScenario, HostError> {
+        HostedScenario::new(
+            "spacewars",
+            seed,
+            &settings_from_config(config),
+            TEST_VIEWPORT,
+            ScenarioStartMode::Normal,
+        )
+    }
+
+    fn spacewars_state(scenario: &HostedScenario) -> &SpacewarsState {
+        scenario
+            .as_any()
+            .downcast_ref::<SpacewarsClientScenario>()
+            .expect("scenario should host Spacewars")
+            .state
+            .as_ref()
+    }
+
+    fn spacewars_state_mut(scenario: &mut HostedScenario) -> &mut SpacewarsState {
+        scenario
+            .as_any_mut()
+            .downcast_mut::<SpacewarsClientScenario>()
+            .expect("scenario should host Spacewars")
+            .state
+            .as_mut()
     }
 
     fn small_duel_config() -> SpacewarsConfig {
@@ -1306,22 +1322,58 @@ mod tests {
         let scenario = hosted_scenario("null", 0).unwrap();
 
         assert!(scenario.render_frame().layers.is_empty());
-        assert_eq!(scenario.spacewars_panel_state(false, false, ""), None);
+        assert_eq!(scenario.center_panel_state(false, false, ""), None);
+        assert_eq!(scenario.registration().id, "null");
+    }
+
+    #[test]
+    fn pizza_scenario_receives_unprojected_pointer_actions() {
+        let mut settings = Settings::default();
+        settings.pizza.desired_balls = 0;
+        let mut scenario = HostedScenario::new(
+            "pizza",
+            7,
+            &settings,
+            TEST_VIEWPORT,
+            ScenarioStartMode::Normal,
+        )
+        .unwrap();
+        let frames = scenario.render_frames(RenderBackend::Vector, TEST_VIEWPORT);
+        let projections =
+            render::frame_projections(&frames, TEST_VIEWPORT, scenario.frame_layout());
+        let mut input = ClientInput::default();
+        input.push_pointer_event(ScreenPointerEvent {
+            position: RenderPoint::new(TEST_VIEWPORT.width * 0.5, TEST_VIEWPORT.height * 0.5),
+            phase: engine_common::PointerPhase::Press,
+        });
+
+        let actions = scenario.actions(&mut input, false, &projections);
+        assert_eq!(
+            actions,
+            vec![Action::Pointer(engine_common::PointerAction {
+                position: RenderPoint::new(0.5, 0.28125),
+                phase: engine_common::PointerPhase::Press,
+            })]
+        );
+        scenario.step(&actions, Duration::from_secs_f64(1.0 / 60.0));
+
+        let pizza = scenario
+            .as_any()
+            .downcast_ref::<PizzaClientScenario>()
+            .expect("scenario should host Pizza");
+        assert_eq!(pizza.state.balls.len(), 1);
+        assert!(pizza.state.held_ball_id.is_some());
     }
 
     #[test]
     fn spacewars_scenario_renders_initial_world() {
         let scenario = hosted_scenario("spacewars", 0).unwrap();
         let frame = scenario.render_frame();
+        let state = spacewars_state(&scenario);
 
-        match &scenario {
-            HostedScenario::Spacewars(state) => {
-                assert_eq!(state.config, SpacewarsConfig::default());
-                assert!(state.sun.is_some());
-                assert!(!state.planets.is_empty());
-            }
-            HostedScenario::Null(_) => panic!("spacewars scenario should not host null"),
-        }
+        assert_eq!(state.config, SpacewarsConfig::default());
+        assert!(state.sun.is_some());
+        assert!(!state.planets.is_empty());
         assert!(!frame.layers.is_empty());
         assert!(matches!(
             scenario.tick_model(),
@@ -1332,16 +1384,12 @@ mod tests {
     #[test]
     fn spacewars_scenario_uses_supplied_config() {
         let config = small_duel_config();
-        let scenario = HostedScenario::new("spacewars", 0, config.clone()).unwrap();
+        let scenario = hosted_spacewars_with_config(0, &config).unwrap();
+        let state = spacewars_state(&scenario);
 
-        match &scenario {
-            HostedScenario::Spacewars(state) => {
-                assert_eq!(state.config, config);
-                assert!(state.sun.is_none());
-                assert!(state.planets.is_empty());
-            }
-            HostedScenario::Null(_) => panic!("spacewars scenario should not host null"),
-        }
+        assert_eq!(state.config, config);
+        assert!(state.sun.is_none());
+        assert!(state.planets.is_empty());
     }
 
     #[test]
@@ -1350,9 +1398,7 @@ mod tests {
         let viewport = Viewport::new(1000.0, 700.0);
         let frames = scenario.render_frames(RenderBackend::Vector, viewport);
 
-        let HostedScenario::Spacewars(state) = &scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state(&scenario);
 
         assert_eq!(frames.len(), 4);
         assert_eq!(frames[0].camera.center.x, state.ships[0].position.x);
@@ -1385,18 +1431,20 @@ mod tests {
     #[test]
     fn spacewars_panel_state_reports_health_pod_and_planet_score() {
         let mut scenario = hosted_scenario("spacewars", 0).unwrap();
-        let HostedScenario::Spacewars(state) = &mut scenario else {
-            panic!("spacewars scenario should not host null");
+        let (total_planets, free_planets) = {
+            let state = spacewars_state_mut(&mut scenario);
+            let total_planets = state.planets.len().max(1) as f32;
+            state.ships[0].life = state.ships[0].life_max * 0.5;
+            state.ships[1].form = ShipForm::EscapePod;
+            state.ships[1].life = state.ships[1].life_max * 0.25;
+            state.players[0].planet_count = 1;
+            state.players[1].planet_count = 2;
+            (total_planets, state.planets.len().saturating_sub(3))
         };
-        let total_planets = state.planets.len().max(1) as f32;
-        state.ships[0].life = state.ships[0].life_max * 0.5;
-        state.ships[1].form = ShipForm::EscapePod;
-        state.ships[1].life = state.ships[1].life_max * 0.25;
-        state.players[0].planet_count = 1;
-        state.players[1].planet_count = 2;
-        let free_planets = state.planets.len().saturating_sub(3);
 
-        let panel = spacewars_panel_state(state, false, false, "Target 60 Hz | FPS 60 | UPS 60");
+        let panel = scenario
+            .center_panel_state(false, false, "Target 60 Hz | FPS 60 | UPS 60")
+            .unwrap();
 
         assert_eq!(panel.player_1.name, "Player 1: Player 1");
         assert_eq!(panel.player_1.status, "Ship Health: 50%");
@@ -1420,13 +1468,13 @@ mod tests {
     #[test]
     fn spacewars_panel_state_reports_winner_and_eliminated_player() {
         let mut scenario = hosted_scenario("spacewars", 0).unwrap();
-        let HostedScenario::Spacewars(state) = &mut scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state_mut(&mut scenario);
         state.players[0].eliminated = true;
         state.winner = Some(1);
 
-        let panel = spacewars_panel_state(state, false, false, "Target 60 Hz | FPS 60 | UPS 0");
+        let panel = scenario
+            .center_panel_state(false, false, "Target 60 Hz | FPS 60 | UPS 0")
+            .unwrap();
 
         assert_eq!(panel.player_1.status, "Eliminated");
         assert_eq!(panel.player_1.status_fraction, 0.0);
@@ -1439,12 +1487,11 @@ mod tests {
 
     #[test]
     fn spacewars_panel_state_reports_pause_message() {
-        let mut scenario = hosted_scenario("spacewars", 0).unwrap();
-        let HostedScenario::Spacewars(state) = &mut scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let scenario = hosted_scenario("spacewars", 0).unwrap();
 
-        let panel = spacewars_panel_state(state, true, false, "Target 60 Hz | FPS 60 | UPS 0");
+        let panel = scenario
+            .center_panel_state(true, false, "Target 60 Hz | FPS 60 | UPS 0")
+            .unwrap();
 
         assert_eq!(
             panel.message_text,
@@ -1455,12 +1502,18 @@ mod tests {
 
     #[test]
     fn spacewars_panel_state_reports_benchmark_message() {
-        let mut scenario = HostedScenario::new_spacewars_benchmark(0);
-        let HostedScenario::Spacewars(state) = &mut scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let scenario = HostedScenario::new(
+            "spacewars",
+            0,
+            &Settings::default(),
+            TEST_VIEWPORT,
+            ScenarioStartMode::Benchmark,
+        )
+        .unwrap();
 
-        let panel = spacewars_panel_state(state, false, true, "Target 60 Hz | FPS 42 | UPS 60");
+        let panel = scenario
+            .center_panel_state(false, true, "Target 60 Hz | FPS 42 | UPS 60")
+            .unwrap();
 
         assert_eq!(panel.message_text, "Bench | P/Esc Pause | B Reset | R Game");
         assert_eq!(panel.performance_text, "Target 60 Hz | FPS 42 | UPS 60");
@@ -1469,11 +1522,10 @@ mod tests {
     #[test]
     fn reset_key_restarts_spacewars_with_same_seed() {
         let config = small_duel_config();
-        let mut scenario = HostedScenario::new("spacewars", 42, config.clone()).unwrap();
-        let expected = HostedScenario::new("spacewars", 42, config.clone()).unwrap();
-        let HostedScenario::Spacewars(state) = &mut scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let settings = settings_from_config(&config);
+        let mut scenario = hosted_spacewars_with_config(42, &config).unwrap();
+        let expected = hosted_spacewars_with_config(42, &config).unwrap();
+        let state = spacewars_state_mut(&mut scenario);
         state.tick = 120;
         state.ships[0].position.x += 50.0;
 
@@ -1497,15 +1549,13 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &config,
+            &settings,
+            TEST_VIEWPORT,
+            &[],
         );
 
-        let HostedScenario::Spacewars(state) = &scenario else {
-            panic!("spacewars scenario should not host null");
-        };
-        let HostedScenario::Spacewars(expected) = &expected else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state(&scenario);
+        let expected = spacewars_state(&expected);
         assert_eq!(accumulator, Duration::ZERO);
         assert!(!paused);
         assert!(!benchmark_active);
@@ -1539,7 +1589,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(paused);
 
@@ -1556,11 +1608,11 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
-        let HostedScenario::Spacewars(state) = &scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state(&scenario);
         assert_eq!(state.tick, 0);
         assert_eq!(accumulator, Duration::ZERO);
 
@@ -1578,7 +1630,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(!paused);
     }
@@ -1606,7 +1660,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(paused);
         assert_eq!(result.ingame_controls_visible, None);
@@ -1626,7 +1682,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             true,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(paused);
         assert_eq!(result.ingame_controls_visible, Some(false));
@@ -1645,7 +1703,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(!paused);
     }
@@ -1673,7 +1733,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert_eq!(result.ingame_controls_visible, Some(true));
         assert_eq!(accumulator, Duration::ZERO);
@@ -1692,7 +1754,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             true,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert_eq!(result.ingame_controls_visible, Some(false));
     }
@@ -1720,7 +1784,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(result.return_to_launcher);
         assert_eq!(accumulator, Duration::ZERO);
@@ -1750,7 +1816,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
 
         let counts = scenario.benchmark_counts();
@@ -1764,9 +1832,7 @@ mod tests {
     #[test]
     fn escape_after_game_over_returns_to_launcher_without_stepping() {
         let mut scenario = hosted_scenario("spacewars", 42).unwrap();
-        let HostedScenario::Spacewars(state) = &mut scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state_mut(&mut scenario);
         state.winner = Some(1);
         let tick_before = state.tick;
 
@@ -1790,12 +1856,12 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
 
-        let HostedScenario::Spacewars(state) = &scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state(&scenario);
         assert!(result.return_to_launcher);
         assert_eq!(result.updates, 0);
         assert_eq!(accumulator, Duration::ZERO);
@@ -1826,14 +1892,14 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(!paused);
         assert_eq!(accumulator, Duration::ZERO);
 
-        let HostedScenario::Spacewars(state) = &mut scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state_mut(&mut scenario);
         state.tick = 120;
         state.ships[0].position.x += 50.0;
         paused = true;
@@ -1854,11 +1920,11 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
-        let HostedScenario::Spacewars(state) = &scenario else {
-            panic!("spacewars scenario should not host null");
-        };
+        let state = spacewars_state(&scenario);
         assert_eq!(state.tick, 0);
         assert!(!paused);
         assert!(!benchmark_active);
@@ -1877,7 +1943,9 @@ mod tests {
             &mut paused,
             &mut benchmark_active,
             false,
-            &SpacewarsConfig::default(),
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
         );
         assert!(benchmark_active);
         assert_eq!(scenario.benchmark_counts().asteroids, 100);

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -16,6 +16,7 @@ use slint::{
     Brush, Color as SlintColor, ComponentHandle, ModelRc, SharedString, Timer, TimerMode, VecModel,
 };
 
+use crate::MainWindow;
 pub use crate::client_scenarios::RenderBackend;
 use crate::client_scenarios::{
     self, CenterPanelState, ClientScenario, ScenarioCreateError, ScenarioRegistration,
@@ -24,7 +25,6 @@ use crate::client_scenarios::{
 use crate::input::{self, ClientInput};
 use crate::raster;
 use crate::render::{self, Viewport};
-use crate::{MainWindow, ScenePrimitive};
 
 const TIMER_INTERVAL: Duration = Duration::from_millis(16);
 const MAX_FIXED_STEPS_PER_TICK: usize = 5;
@@ -298,7 +298,7 @@ pub fn start_scenario_loop(
             &input_projections,
         );
         if step_result.return_to_launcher {
-            show_running_launcher(&window);
+            window.invoke_ingame_return_launcher();
             return;
         }
         if let Some(visible) = step_result.ingame_controls_visible {
@@ -382,11 +382,16 @@ fn step_scenario(
     viewport: Viewport,
     input_projections: &[render::FrameProjection],
 ) -> HostStepResult {
+    if input.has_pointer_cancellation() {
+        deliver_pointer_cancellation(scenario, input, input_projections);
+    }
+
     if let Some(request) = controls.take_request() {
         match request {
             ScenarioControlRequest::Resume => {
                 *paused = false;
                 *accumulator = Duration::ZERO;
+                deliver_pointer_cancellation(scenario, input, input_projections);
                 input.clear();
                 tracing::info!(benchmark = *benchmark_active, "resumed from in-game menu.");
                 return HostStepResult::default();
@@ -483,6 +488,7 @@ fn step_scenario(
 
         *paused = true;
         *accumulator = Duration::ZERO;
+        deliver_pointer_cancellation(scenario, input, input_projections);
         input.clear();
         tracing::info!(
             paused = *paused,
@@ -494,6 +500,7 @@ fn step_scenario(
 
     if input.take_controls_requested() && *paused && !scenario.is_game_over() {
         *accumulator = Duration::ZERO;
+        deliver_pointer_cancellation(scenario, input, input_projections);
         input.clear();
         return HostStepResult::set_ingame_controls_visible(!ingame_controls_visible);
     }
@@ -508,6 +515,7 @@ fn step_scenario(
     if input.take_pause_requested() && !scenario.is_game_over() {
         *paused = !*paused;
         *accumulator = Duration::ZERO;
+        deliver_pointer_cancellation(scenario, input, input_projections);
         input.clear();
         tracing::info!(
             paused = *paused,
@@ -545,17 +553,16 @@ fn step_scenario(
     }
 }
 
-fn show_running_launcher(window: &MainWindow) {
-    window.set_primitives(ModelRc::new(VecModel::from(Vec::<ScenePrimitive>::new())));
-    window.set_vector_minimaps_visible(false);
-    window.set_raster_visible(false);
-    window.set_spacewars_ui_visible(false);
-    window.set_scenario_pointer_enabled(false);
-    window.set_ingame_menu_visible(false);
-    window.set_ingame_controls_visible(false);
-    window.set_launcher_error_text(SharedString::from(""));
-    window.set_launcher_controls_visible(false);
-    window.set_launcher_visible(true);
+fn deliver_pointer_cancellation(
+    scenario: &mut HostedScenario,
+    input: &mut ClientInput,
+    input_projections: &[render::FrameProjection],
+) {
+    input.cancel_pointer();
+    let actions = scenario.pointer_actions(input, input_projections);
+    if !actions.is_empty() {
+        scenario.step(&actions, Duration::ZERO);
+    }
 }
 
 fn restart_scenario(
@@ -1115,20 +1122,28 @@ impl HostedScenario {
         input_projections: &[render::FrameProjection],
     ) -> Vec<Action> {
         let mut actions = self.inner.map_keyboard_input(input, benchmark_active);
+        actions.extend(self.pointer_actions(input, input_projections));
+        actions
+    }
+
+    fn pointer_actions(
+        &self,
+        input: &mut ClientInput,
+        input_projections: &[render::FrameProjection],
+    ) -> Vec<Action> {
         if self.registration().capabilities.pointer_input {
-            actions.extend(
-                input
-                    .take_pointer_events()
-                    .into_iter()
-                    .filter_map(|event| {
-                        render::unproject_pointer(input_projections, event.position, event.phase)
-                    })
-                    .map(Action::Pointer),
-            );
+            input
+                .take_pointer_events()
+                .into_iter()
+                .filter_map(|event| {
+                    render::unproject_pointer(input_projections, event.position, event.phase)
+                })
+                .map(Action::Pointer)
+                .collect()
         } else {
             input.discard_pointer_events();
+            Vec::new()
         }
-        actions
     }
 
     pub(crate) fn benchmark_counts(&self) -> SpacewarsBenchmarkCounts {
@@ -1363,6 +1378,70 @@ mod tests {
             .expect("scenario should host Pizza");
         assert_eq!(pizza.state.balls.len(), 1);
         assert!(pizza.state.held_ball_id.is_some());
+    }
+
+    #[test]
+    fn pausing_cancels_pizza_pointer_interaction() {
+        let mut settings = Settings::default();
+        settings.pizza.desired_balls = 0;
+        let mut scenario = HostedScenario::new(
+            "pizza",
+            7,
+            &settings,
+            TEST_VIEWPORT,
+            ScenarioStartMode::Normal,
+        )
+        .unwrap();
+        let frames = scenario.render_frames(RenderBackend::Vector, TEST_VIEWPORT);
+        let projections =
+            render::frame_projections(&frames, TEST_VIEWPORT, scenario.frame_layout());
+        let mut input = ClientInput::default();
+        input.push_pointer_event(ScreenPointerEvent {
+            position: RenderPoint::new(TEST_VIEWPORT.width * 0.5, TEST_VIEWPORT.height * 0.5),
+            phase: engine_common::PointerPhase::Press,
+        });
+        let actions = scenario.actions(&mut input, false, &projections);
+        scenario.step(&actions, Duration::from_secs_f64(1.0 / 60.0));
+
+        input.push_pointer_event(ScreenPointerEvent {
+            position: RenderPoint::new(TEST_VIEWPORT.width * 0.6, TEST_VIEWPORT.height * 0.5),
+            phase: engine_common::PointerPhase::Drag,
+        });
+        let actions = scenario.actions(&mut input, false, &projections);
+        scenario.step(&actions, Duration::from_secs_f64(1.0 / 60.0));
+        input.press(input::GameKey::Pause);
+
+        let mut accumulator = Duration::ZERO;
+        let mut controls = ScenarioControls::default();
+        let mut paused = false;
+        let mut benchmark_active = false;
+        step_scenario(
+            &mut scenario,
+            "pizza",
+            7,
+            TickModel::FixedTimestep { hz: 60 },
+            Some(Duration::from_secs_f64(1.0 / 60.0)),
+            Duration::ZERO,
+            &mut accumulator,
+            &mut input,
+            &mut controls,
+            &mut paused,
+            &mut benchmark_active,
+            false,
+            &settings,
+            TEST_VIEWPORT,
+            &projections,
+        );
+
+        let pizza = scenario
+            .as_any()
+            .downcast_ref::<PizzaClientScenario>()
+            .expect("scenario should host Pizza");
+        assert!(paused);
+        assert!(pizza.state.held_ball_id.is_none());
+        assert!(!pizza.state.balls[0].invincible);
+        assert!(pizza.state.balls[0].moving);
+        assert_eq!(pizza.state.balls[0].velocity, engine_core::Vec2::ZERO);
     }
 
     #[test]

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -20,6 +20,7 @@ pub(crate) struct ClientInput {
     pressed: BTreeSet<GameKey>,
     released: BTreeSet<GameKey>,
     pointer_events: Vec<ScreenPointerEvent>,
+    active_pointer: Option<RenderPoint>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -65,7 +66,9 @@ pub(crate) fn install_window_input(window: &MainWindow, input: SharedInput) {
     let keyboard_input = Rc::clone(&input);
     window.window().on_winit_window_event(move |_, event| {
         if matches!(event, WindowEvent::Focused(false)) {
-            keyboard_input.borrow_mut().clear();
+            let mut input = keyboard_input.borrow_mut();
+            input.cancel_pointer();
+            input.clear_keyboard();
             return EventResult::Propagate;
         }
 
@@ -86,9 +89,10 @@ pub(crate) fn install_window_input(window: &MainWindow, input: SharedInput) {
             0 => PointerPhase::Press,
             1 => PointerPhase::Drag,
             2 => PointerPhase::Release,
+            3 => PointerPhase::Cancel,
             _ => return,
         };
-        input.borrow_mut().pointer_events.push(ScreenPointerEvent {
+        input.borrow_mut().push_pointer_event(ScreenPointerEvent {
             position: RenderPoint::new(x, y),
             phase,
         });
@@ -173,22 +177,62 @@ impl ClientInput {
     }
 
     pub(crate) fn clear(&mut self) {
+        self.clear_keyboard();
+        self.pointer_events.clear();
+        self.active_pointer = None;
+    }
+
+    fn clear_keyboard(&mut self) {
         self.pressed.clear();
         self.released.clear();
-        self.pointer_events.clear();
     }
 
     pub(crate) fn take_pointer_events(&mut self) -> Vec<ScreenPointerEvent> {
         std::mem::take(&mut self.pointer_events)
     }
 
-    pub(crate) fn discard_pointer_events(&mut self) {
-        self.pointer_events.clear();
+    pub(crate) fn has_pointer_cancellation(&self) -> bool {
+        self.pointer_events
+            .iter()
+            .any(|event| event.phase == PointerPhase::Cancel)
     }
 
-    #[cfg(test)]
+    pub(crate) fn cancel_pointer(&mut self) {
+        let Some(position) = self.active_pointer.take() else {
+            return;
+        };
+        self.pointer_events.push(ScreenPointerEvent {
+            position,
+            phase: PointerPhase::Cancel,
+        });
+    }
+
+    pub(crate) fn discard_pointer_events(&mut self) {
+        self.pointer_events.clear();
+        self.active_pointer = None;
+    }
+
     pub(crate) fn push_pointer_event(&mut self, event: ScreenPointerEvent) {
-        self.pointer_events.push(event);
+        match event.phase {
+            PointerPhase::Press => {
+                self.active_pointer = Some(event.position);
+                self.pointer_events.push(event);
+            }
+            PointerPhase::Drag => {
+                if self.active_pointer.is_some() {
+                    self.active_pointer = Some(event.position);
+                    self.pointer_events.push(event);
+                }
+            }
+            PointerPhase::Release => {
+                if self.active_pointer.take().is_some() {
+                    self.pointer_events.push(event);
+                }
+            }
+            PointerPhase::Cancel => {
+                self.cancel_pointer();
+            }
+        }
     }
 
     pub(crate) fn press(&mut self, key: GameKey) {
@@ -333,6 +377,48 @@ mod tests {
         actions
             .iter()
             .any(|action| action.player == player && action.kind == kind)
+    }
+
+    #[test]
+    fn pointer_cancel_uses_the_last_active_position_once() {
+        let mut input = ClientInput::default();
+        input.push_pointer_event(ScreenPointerEvent {
+            position: RenderPoint::new(10.0, 20.0),
+            phase: PointerPhase::Press,
+        });
+        input.push_pointer_event(ScreenPointerEvent {
+            position: RenderPoint::new(30.0, 40.0),
+            phase: PointerPhase::Drag,
+        });
+        input.take_pointer_events();
+
+        input.cancel_pointer();
+        input.cancel_pointer();
+
+        assert_eq!(
+            input.take_pointer_events(),
+            vec![ScreenPointerEvent {
+                position: RenderPoint::new(30.0, 40.0),
+                phase: PointerPhase::Cancel,
+            }]
+        );
+    }
+
+    #[test]
+    fn clearing_keyboard_state_preserves_pointer_cancellation() {
+        let mut input = ClientInput::default();
+        input.press(GameKey::P1Thrust);
+        input.push_pointer_event(ScreenPointerEvent {
+            position: RenderPoint::new(10.0, 20.0),
+            phase: PointerPhase::Press,
+        });
+        input.take_pointer_events();
+        input.cancel_pointer();
+
+        input.clear_keyboard();
+
+        assert!(!input.pressed.contains(&GameKey::P1Thrust));
+        assert!(input.has_pointer_cancellation());
     }
 
     #[test]

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::rc::Rc;
 
-use engine_common::Action;
+use engine_common::{Action, PointerPhase, RenderPoint};
 use scenario_spacewars::SpacewarsAction;
 use slint::ComponentHandle;
 use slint::winit_030::winit::event::{ElementState, WindowEvent};
@@ -19,6 +19,13 @@ pub(crate) type SharedInput = Rc<RefCell<ClientInput>>;
 pub(crate) struct ClientInput {
     pressed: BTreeSet<GameKey>,
     released: BTreeSet<GameKey>,
+    pointer_events: Vec<ScreenPointerEvent>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ScreenPointerEvent {
+    pub position: RenderPoint,
+    pub phase: PointerPhase,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -55,9 +62,10 @@ pub(crate) fn install_window_input(window: &MainWindow, input: SharedInput) {
     // `has_winit_window()` stays false until the native window is created during
     // `run()`. The event filter only needs the winit adapter, so install it
     // before the event loop starts.
+    let keyboard_input = Rc::clone(&input);
     window.window().on_winit_window_event(move |_, event| {
         if matches!(event, WindowEvent::Focused(false)) {
-            input.borrow_mut().clear();
+            keyboard_input.borrow_mut().clear();
             return EventResult::Propagate;
         }
 
@@ -66,11 +74,24 @@ pub(crate) fn install_window_input(window: &MainWindow, input: SharedInput) {
         };
 
         match state {
-            ElementState::Pressed => input.borrow_mut().press(key),
-            ElementState::Released => input.borrow_mut().release(key),
+            ElementState::Pressed => keyboard_input.borrow_mut().press(key),
+            ElementState::Released => keyboard_input.borrow_mut().release(key),
         }
 
         EventResult::Propagate
+    });
+
+    window.on_scenario_pointer(move |x, y, phase| {
+        let phase = match phase {
+            0 => PointerPhase::Press,
+            1 => PointerPhase::Drag,
+            2 => PointerPhase::Release,
+            _ => return,
+        };
+        input.borrow_mut().pointer_events.push(ScreenPointerEvent {
+            position: RenderPoint::new(x, y),
+            phase,
+        });
     });
 }
 
@@ -154,6 +175,20 @@ impl ClientInput {
     pub(crate) fn clear(&mut self) {
         self.pressed.clear();
         self.released.clear();
+        self.pointer_events.clear();
+    }
+
+    pub(crate) fn take_pointer_events(&mut self) -> Vec<ScreenPointerEvent> {
+        std::mem::take(&mut self.pointer_events)
+    }
+
+    pub(crate) fn discard_pointer_events(&mut self) {
+        self.pointer_events.clear();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn push_pointer_event(&mut self, event: ScreenPointerEvent) {
+        self.pointer_events.push(event);
     }
 
     pub(crate) fn press(&mut self, key: GameKey) {

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -1,8 +1,9 @@
-//! Spacewars client: Slint UI + custom drawing + input + audio + scenario host.
+//! Scenario client: Slint UI, input, rendering, settings, and scenario host.
 //!
-//! M9 state: opens a Slint window, loads/saves user settings, hosts null or
-//! Spacewars scenarios, and renders their `RenderFrame`s.
+//! The compile-time registry currently hosts Pizza and Spacewars from the
+//! launcher, with Null retained as a hidden test scenario.
 
+mod client_scenarios;
 mod host;
 mod input;
 mod ipc;
@@ -18,12 +19,14 @@ use std::sync::{Arc, RwLock};
 
 use clap::{Parser, ValueEnum};
 use engine_common::{
-    CrashBehavior, MAX_SPACEWARS_ASTEROID_PROBABILITY_PER_SEC, MAX_SPACEWARS_PLAYER_HEALTH_PERCENT,
-    MAX_SPACEWARS_PLAYER_VIEW_HEIGHT, MAX_SPACEWARS_UNIVERSE_RADIUS,
+    CrashBehavior, MAX_PIZZA_BALL_SPAWN_RATE, MAX_PIZZA_DESIRED_BALLS,
+    MAX_SPACEWARS_ASTEROID_PROBABILITY_PER_SEC, MAX_SPACEWARS_PLAYER_HEALTH_PERCENT,
+    MAX_SPACEWARS_PLAYER_VIEW_HEIGHT, MAX_SPACEWARS_UNIVERSE_RADIUS, MIN_PIZZA_BALL_SPAWN_RATE,
     MIN_SPACEWARS_ASTEROID_PROBABILITY_PER_SEC, MIN_SPACEWARS_PLAYER_HEALTH_PERCENT,
-    MIN_SPACEWARS_PLAYER_VIEW_HEIGHT, MIN_SPACEWARS_UNIVERSE_RADIUS, RendererSetting, Settings,
-    SpacewarsSettings,
+    MIN_SPACEWARS_PLAYER_VIEW_HEIGHT, MIN_SPACEWARS_UNIVERSE_RADIUS, PizzaSettings,
+    RendererSetting, Settings, SpacewarsSettings,
 };
+#[cfg(test)]
 use engine_core::SpacewarsConfig;
 use settings::LoadStatus;
 use slint::{ComponentHandle, ModelRc, SharedString, Timer, VecModel};
@@ -168,13 +171,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     log_settings_load_status(&settings_path, &loaded_settings.status);
     needs_writeback |= normalize_launch_settings(&mut loaded);
     needs_writeback |= normalize_spacewars_settings(&mut loaded);
+    needs_writeback |= normalize_pizza_settings(&mut loaded);
     let effective_launch = effective_launch_options(&args, &loaded);
 
     if !args.uses_debug_render() {
         host::validate_scenario(effective_launch.scenario.as_str())?;
     }
-    if args.uses_benchmark() && effective_launch.scenario != "spacewars" {
-        return Err("benchmark mode currently supports only the spacewars scenario".into());
+    if args.uses_benchmark()
+        && !host::scenario_registration(effective_launch.scenario.as_str())
+            .is_some_and(|registration| registration.capabilities.benchmark)
+    {
+        return Err(format!(
+            "scenario {:?} does not support benchmark mode",
+            effective_launch.scenario
+        )
+        .into());
     }
     tracing::info!(
         path = %settings_path.display(),
@@ -244,20 +255,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             effective_launch.renderer,
         ));
     } else if launch_directly {
-        let spacewars_config = spacewars_config_from_settings(&settings.read().unwrap());
+        let scenario_settings = settings.read().unwrap().clone();
         *render_timer.borrow_mut() = Some(start_scenario_from_launch(
             &window,
             &effective_launch,
             args.benchmark,
             Rc::clone(&scenario_controls),
-            spacewars_config,
+            scenario_settings,
         )?);
     } else {
-        show_launcher(
-            &window,
-            &effective_launch,
-            &settings.read().unwrap().spacewars,
-        );
+        show_launcher(&window, &effective_launch, &settings.read().unwrap());
     }
 
     window.run()?;
@@ -289,9 +296,10 @@ fn effective_launch_options(args: &Args, settings: &Settings) -> EffectiveLaunch
 fn normalize_launch_settings(settings: &mut Settings) -> bool {
     let mut changed = false;
 
-    if settings.launch.scenario.trim().is_empty()
-        || !host::is_known_scenario(settings.launch.scenario.as_str())
-    {
+    let saved_scenario_is_launchable =
+        host::scenario_registration(settings.launch.scenario.as_str())
+            .is_some_and(|registration| registration.launcher_visible);
+    if settings.launch.scenario.trim().is_empty() || !saved_scenario_is_launchable {
         tracing::warn!(
             scenario = %settings.launch.scenario,
             "invalid saved launch scenario; falling back to spacewars."
@@ -337,6 +345,22 @@ fn normalize_spacewars_settings(settings: &mut Settings) -> bool {
     true
 }
 
+fn normalize_pizza_settings(settings: &mut Settings) -> bool {
+    let normalized = settings.pizza.normalized();
+    if normalized == settings.pizza {
+        return false;
+    }
+    tracing::warn!(
+        desired_balls = settings.pizza.desired_balls,
+        normalized_desired_balls = normalized.desired_balls,
+        ball_spawn_rate = settings.pizza.ball_spawn_rate,
+        normalized_ball_spawn_rate = normalized.ball_spawn_rate,
+        "invalid Pizza setup; using normalized values."
+    );
+    settings.pizza = normalized;
+    true
+}
+
 fn normalize_raster_scale(value: f32) -> f32 {
     if value.is_finite() {
         value.clamp(MIN_RASTER_SCALE, MAX_RASTER_SCALE)
@@ -349,20 +373,27 @@ fn should_launch_directly(args: &Args) -> bool {
     args.uses_debug_render() || args.uses_benchmark() || args.has_launch_override()
 }
 
-fn show_launcher(window: &MainWindow, launch: &EffectiveLaunch, setup: &SpacewarsSettings) {
+fn show_launcher(window: &MainWindow, launch: &EffectiveLaunch, settings: &Settings) {
     window.set_primitives(ModelRc::new(VecModel::from(Vec::<ScenePrimitive>::new())));
     window.set_vector_minimaps_visible(false);
     window.set_raster_visible(false);
     window.set_spacewars_ui_visible(false);
+    window.set_scenario_pointer_enabled(false);
     window.set_ingame_menu_visible(false);
     window.set_ingame_controls_visible(false);
+    let scenario_names = host::launcher_scenario_names()
+        .into_iter()
+        .map(SharedString::from)
+        .collect::<Vec<_>>();
+    window.set_launcher_scenarios(ModelRc::new(VecModel::from(scenario_names)));
     window.set_launcher_scenario(SharedString::from(launch.scenario.clone()));
+    apply_scenario_metadata(window, launch.scenario.as_str());
     window.set_launcher_seed_text(SharedString::from(launch.seed.to_string()));
     window.set_launcher_renderer(SharedString::from(renderer_label(launch.renderer)));
     window.set_launcher_raster_scale_text(SharedString::from(format_raster_scale(
         launch.raster_scale,
     )));
-    let setup = setup.normalized();
+    let setup = settings.spacewars.normalized();
     window.set_launcher_spacewars_preset(SharedString::from(preset_label_for_setup(&setup)));
     window.set_launcher_universe_radius_text(SharedString::from(setup.universe_radius.to_string()));
     window.set_launcher_use_planets(SharedString::from(bool_label(setup.use_planets)));
@@ -373,9 +404,27 @@ fn show_launcher(window: &MainWindow, launch: &EffectiveLaunch, setup: &Spacewar
     window.set_launcher_player_health_text(SharedString::from(
         setup.player_health_percent.to_string(),
     ));
+    let pizza = settings.pizza.normalized();
+    window
+        .set_launcher_pizza_desired_balls_text(SharedString::from(pizza.desired_balls.to_string()));
+    window.set_launcher_pizza_spawn_rate_text(SharedString::from(format_float_setting(
+        pizza.ball_spawn_rate,
+    )));
     window.set_launcher_error_text(SharedString::from(""));
     window.set_launcher_controls_visible(false);
     window.set_launcher_visible(true);
+}
+
+fn apply_scenario_metadata(window: &MainWindow, scenario: &str) {
+    let Some(registration) = host::scenario_registration(scenario) else {
+        window.set_scenario_benchmark_available(false);
+        window.set_scenario_player_zoom_available(false);
+        window.set_scenario_controls_help(SharedString::from(""));
+        return;
+    };
+    window.set_scenario_benchmark_available(registration.capabilities.benchmark);
+    window.set_scenario_player_zoom_available(registration.capabilities.player_zoom);
+    window.set_scenario_controls_help(SharedString::from(registration.controls_help));
 }
 
 fn save_startup_settings_if_needed(
@@ -449,6 +498,14 @@ fn install_launcher_callbacks(
             &settings_path,
             true,
         );
+    });
+
+    let weak = window.as_weak();
+    window.on_launcher_scenario_selected(move |scenario| {
+        let Some(window) = weak.upgrade() else {
+            return;
+        };
+        apply_scenario_metadata(&window, scenario.as_str());
     });
 
     let weak = window.as_weak();
@@ -546,7 +603,7 @@ fn handle_return_to_launcher(
     scenario_controls.borrow_mut().clear();
     let settings = settings.read().unwrap();
     let launch = launch_from_settings(&settings);
-    show_launcher(&window, &launch, &settings.spacewars);
+    show_launcher(&window, &launch, &settings);
 }
 
 fn handle_launcher_apply_preset(weak_window: &slint::Weak<MainWindow>) {
@@ -623,16 +680,20 @@ fn handle_launcher_start(
     };
     window.set_launcher_error_text(SharedString::from(""));
 
-    let selections = match launcher_selections_from_window(&window) {
+    let current_settings = settings.read().unwrap().clone();
+    let selections = match launcher_selections_from_window(&window, &current_settings) {
         Ok(selections) => selections,
         Err(message) => {
             window.set_launcher_error_text(SharedString::from(message));
             return;
         }
     };
-    if start_benchmark && selections.launch.scenario != "spacewars" {
+    if start_benchmark
+        && !host::scenario_registration(selections.launch.scenario.as_str())
+            .is_some_and(|registration| registration.capabilities.benchmark)
+    {
         window.set_launcher_error_text(SharedString::from(
-            "Benchmark mode currently supports only spacewars.",
+            "The selected scenario does not support benchmark mode.",
         ));
         return;
     }
@@ -642,14 +703,14 @@ fn handle_launcher_start(
         )));
         return;
     }
-    let spacewars_config = spacewars_config_from_settings(&settings.read().unwrap());
+    let scenario_settings = settings.read().unwrap().clone();
 
     match start_scenario_from_launch(
         &window,
         &selections.launch,
         start_benchmark,
         Rc::clone(scenario_controls),
-        spacewars_config,
+        scenario_settings,
     ) {
         Ok(timer) => {
             let mut timer_slot = render_timer.borrow_mut();
@@ -673,6 +734,7 @@ fn handle_launcher_start(
 struct LauncherSelections {
     launch: EffectiveLaunch,
     spacewars: SpacewarsSettings,
+    pizza: PizzaSettings,
 }
 
 fn persist_launcher_settings(
@@ -685,6 +747,7 @@ fn persist_launcher_settings(
     let renderer = renderer_setting(launch.renderer);
     let raster_scale = normalize_raster_scale(launch.raster_scale);
     let spacewars = selections.spacewars.normalized();
+    let pizza = selections.pizza.normalized();
     let mut changed = false;
 
     if settings.launch.scenario != launch.scenario {
@@ -711,6 +774,10 @@ fn persist_launcher_settings(
         settings.spacewars = spacewars;
         changed = true;
     }
+    if settings.pizza != pizza {
+        settings.pizza = pizza;
+        changed = true;
+    }
 
     if changed {
         settings::save_settings(&settings, settings_path)?;
@@ -729,10 +796,12 @@ fn launch_from_settings(settings: &Settings) -> EffectiveLaunch {
     }
 }
 
+#[cfg(test)]
 fn spacewars_config_from_settings(settings: &Settings) -> SpacewarsConfig {
     spacewars_config_from_setup(&settings.spacewars.normalized())
 }
 
+#[cfg(test)]
 fn spacewars_config_from_setup(setup: &SpacewarsSettings) -> SpacewarsConfig {
     let mut config = SpacewarsConfig {
         universe_radius: setup.universe_radius,
@@ -836,10 +905,29 @@ fn long_game_spacewars_preset() -> SpacewarsSettings {
     }
 }
 
-fn launcher_selections_from_window(window: &MainWindow) -> Result<LauncherSelections, String> {
+fn launcher_selections_from_window(
+    window: &MainWindow,
+    current_settings: &Settings,
+) -> Result<LauncherSelections, String> {
+    let launch = launch_options_from_window(window)?;
+    let (spacewars, pizza) = match launch.scenario.as_str() {
+        "spacewars" => (
+            spacewars_setup_from_window(window)?,
+            current_settings.pizza.clone(),
+        ),
+        "pizza" => (
+            current_settings.spacewars.clone(),
+            pizza_setup_from_window(window)?,
+        ),
+        _ => (
+            current_settings.spacewars.clone(),
+            current_settings.pizza.clone(),
+        ),
+    };
     Ok(LauncherSelections {
-        launch: launch_options_from_window(window)?,
-        spacewars: spacewars_setup_from_window(window)?,
+        launch,
+        spacewars,
+        pizza,
     })
 }
 
@@ -861,6 +949,13 @@ fn spacewars_setup_from_window(window: &MainWindow) -> Result<SpacewarsSettings,
         window.get_launcher_player_health_text().as_str(),
         window.get_launcher_p1_zoom_text().as_str(),
         window.get_launcher_p2_zoom_text().as_str(),
+    )
+}
+
+fn pizza_setup_from_window(window: &MainWindow) -> Result<PizzaSettings, String> {
+    pizza_setup_from_values(
+        window.get_launcher_pizza_desired_balls_text().as_str(),
+        window.get_launcher_pizza_spawn_rate_text().as_str(),
     )
 }
 
@@ -941,6 +1036,26 @@ fn spacewars_setup_from_values(
     Ok(setup.normalized())
 }
 
+fn pizza_setup_from_values(
+    desired_balls: &str,
+    ball_spawn_rate: &str,
+) -> Result<PizzaSettings, String> {
+    Ok(PizzaSettings {
+        desired_balls: parse_u32_setting(
+            desired_balls,
+            "Desired balls",
+            0,
+            MAX_PIZZA_DESIRED_BALLS,
+        )?,
+        ball_spawn_rate: parse_f32_setting(
+            ball_spawn_rate,
+            "Spawn rate",
+            MIN_PIZZA_BALL_SPAWN_RATE,
+            MAX_PIZZA_BALL_SPAWN_RATE,
+        )?,
+    })
+}
+
 fn parse_u32_setting(value: &str, label: &str, min: u32, max: u32) -> Result<u32, String> {
     value
         .trim()
@@ -991,9 +1106,10 @@ fn start_scenario_from_launch(
     launch: &EffectiveLaunch,
     start_benchmark: bool,
     controls: host::SharedScenarioControls,
-    spacewars_config: SpacewarsConfig,
+    settings: Settings,
 ) -> Result<Timer, host::HostError> {
     controls.borrow_mut().clear();
+    apply_scenario_metadata(window, launch.scenario.as_str());
     host::start_scenario_loop(
         window,
         launch.scenario.as_str(),
@@ -1003,7 +1119,7 @@ fn start_scenario_from_launch(
             renderer: launch.renderer,
             raster_scale: launch.raster_scale,
             controls: Some(controls),
-            spacewars_config,
+            settings,
         },
     )
 }
@@ -1436,6 +1552,10 @@ mod tests {
                 player_1_view_height: 420.0,
                 player_2_view_height: 640.0,
             },
+            pizza: PizzaSettings {
+                desired_balls: 321,
+                ball_spawn_rate: 0.42,
+            },
         };
 
         assert!(persist_launcher_settings(&settings, &path, &selections).unwrap());
@@ -1447,6 +1567,7 @@ mod tests {
         assert_eq!(stored.launch.renderer, RendererSetting::Raster);
         assert_eq!(stored.launch.raster_scale, 2.0);
         assert_eq!(stored.spacewars, selections.spacewars);
+        assert_eq!(stored.pizza, selections.pizza);
         assert_eq!(stored.last_scenario.as_deref(), Some("spacewars"));
         drop(stored);
 
@@ -1456,6 +1577,7 @@ mod tests {
         assert_eq!(reloaded.settings.launch.renderer, RendererSetting::Raster);
         assert_eq!(reloaded.settings.launch.raster_scale, 2.0);
         assert_eq!(reloaded.settings.spacewars, selections.spacewars);
+        assert_eq!(reloaded.settings.pizza, selections.pizza);
         assert_eq!(
             reloaded.settings.last_scenario.as_deref(),
             Some("spacewars")
@@ -1549,6 +1671,41 @@ mod tests {
         );
 
         assert!(!normalize_spacewars_settings(&mut settings));
+    }
+
+    #[test]
+    fn pizza_settings_normalization_clamps_saved_values() {
+        let mut settings = Settings::default();
+        settings.pizza.desired_balls = MAX_PIZZA_DESIRED_BALLS + 1;
+        settings.pizza.ball_spawn_rate = f32::NAN;
+
+        assert!(normalize_pizza_settings(&mut settings));
+        assert_eq!(settings.pizza.desired_balls, MAX_PIZZA_DESIRED_BALLS);
+        assert_eq!(
+            settings.pizza.ball_spawn_rate,
+            engine_common::DEFAULT_PIZZA_BALL_SPAWN_RATE
+        );
+        assert!(!normalize_pizza_settings(&mut settings));
+    }
+
+    #[test]
+    fn pizza_setup_values_parse_and_validate_caps() {
+        assert_eq!(
+            pizza_setup_from_values("321", "0.42").unwrap(),
+            PizzaSettings {
+                desired_balls: 321,
+                ball_spawn_rate: 0.42,
+            }
+        );
+        assert_eq!(
+            pizza_setup_from_values("501", "1.0").unwrap(),
+            PizzaSettings {
+                desired_balls: MAX_PIZZA_DESIRED_BALLS,
+                ball_spawn_rate: MAX_PIZZA_BALL_SPAWN_RATE,
+            }
+        );
+        assert!(pizza_setup_from_values("many", "0.42").is_err());
+        assert!(pizza_setup_from_values("24", "often").is_err());
     }
 
     #[test]

--- a/crates/engine-client/src/render.rs
+++ b/crates/engine-client/src/render.rs
@@ -9,8 +9,8 @@ use std::fmt::Write as _;
 use std::time::Duration;
 
 use engine_common::{
-    Camera2, Fill, RenderCircle, RenderColor, RenderFrame, RenderLine, RenderPoint, RenderPolygon,
-    RenderPrimitive, RenderText, Stroke, TextAnchor,
+    Camera2, Fill, PointerAction, PointerPhase, RenderCircle, RenderColor, RenderFrame, RenderLine,
+    RenderPoint, RenderPolygon, RenderPrimitive, RenderText, Stroke, TextAnchor,
 };
 use slint::{Brush, Color, SharedString};
 
@@ -56,6 +56,12 @@ pub struct VectorMinimap {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FrameProjection {
+    pub viewport: Viewport,
+    pub camera: Camera2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Viewport {
     pub x: f32,
     pub y: f32,
@@ -87,6 +93,13 @@ impl Viewport {
 
     pub fn aspect_ratio(self) -> f32 {
         self.width / self.height
+    }
+
+    pub fn contains(self, point: RenderPoint) -> bool {
+        point.x >= self.x
+            && point.x <= self.x + self.width
+            && point.y >= self.y
+            && point.y <= self.y + self.height
     }
 
     pub fn split_horizontally(self, count: usize) -> Vec<Self> {
@@ -225,6 +238,46 @@ pub(crate) fn frame_viewports(
             viewports
         }
     }
+}
+
+pub(crate) fn frame_projections(
+    frames: &[RenderFrame],
+    viewport: Viewport,
+    layout: FrameLayout,
+) -> Vec<FrameProjection> {
+    frames
+        .iter()
+        .zip(frame_viewports(viewport, frames.len(), layout))
+        .map(|(frame, viewport)| FrameProjection {
+            viewport,
+            camera: frame.camera,
+        })
+        .collect()
+}
+
+pub(crate) fn unproject_pointer(
+    projections: &[FrameProjection],
+    screen_position: RenderPoint,
+    phase: PointerPhase,
+) -> Option<PointerAction> {
+    let projection = projections
+        .iter()
+        .rev()
+        .find(|projection| projection.viewport.contains(screen_position))?;
+    let viewport = projection.viewport;
+    if viewport.width <= 0.0 || viewport.height <= 0.0 {
+        return None;
+    }
+    let normalized = RenderPoint::new(
+        (screen_position.x - viewport.x) / viewport.width,
+        (screen_position.y - viewport.y) / viewport.height,
+    );
+    Some(PointerAction {
+        position: projection
+            .camera
+            .viewport_to_world(normalized, viewport.aspect_ratio()),
+        phase,
+    })
 }
 
 /// Convert a scenario frame into ordered Slint scene primitives.
@@ -679,6 +732,64 @@ mod tests {
         let bottom_right = project_point(camera, viewport, RenderPoint::new(100.0, -50.0));
         assert_close(bottom_right.x, 200.0);
         assert_close(bottom_right.y, 100.0);
+    }
+
+    #[test]
+    fn pointer_unprojection_uses_the_matching_frame_camera() {
+        let projection = FrameProjection {
+            viewport: Viewport::with_origin(50.0, 25.0, 200.0, 100.0),
+            camera: Camera2::new(RenderPoint::new(10.0, 20.0), 100.0),
+        };
+
+        let center = unproject_pointer(
+            &[projection],
+            RenderPoint::new(150.0, 75.0),
+            PointerPhase::Drag,
+        )
+        .unwrap();
+        assert_close(center.position.x, 10.0);
+        assert_close(center.position.y, 20.0);
+        assert_eq!(center.phase, PointerPhase::Drag);
+
+        let top_left = unproject_pointer(
+            &[projection],
+            RenderPoint::new(50.0, 25.0),
+            PointerPhase::Press,
+        )
+        .unwrap();
+        assert_close(top_left.position.x, -90.0);
+        assert_close(top_left.position.y, 70.0);
+        assert!(
+            unproject_pointer(
+                &[projection],
+                RenderPoint::new(49.0, 25.0),
+                PointerPhase::Release,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn pointer_unprojection_prefers_the_topmost_overlapping_frame() {
+        let viewport = Viewport::new(100.0, 100.0);
+        let projections = [
+            FrameProjection {
+                viewport,
+                camera: Camera2::new(RenderPoint::ZERO, 100.0),
+            },
+            FrameProjection {
+                viewport,
+                camera: Camera2::new(RenderPoint::new(200.0, 300.0), 20.0),
+            },
+        ];
+
+        let pointer = unproject_pointer(
+            &projections,
+            RenderPoint::new(50.0, 50.0),
+            PointerPhase::Press,
+        )
+        .unwrap();
+        assert_eq!(pointer.position, RenderPoint::new(200.0, 300.0));
     }
 
     #[test]

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -248,6 +248,10 @@ export component MainWindow inherits Window {
         mouse-cursor: crosshair;
 
         pointer-event(event) => {
+            if (event.kind == PointerEventKind.cancel) {
+                root.scenario-pointer(self.mouse-x / 1px, self.mouse-y / 1px, 3);
+                return;
+            }
             if (event.button != PointerEventButton.left) {
                 return;
             }

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -128,10 +128,12 @@ export component MainWindow inherits Window {
     in property <length> p2-minimap-size: 0px;
     in property <bool> raster-visible: false;
     in property <image> raster-frame;
+    in property <bool> scenario-pointer-enabled: false;
     in-out property <bool> launcher-visible: false;
     in-out property <bool> launcher-controls-visible: false;
     in-out property <bool> ingame-menu-visible: false;
     in-out property <bool> ingame-controls-visible: false;
+    in property <[string]> launcher-scenarios;
     in-out property <string> launcher-scenario: "spacewars";
     in-out property <string> launcher-seed-text: "0";
     in-out property <string> launcher-renderer: "vector";
@@ -144,7 +146,12 @@ export component MainWindow inherits Window {
     in-out property <string> launcher-player-health-text: "100";
     in-out property <string> launcher-p1-zoom-text: "320";
     in-out property <string> launcher-p2-zoom-text: "320";
+    in-out property <string> launcher-pizza-desired-balls-text: "24";
+    in-out property <string> launcher-pizza-spawn-rate-text: "0.10";
     in property <string> launcher-error-text: "";
+    in property <bool> scenario-benchmark-available: false;
+    in property <bool> scenario-player-zoom-available: false;
+    in property <string> scenario-controls-help: "";
     in property <bool> spacewars-ui-visible: false;
     in property <string> p1-name: "";
     in property <string> p1-status: "";
@@ -170,6 +177,7 @@ export component MainWindow inherits Window {
     callback launcher-p1-zoom-out();
     callback launcher-p2-zoom-in();
     callback launcher-p2-zoom-out();
+    callback launcher-scenario-selected(string);
     callback launcher-quit();
     callback ingame-resume();
     callback ingame-restart();
@@ -179,6 +187,7 @@ export component MainWindow inherits Window {
     callback ingame-p1-zoom-out();
     callback ingame-p2-zoom-in();
     callback ingame-p2-zoom-out();
+    callback scenario-pointer(float, float, int);
 
     forward-focus: launcher-shortcuts;
 
@@ -230,6 +239,30 @@ export component MainWindow inherits Window {
         height: root.p2-minimap-size;
         opacity: root.minimap-opacity;
         primitives: root.p2-minimap-primitives;
+    }
+
+    scenario-pointer-area := TouchArea {
+        enabled: root.scenario-pointer-enabled && !root.launcher-visible && !root.ingame-menu-visible;
+        width: parent.width;
+        height: parent.height;
+        mouse-cursor: crosshair;
+
+        pointer-event(event) => {
+            if (event.button != PointerEventButton.left) {
+                return;
+            }
+            if (event.kind == PointerEventKind.down) {
+                root.scenario-pointer(self.mouse-x / 1px, self.mouse-y / 1px, 0);
+            } else if (event.kind == PointerEventKind.up) {
+                root.scenario-pointer(self.mouse-x / 1px, self.mouse-y / 1px, 2);
+            }
+        }
+
+        moved => {
+            if (self.pressed) {
+                root.scenario-pointer(self.mouse-x / 1px, self.mouse-y / 1px, 1);
+            }
+        }
     }
 
     Rectangle {
@@ -416,13 +449,15 @@ export component MainWindow inherits Window {
                     x: 0px;
                     y: 0px;
                     width: parent.width;
-                    text: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon";
+                    height: 132px;
+                    text: root.scenario-controls-help;
                     color: #e6edf7;
                     font-size: 13px;
                     wrap: word-wrap;
                 }
 
                 Text {
+                    visible: false;
                     x: 0px;
                     y: 54px;
                     width: parent.width;
@@ -433,6 +468,7 @@ export component MainWindow inherits Window {
                 }
 
                 Text {
+                    visible: root.scenario-player-zoom-available;
                     x: 0px;
                     y: 126px;
                     width: parent.width;
@@ -443,6 +479,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 0px;
                     y: 154px;
                     width: 104px;
@@ -454,6 +491,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 114px;
                     y: 154px;
                     width: 104px;
@@ -465,6 +503,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 228px;
                     y: 154px;
                     width: 104px;
@@ -476,6 +515,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 342px;
                     y: 154px;
                     width: 104px;
@@ -490,7 +530,7 @@ export component MainWindow inherits Window {
                     x: 0px;
                     y: 214px;
                     width: parent.width;
-                    text: "Global: P/Esc pause/resume, R restart, B benchmark, Q launcher, C or F1 controls/back. Losing window focus clears held keys.";
+                    text: "Global: P/Esc pause/resume, R restart, " + (root.scenario-benchmark-available ? "B benchmark, " : "") + "Q launcher, C or F1 controls/back. Losing window focus clears held input.";
                     color: #c7d0dc;
                     font-size: 13px;
                     wrap: word-wrap;
@@ -523,7 +563,7 @@ export component MainWindow inherits Window {
             }
 
             Button {
-                visible: !root.ingame-controls-visible;
+                visible: !root.ingame-controls-visible && root.scenario-benchmark-available;
                 x: 354px;
                 y: 106px;
                 width: 160px;
@@ -620,7 +660,7 @@ export component MainWindow inherits Window {
                 return reject;
             }
 
-            if (seed-edit.has-focus || universe-radius-edit.has-focus || asteroid-rate-edit.has-focus || player-health-edit.has-focus) {
+            if (seed-edit.has-focus || universe-radius-edit.has-focus || asteroid-rate-edit.has-focus || player-health-edit.has-focus || pizza-balls-edit.has-focus || pizza-spawn-rate-edit.has-focus) {
                 return reject;
             }
 
@@ -647,7 +687,7 @@ export component MainWindow inherits Window {
                 x: (parent.width - self.width) / 2;
                 y: (parent.height - self.height) / 2;
                 width: root.launcher-controls-visible ? 500px : 580px;
-                height: root.launcher-controls-visible ? 540px : 710px;
+                height: root.launcher-controls-visible ? 540px : root.launcher-scenario == "pizza" ? 560px : 710px;
                 background: #080a12f2;
                 border-color: #596273;
                 border-width: 1px;
@@ -690,8 +730,11 @@ export component MainWindow inherits Window {
 
                     ComboBox {
                         horizontal-stretch: 1;
-                        model: ["spacewars", "null"];
+                        model: root.launcher-scenarios;
                         current-value <=> root.launcher-scenario;
+                        selected(value) => {
+                            root.launcher-scenario-selected(value);
+                        }
                     }
                 }
 
@@ -756,15 +799,17 @@ export component MainWindow inherits Window {
                 }
 
                 Text {
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 22px : 0px;
                     text: "Game Setup";
                     color: #e6edf7;
                     font-size: 13px;
-                    height: 22px;
                     vertical-alignment: bottom;
                 }
 
                 HorizontalLayout {
-                    height: 34px;
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
                     spacing: 10px;
 
                     Text {
@@ -791,7 +836,8 @@ export component MainWindow inherits Window {
                 }
 
                 HorizontalLayout {
-                    height: 34px;
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
                     spacing: 10px;
 
                     Text {
@@ -813,7 +859,8 @@ export component MainWindow inherits Window {
                 }
 
                 HorizontalLayout {
-                    height: 34px;
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
                     spacing: 10px;
 
                     Text {
@@ -832,7 +879,8 @@ export component MainWindow inherits Window {
                 }
 
                 HorizontalLayout {
-                    height: 34px;
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
                     spacing: 10px;
 
                     Text {
@@ -851,7 +899,8 @@ export component MainWindow inherits Window {
                 }
 
                 HorizontalLayout {
-                    height: 34px;
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
                     spacing: 10px;
 
                     Text {
@@ -873,7 +922,8 @@ export component MainWindow inherits Window {
                 }
 
                 HorizontalLayout {
-                    height: 34px;
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
                     spacing: 10px;
 
                     Text {
@@ -895,17 +945,82 @@ export component MainWindow inherits Window {
                 }
 
                 Text {
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 16px : 0px;
                     text: "Setup: " + root.launcher-spacewars-preset + " | radius " + root.launcher-universe-radius-text + " | health " + root.launcher-player-health-text + "%";
                     color: #c7d0dc;
                     font-size: 12px;
-                    height: 16px;
                 }
 
                 Text {
+                    visible: root.launcher-scenario == "spacewars";
+                    height: root.launcher-scenario == "spacewars" ? 16px : 0px;
                     text: "Planets " + root.launcher-use-planets + " | asteroids " + root.launcher-asteroids-enabled + " @ " + root.launcher-asteroid-probability-text + "/s";
                     color: #c7d0dc;
                     font-size: 12px;
-                    height: 16px;
+                }
+
+                Text {
+                    visible: root.launcher-scenario == "pizza";
+                    height: root.launcher-scenario == "pizza" ? 22px : 0px;
+                    text: "Pizza Setup";
+                    color: #e6edf7;
+                    font-size: 13px;
+                    vertical-alignment: bottom;
+                }
+
+                HorizontalLayout {
+                    visible: root.launcher-scenario == "pizza";
+                    height: root.launcher-scenario == "pizza" ? 34px : 0px;
+                    spacing: 10px;
+
+                    Text {
+                        text: "Desired Balls";
+                        color: #c7d0dc;
+                        font-size: 13px;
+                        vertical-alignment: center;
+                        width: 150px;
+                    }
+
+                    pizza-balls-edit := LineEdit {
+                        horizontal-stretch: 1;
+                        text <=> root.launcher-pizza-desired-balls-text;
+                        placeholder-text: "24";
+                        accepted => {
+                            root.launcher-start-game();
+                        }
+                    }
+                }
+
+                HorizontalLayout {
+                    visible: root.launcher-scenario == "pizza";
+                    height: root.launcher-scenario == "pizza" ? 34px : 0px;
+                    spacing: 10px;
+
+                    Text {
+                        text: "Spawn Rate";
+                        color: #c7d0dc;
+                        font-size: 13px;
+                        vertical-alignment: center;
+                        width: 150px;
+                    }
+
+                    pizza-spawn-rate-edit := LineEdit {
+                        horizontal-stretch: 1;
+                        text <=> root.launcher-pizza-spawn-rate-text;
+                        placeholder-text: "0.10";
+                        accepted => {
+                            root.launcher-start-game();
+                        }
+                    }
+                }
+
+                Text {
+                    visible: root.launcher-scenario == "pizza";
+                    height: root.launcher-scenario == "pizza" ? 16px : 0px;
+                    text: "Spawns up to " + root.launcher-pizza-desired-balls-text + " balls at " + root.launcher-pizza-spawn-rate-text + " chance/tick.";
+                    color: #c7d0dc;
+                    font-size: 12px;
                 }
 
                 Text {
@@ -929,6 +1044,7 @@ export component MainWindow inherits Window {
                     }
 
                     Button {
+                        visible: root.scenario-benchmark-available;
                         width: 150px;
                         text: "Benchmark (B)";
                         clicked => {
@@ -980,13 +1096,15 @@ export component MainWindow inherits Window {
                     x: 0px;
                     y: 0px;
                     width: parent.width;
-                    text: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon";
+                    height: 132px;
+                    text: root.scenario-controls-help;
                     color: #e6edf7;
                     font-size: 13px;
                     wrap: word-wrap;
                 }
 
                 Text {
+                    visible: false;
                     x: 0px;
                     y: 54px;
                     width: parent.width;
@@ -997,6 +1115,7 @@ export component MainWindow inherits Window {
                 }
 
                 Text {
+                    visible: root.scenario-player-zoom-available;
                     x: 0px;
                     y: 126px;
                     width: parent.width;
@@ -1007,6 +1126,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 0px;
                     y: 154px;
                     width: 104px;
@@ -1018,6 +1138,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 114px;
                     y: 154px;
                     width: 104px;
@@ -1029,6 +1150,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 228px;
                     y: 154px;
                     width: 104px;
@@ -1040,6 +1162,7 @@ export component MainWindow inherits Window {
                 }
 
                 Button {
+                    visible: root.scenario-player-zoom-available;
                     x: 342px;
                     y: 154px;
                     width: 104px;

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -55,12 +55,34 @@ pub struct StepResult {
 
 // -- Actions & observations ---------------------------------------------------
 
-/// A player or agent action. Per-scenario schemas extend this via the `kind`
-/// discriminant and scenario-local wrappers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Action {
-    pub kind: u32,
-    pub payload: Vec<u8>,
+/// A player, pointer, or agent action.
+///
+/// Scenario-specific actions retain the compact discriminant/payload shape.
+/// Pointer input is shared so clients can unproject it once without teaching
+/// simulations about window-system events.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Action {
+    Scenario { kind: u32, payload: Vec<u8> },
+    Pointer(PointerAction),
+}
+
+impl Action {
+    pub fn scenario(kind: u32, payload: Vec<u8>) -> Self {
+        Self::Scenario { kind, payload }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PointerAction {
+    pub position: RenderPoint,
+    pub phase: PointerPhase,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PointerPhase {
+    Press,
+    Drag,
+    Release,
 }
 
 /// What a scenario hands to an agent each tick. Shape is per-scenario; the
@@ -100,6 +122,7 @@ pub struct Settings {
     pub controls: ControlBindings,
     pub launch: LaunchSettings,
     pub spacewars: SpacewarsSettings,
+    pub pizza: PizzaSettings,
     pub runtime: RuntimeSettings,
     pub last_scenario: Option<String>,
 }
@@ -659,6 +682,55 @@ fn normalize_spacewars_player_view_height(value: f32) -> f32 {
         )
     } else {
         DEFAULT_SPACEWARS_PLAYER_VIEW_HEIGHT
+    }
+}
+
+pub const DEFAULT_PIZZA_DESIRED_BALLS: u32 = 24;
+pub const MAX_PIZZA_DESIRED_BALLS: u32 = 500;
+pub const DEFAULT_PIZZA_BALL_SPAWN_RATE: f32 = 0.10;
+pub const MIN_PIZZA_BALL_SPAWN_RATE: f32 = 0.01;
+pub const MAX_PIZZA_BALL_SPAWN_RATE: f32 = 0.99;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PizzaSettings {
+    #[serde(default = "default_pizza_desired_balls")]
+    pub desired_balls: u32,
+    #[serde(default = "default_pizza_ball_spawn_rate")]
+    pub ball_spawn_rate: f32,
+}
+
+impl Default for PizzaSettings {
+    fn default() -> Self {
+        Self {
+            desired_balls: DEFAULT_PIZZA_DESIRED_BALLS,
+            ball_spawn_rate: DEFAULT_PIZZA_BALL_SPAWN_RATE,
+        }
+    }
+}
+
+impl PizzaSettings {
+    pub fn normalized(&self) -> Self {
+        Self {
+            desired_balls: self.desired_balls.min(MAX_PIZZA_DESIRED_BALLS),
+            ball_spawn_rate: normalize_pizza_ball_spawn_rate(self.ball_spawn_rate),
+        }
+    }
+}
+
+const fn default_pizza_desired_balls() -> u32 {
+    DEFAULT_PIZZA_DESIRED_BALLS
+}
+
+const fn default_pizza_ball_spawn_rate() -> f32 {
+    DEFAULT_PIZZA_BALL_SPAWN_RATE
+}
+
+fn normalize_pizza_ball_spawn_rate(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(MIN_PIZZA_BALL_SPAWN_RATE, MAX_PIZZA_BALL_SPAWN_RATE)
+    } else {
+        DEFAULT_PIZZA_BALL_SPAWN_RATE
     }
 }
 

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -83,6 +83,7 @@ pub enum PointerPhase {
     Press,
     Drag,
     Release,
+    Cancel,
 }
 
 /// What a scenario hands to an agent each tick. Shape is per-scenario; the

--- a/crates/engine-common/src/render.rs
+++ b/crates/engine-common/src/render.rs
@@ -122,6 +122,17 @@ impl Camera2 {
             (bounds.max.y - point.y) / height,
         )
     }
+
+    /// Convert normalized viewport coordinates back into world coordinates.
+    ///
+    /// The input uses `[0, 1]` coordinates with `(0, 0)` at the top left.
+    pub fn viewport_to_world(self, point: RenderPoint, aspect_ratio: f32) -> RenderPoint {
+        let bounds = self.world_bounds(aspect_ratio);
+        RenderPoint::new(
+            bounds.min.x + point.x * bounds.width(),
+            bounds.max.y - point.y * bounds.height(),
+        )
+    }
 }
 
 impl Default for Camera2 {

--- a/docs/design/reboot-rust-slint.md
+++ b/docs/design/reboot-rust-slint.md
@@ -285,6 +285,7 @@ Space-Wars/
 │   └── engine-sim-server/        # BINARY (Phase 2). Remote scenario host.
 ├── scenarios/
 │   ├── spacewars/                # 2008 arcade port. Uses engine-core.
+│   ├── pizza/                    # Interactive gravity/collision ball simulation.
 │   ├── clock/                    # Uses engine-core.
 │   ├── planetary/                # Uses engine-core.
 │   └── nes-<rom>/                # One per ROM. Uses engine-nes.
@@ -502,3 +503,14 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - M20e: Validate on Raspberry Pi 5 hardware with the raster renderer: confirm display backend startup, fullscreen behavior, keyboard input, settings writeback, quit/restart flow, and benchmark FPS at useful raster scales.
 - M20f: Wire crash/restart policy deliberately. The settings model already has `runtime.crash_behavior`; the Pi service should use `Reboot` or process restart behavior explicitly, while desktop/debug runs keep `Freeze`/`--dev` behavior.
 - Acceptance: a Pi image or manual Pi session can start Spacewars in fullscreen local-play mode with persistent settings, stable input, and a known renderer/backend configuration.
+
+### M21: Multiple-scenario framework + Pizza
+
+- Move the client from a Spacewars-specific host to a small compile-time scenario framework, then prove the boundary with a second interactive scenario. The JavaScript implementation in [`aortez.github.io`](https://github.com/aortez/aortez.github.io) is the living behavioral reference for Pizza.
+- M21a: ✅ Replace the hand-written hosted-scenario enum dispatch with an object-safe `ClientScenario` adapter and compile-time registry. Each adapter owns construction from settings, input mapping, frame layout, and optional capabilities. `null` remains hostable for tests but hidden from the launcher; `pizza` and `spacewars` are launcher-visible.
+- M21b: ✅ Add generic pointer actions with world-space position and press/drag/release phases. Slint captures pointer events over the render surface, and the client unprojects them through the matching frame viewport and camera before dispatch.
+- M21c: ✅ Add the deterministic `scenarios/pizza` core at a fixed 60 Hz: seeded capped spawning, containment, exact capped O(n²) gravity/collisions, mass-share overlap correction, 0.9 elasticity, impact damage, and fragment explosions.
+- M21d: ✅ Port Pizza interaction through the generic pointer path: press empty space to create and hold a ball, press an existing ball to grab it, rubber-band toward the cursor while held, and release to fling it.
+- M21e: ✅ Populate the launcher from the registry, show scenario-specific setup/help/capabilities, persist Pizza desired-count and spawn-rate settings through the existing safe write path, and allow either scenario to be selected and started without restarting the client.
+- Deliberately deferred: quadtree broad-phase collision lookup, Barnes–Hut gravity, particle optimization, and related telemetry. Those should follow the JavaScript optimization work only after this exact capped implementation supplies a correctness baseline and useful measurements.
+- Acceptance: the launcher lists Pizza and Spacewars; both can be selected and played in one process; and a future scenario requires a scenario crate, one client adapter, and one registry entry.

--- a/scenarios/pizza/Cargo.toml
+++ b/scenarios/pizza/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "scenario-pizza"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+engine-common = { workspace = true }
+engine-core = { workspace = true }
+rand = { workspace = true }

--- a/scenarios/pizza/src/lib.rs
+++ b/scenarios/pizza/src/lib.rs
@@ -1,0 +1,650 @@
+//! Deterministic Rust port of the allan.pizza ball simulation.
+//!
+//! This first pass intentionally uses exact O(n²) collision and gravity loops.
+//! The reference quadtree and Barnes-Hut optimizations remain a later,
+//! measurable replacement for these correctness-oriented paths.
+
+use std::time::Duration;
+
+use engine_common::{
+    Action, Camera2, Observation, PointerAction, PointerPhase, RenderCircle, RenderColor,
+    RenderFrame, RenderPoint, RenderPrimitive, Scenario, StepResult, Stroke, TickModel,
+};
+use engine_core::{Color, Vec2};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+pub const MAX_BALLS: usize = 500;
+pub const MIN_SPAWN_RATE: f32 = 0.01;
+pub const MAX_SPAWN_RATE: f32 = 0.99;
+
+const GRAVITY: f32 = 0.0005;
+const GRAVITY_SOFTENING: f32 = 0.000_001;
+const WALL_ELASTICITY: f32 = 0.9;
+const WALL_FUDGE: f32 = 0.000_01;
+const COLLISION_ELASTICITY: f32 = 0.9;
+const DAMAGE_SCALAR: f32 = 0.01;
+const MIN_BALL_RADIUS: f32 = 0.002;
+const MIN_FRAGMENT_RADIUS: f32 = 0.0002;
+const MAX_RANDOM_BALL_RADIUS: f32 = 0.08;
+const MIN_RANDOM_BALL_RADIUS: f32 = 0.01;
+const EXPLOSION_DIVISIONS: usize = 2;
+const EXPLOSION_VELOCITY_FACTOR: f32 = 0.1;
+const EXPLOSION_SIZE_FACTOR: f32 = 1.5;
+const EXPLOSION_PARENT_VELOCITY_FACTOR: f32 = 0.5;
+const CURSOR_FORCE: f32 = 0.05;
+const CURSOR_SMOOTHING: f32 = 0.80;
+const WORLD_TIME_SCALE: f32 = 0.9;
+const CURSOR_TIME_SCALE: f32 = 3.0;
+const BALL_LAYER: i32 = 0;
+
+pub struct PizzaScenario;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PizzaBounds {
+    pub width: f32,
+    pub height: f32,
+}
+
+impl PizzaBounds {
+    pub fn from_aspect_ratio(aspect_ratio: f32) -> Self {
+        let aspect_ratio = if aspect_ratio.is_finite() && aspect_ratio > 0.0 {
+            aspect_ratio
+        } else {
+            16.0 / 9.0
+        };
+        if aspect_ratio >= 1.0 {
+            Self {
+                width: 1.0,
+                height: 1.0 / aspect_ratio,
+            }
+        } else {
+            Self {
+                width: aspect_ratio,
+                height: 1.0,
+            }
+        }
+    }
+
+    fn center(self) -> Vec2 {
+        Vec2::new(self.width * 0.5, self.height * 0.5)
+    }
+}
+
+impl Default for PizzaBounds {
+    fn default() -> Self {
+        Self::from_aspect_ratio(16.0 / 9.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PizzaConfig {
+    pub desired_ball_count: usize,
+    pub ball_spawn_rate: f32,
+    pub bounds: PizzaBounds,
+}
+
+impl PizzaConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            desired_ball_count: self.desired_ball_count.min(MAX_BALLS),
+            ball_spawn_rate: if self.ball_spawn_rate.is_finite() {
+                self.ball_spawn_rate.clamp(MIN_SPAWN_RATE, MAX_SPAWN_RATE)
+            } else {
+                0.10
+            },
+            bounds: PizzaBounds::from_aspect_ratio(self.bounds.width / self.bounds.height),
+        }
+    }
+}
+
+impl Default for PizzaConfig {
+    fn default() -> Self {
+        Self {
+            desired_ball_count: 24,
+            ball_spawn_rate: 0.10,
+            bounds: PizzaBounds::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BallState {
+    pub id: u64,
+    pub position: Vec2,
+    pub velocity: Vec2,
+    pub radius: f32,
+    pub color: Color,
+    pub hp: f32,
+    pub moving: bool,
+    pub invincible: bool,
+}
+
+impl BallState {
+    fn new(id: u64, position: Vec2, radius: f32, color: Color) -> Self {
+        Self {
+            id,
+            position,
+            velocity: Vec2::ZERO,
+            radius,
+            color,
+            hp: radius,
+            moving: true,
+            invincible: false,
+        }
+    }
+
+    fn mass(self) -> f32 {
+        self.radius * self.radius
+    }
+}
+
+pub struct PizzaState {
+    pub config: PizzaConfig,
+    pub balls: Vec<BallState>,
+    pub tick: u64,
+    pub held_ball_id: Option<u64>,
+    pub pointer_position: Vec2,
+    pub cursor_velocity: Vec2,
+    seed: u64,
+    next_ball_id: u64,
+    rng: StdRng,
+}
+
+impl PizzaState {
+    pub fn set_aspect_ratio(&mut self, aspect_ratio: f32) {
+        self.config.bounds = PizzaBounds::from_aspect_ratio(aspect_ratio);
+        for ball in &mut self.balls {
+            contain_ball(ball, self.config.bounds);
+        }
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    fn allocate_ball(&mut self, position: Vec2, radius: f32, color: Color) -> BallState {
+        let id = self.next_ball_id;
+        self.next_ball_id += 1;
+        BallState::new(id, position, radius, color)
+    }
+
+    fn random_ball(&mut self) -> BallState {
+        let bounds = self.config.bounds;
+        let max_radius = MAX_RANDOM_BALL_RADIUS
+            .min(bounds.width * 0.5)
+            .min(bounds.height * 0.5);
+        let min_radius = MIN_RANDOM_BALL_RADIUS.min(max_radius);
+        let radius = self.rng.random_range(min_radius..=max_radius);
+        let x = random_position_component(&mut self.rng, radius, bounds.width);
+        let y = random_position_component(&mut self.rng, radius, bounds.height);
+        let color = random_color(&mut self.rng);
+        self.allocate_ball(Vec2::new(x, y), radius, color)
+    }
+
+    fn advance_spawner(&mut self) {
+        if self.balls.len() >= self.config.desired_ball_count
+            || self.balls.len() >= MAX_BALLS
+            || self.rng.random::<f32>() >= self.config.ball_spawn_rate
+        {
+            return;
+        }
+        let ball = self.random_ball();
+        self.balls.push(ball);
+    }
+
+    fn apply_pointer_action(&mut self, action: PointerAction) {
+        self.pointer_position = Vec2::new(action.position.x, action.position.y);
+        match action.phase {
+            PointerPhase::Press => self.press_pointer(),
+            PointerPhase::Drag => {}
+            PointerPhase::Release => self.release_pointer(),
+        }
+    }
+
+    fn press_pointer(&mut self) {
+        if self.held_ball_id.is_some() {
+            return;
+        }
+
+        let selected = self
+            .balls
+            .iter()
+            .find(|ball| ball.position.distance_to(self.pointer_position) <= ball.radius)
+            .map(|ball| ball.id);
+        let id = if let Some(id) = selected {
+            id
+        } else {
+            if self.balls.len() >= MAX_BALLS {
+                self.remove_replaceable_ball();
+            }
+            let max_radius = MAX_RANDOM_BALL_RADIUS
+                .min(self.config.bounds.width * 0.5)
+                .min(self.config.bounds.height * 0.5);
+            let min_radius = MIN_RANDOM_BALL_RADIUS.min(max_radius);
+            let radius = self.rng.random_range(min_radius..=max_radius);
+            let color = random_color(&mut self.rng);
+            let ball = self.allocate_ball(self.pointer_position, radius, color);
+            let id = ball.id;
+            self.balls.push(ball);
+            id
+        };
+
+        self.held_ball_id = Some(id);
+        if let Some(ball) = self.ball_mut(id) {
+            ball.moving = false;
+            ball.invincible = true;
+        }
+    }
+
+    fn release_pointer(&mut self) {
+        let Some(id) = self.held_ball_id.take() else {
+            return;
+        };
+        let cursor_velocity = self.cursor_velocity;
+        if let Some(ball) = self.ball_mut(id) {
+            ball.hp = ball.radius;
+            ball.velocity = cursor_velocity;
+            ball.moving = true;
+            ball.invincible = false;
+        }
+        self.cursor_velocity = Vec2::ZERO;
+    }
+
+    fn advance_held_ball(&mut self, dt: f32) {
+        let Some(id) = self.held_ball_id else {
+            return;
+        };
+        let pointer_position = self.pointer_position;
+        let Some(ball_index) = self.balls.iter().position(|ball| ball.id == id) else {
+            self.held_ball_id = None;
+            return;
+        };
+        let ball = self.balls[ball_index];
+        let displacement = pointer_position - ball.position;
+        let distance = displacement.length();
+        let direction = if distance > 0.0 {
+            displacement / distance
+        } else {
+            Vec2::ZERO
+        };
+        let target_velocity = direction * (CURSOR_FORCE / ball.mass()) * distance.min(ball.radius);
+        self.cursor_velocity =
+            self.cursor_velocity * CURSOR_SMOOTHING + target_velocity * (1.0 - CURSOR_SMOOTHING);
+        let ball = &mut self.balls[ball_index];
+        ball.velocity = self.cursor_velocity;
+        ball.position += self.cursor_velocity * (dt * CURSOR_TIME_SCALE);
+        contain_ball(ball, self.config.bounds);
+    }
+
+    fn ball_mut(&mut self, id: u64) -> Option<&mut BallState> {
+        self.balls.iter_mut().find(|ball| ball.id == id)
+    }
+
+    fn remove_replaceable_ball(&mut self) {
+        let held = self.held_ball_id;
+        let candidates = self
+            .balls
+            .iter()
+            .enumerate()
+            .filter(|(_, ball)| Some(ball.id) != held)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if !candidates.is_empty() {
+            let candidate = self.rng.random_range(0..candidates.len());
+            self.balls.swap_remove(candidates[candidate]);
+        }
+    }
+}
+
+impl Scenario for PizzaScenario {
+    type State = PizzaState;
+    type Config = PizzaConfig;
+
+    fn init(config: Self::Config, seed: u64) -> Self::State {
+        PizzaState {
+            config: config.normalized(),
+            balls: Vec::new(),
+            tick: 0,
+            held_ball_id: None,
+            pointer_position: Vec2::ZERO,
+            cursor_velocity: Vec2::ZERO,
+            seed,
+            next_ball_id: 1,
+            rng: StdRng::seed_from_u64(seed),
+        }
+    }
+
+    fn step(state: &mut Self::State, actions: &[Action], dt: Duration) -> StepResult {
+        for action in actions {
+            if let Action::Pointer(pointer) = action {
+                state.apply_pointer_action(*pointer);
+            }
+        }
+
+        let dt = dt.as_secs_f32();
+        state.advance_held_ball(dt);
+        state.advance_spawner();
+
+        let movement_dt = dt * WORLD_TIME_SCALE;
+        for ball in &mut state.balls {
+            if ball.moving {
+                ball.position += ball.velocity * movement_dt;
+            }
+            contain_ball(ball, state.config.bounds);
+        }
+
+        apply_exact_gravity(&mut state.balls);
+        resolve_collisions(&mut state.balls);
+        for ball in &mut state.balls {
+            contain_ball(ball, state.config.bounds);
+        }
+        explode_dead_balls(state);
+        state.tick += 1;
+        StepResult::default()
+    }
+
+    fn observe(_state: &Self::State) -> Observation {
+        Observation {
+            payload: Vec::new(),
+        }
+    }
+
+    fn render_frame(state: &Self::State) -> RenderFrame {
+        let bounds = state.config.bounds;
+        let mut frame = RenderFrame::new(Camera2::new(
+            RenderPoint::new(bounds.center().x, bounds.center().y),
+            bounds.height,
+        ));
+        for ball in &state.balls {
+            let color = RenderColor::rgba(ball.color.r, ball.color.g, ball.color.b, ball.color.a);
+            let stroke_color = if ball.invincible {
+                RenderColor::WHITE
+            } else {
+                RenderColor::rgba(0.08, 0.08, 0.12, 0.9)
+            };
+            frame.push_primitive(
+                BALL_LAYER,
+                RenderPrimitive::Circle(RenderCircle {
+                    center: RenderPoint::new(ball.position.x, ball.position.y),
+                    radius: ball.radius,
+                    fill: Some(engine_common::Fill::new(color)),
+                    stroke: Some(Stroke::new(stroke_color, 1.0)),
+                }),
+            );
+        }
+        frame
+    }
+
+    fn tick_model() -> TickModel {
+        TickModel::FixedTimestep { hz: 60 }
+    }
+}
+
+fn random_position_component(rng: &mut StdRng, radius: f32, maximum: f32) -> f32 {
+    let available = (maximum - radius * 2.0).max(0.0);
+    radius + rng.random::<f32>() * available
+}
+
+fn random_color(rng: &mut StdRng) -> Color {
+    Color::rgb(rng.random(), rng.random(), rng.random())
+}
+
+fn contain_ball(ball: &mut BallState, bounds: PizzaBounds) {
+    let max_x = (bounds.width - ball.radius - WALL_FUDGE).max(ball.radius);
+    let max_y = (bounds.height - ball.radius - WALL_FUDGE).max(ball.radius);
+    if ball.position.x + ball.radius >= bounds.width {
+        ball.position.x = max_x;
+        ball.velocity.x = -ball.velocity.x * WALL_ELASTICITY;
+    }
+    if ball.position.y + ball.radius >= bounds.height {
+        ball.position.y = max_y;
+        ball.velocity.y = -ball.velocity.y * WALL_ELASTICITY;
+    }
+    if ball.position.x - ball.radius <= 0.0 {
+        ball.position.x = ball.radius + WALL_FUDGE;
+        ball.velocity.x = -ball.velocity.x * WALL_ELASTICITY;
+    }
+    if ball.position.y - ball.radius <= 0.0 {
+        ball.position.y = ball.radius + WALL_FUDGE;
+        ball.velocity.y = -ball.velocity.y * WALL_ELASTICITY;
+    }
+}
+
+fn apply_exact_gravity(balls: &mut [BallState]) {
+    for left_index in 0..balls.len() {
+        for right_index in left_index + 1..balls.len() {
+            let (left_slice, right_slice) = balls.split_at_mut(right_index);
+            let left = &mut left_slice[left_index];
+            let right = &mut right_slice[0];
+            let delta = right.position - left.position;
+            let distance_squared =
+                (delta.length_squared() + GRAVITY_SOFTENING * GRAVITY_SOFTENING).max(f32::EPSILON);
+            let direction = delta.normalized();
+            if direction == Vec2::ZERO {
+                continue;
+            }
+            let force = GRAVITY * left.mass() * right.mass() / distance_squared;
+            left.velocity += direction * (force / left.mass());
+            right.velocity -= direction * (force / right.mass());
+        }
+    }
+}
+
+fn resolve_collisions(balls: &mut [BallState]) {
+    for left_index in 0..balls.len() {
+        for right_index in left_index + 1..balls.len() {
+            let (left_slice, right_slice) = balls.split_at_mut(right_index);
+            let left = &mut left_slice[left_index];
+            let right = &mut right_slice[0];
+            if left.position.distance_to(right.position) < left.radius + right.radius {
+                collide_balls(left, right);
+            }
+        }
+    }
+}
+
+fn collide_balls(left: &mut BallState, right: &mut BallState) {
+    let delta_vector = left.position - right.position;
+    let delta = delta_vector.length();
+    let normal = if delta == 0.0 {
+        Vec2::X
+    } else {
+        delta_vector / delta
+    };
+    let translation = normal * (left.radius + right.radius - delta);
+    let left_mass = left.mass();
+    let right_mass = right.mass();
+    let total_mass = left_mass + right_mass;
+
+    if !left.moving {
+        right.position -= translation;
+    } else if !right.moving {
+        left.position += translation;
+    } else {
+        left.position += translation * (right_mass / total_mass);
+        right.position -= translation * (left_mass / total_mass);
+    }
+    if !left.moving && !right.moving {
+        return;
+    }
+
+    let tangent = Vec2::new(normal.y, -normal.x);
+    let left_normal = normal * left.velocity.dot(normal);
+    let left_tangent = tangent * left.velocity.dot(tangent);
+    let right_normal = normal * right.velocity.dot(normal);
+    let right_tangent = tangent * right.velocity.dot(tangent);
+    let left_delta_scale = (right_mass - left_mass) / total_mass * left_normal.length()
+        + 2.0 * right_mass / total_mass * right_normal.length();
+    let right_delta_scale = (left_mass - right_mass) / total_mass * right_normal.length()
+        + 2.0 * left_mass / total_mass * left_normal.length();
+    let raw_left_delta = normal * left_delta_scale;
+    let raw_right_delta = normal * right_delta_scale;
+    let left_delta = raw_left_delta * COLLISION_ELASTICITY;
+    let right_delta = raw_right_delta * COLLISION_ELASTICITY;
+
+    if left.moving {
+        left.velocity = left_tangent + left_delta;
+    }
+    if right.moving {
+        right.velocity = right_tangent - right_delta;
+    }
+    if !left.invincible {
+        left.hp -= if left.moving {
+            left_delta.length()
+        } else {
+            raw_left_delta.length()
+        } * DAMAGE_SCALAR;
+    }
+    if !right.invincible {
+        right.hp -= if right.moving {
+            right_delta.length()
+        } else {
+            raw_right_delta.length()
+        } * DAMAGE_SCALAR;
+    }
+}
+
+fn explode_dead_balls(state: &mut PizzaState) {
+    let mut dead = Vec::new();
+    state.balls.retain(|ball| {
+        if !ball.invincible && ball.hp <= 0.0 {
+            dead.push(*ball);
+            false
+        } else {
+            true
+        }
+    });
+
+    for parent in dead {
+        if state.balls.len() >= MAX_BALLS {
+            break;
+        }
+        let division_size = parent.radius / EXPLOSION_DIVISIONS as f32;
+        for y_index in 0..EXPLOSION_DIVISIONS * 2 {
+            for x_index in 0..EXPLOSION_DIVISIONS * 2 {
+                let offset = Vec2::new(
+                    -parent.radius + x_index as f32 * division_size,
+                    -parent.radius + y_index as f32 * division_size,
+                );
+                if offset.length() > parent.radius {
+                    continue;
+                }
+                let radius =
+                    division_size * EXPLOSION_SIZE_FACTOR * state.rng.random_range(0.1..=1.0);
+                if radius < MIN_FRAGMENT_RADIUS || radius < MIN_BALL_RADIUS {
+                    continue;
+                }
+                let velocity_scale = state.rng.random::<f32>() * EXPLOSION_VELOCITY_FACTOR;
+                let velocity =
+                    (offset + parent.velocity * EXPLOSION_PARENT_VELOCITY_FACTOR) * velocity_scale;
+                let color = parent.color.random_variation(100.0 / 255.0, &mut state.rng);
+                let mut fragment = state.allocate_ball(parent.position + offset, radius, color);
+                fragment.velocity = velocity;
+                contain_ball(&mut fragment, state.config.bounds);
+                state.balls.push(fragment);
+                if state.balls.len() >= MAX_BALLS {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXED_DT: Duration = Duration::from_nanos(16_666_667);
+
+    fn step(state: &mut PizzaState, actions: &[Action]) {
+        PizzaScenario::step(state, actions, FIXED_DT);
+    }
+
+    fn pointer(x: f32, y: f32, phase: PointerPhase) -> Action {
+        Action::Pointer(PointerAction {
+            position: RenderPoint::new(x, y),
+            phase,
+        })
+    }
+
+    #[test]
+    fn seeded_spawner_is_deterministic_and_capped() {
+        let config = PizzaConfig {
+            desired_ball_count: 8,
+            ball_spawn_rate: MAX_SPAWN_RATE,
+            ..PizzaConfig::default()
+        };
+        let mut left = PizzaScenario::init(config.clone(), 42);
+        let mut right = PizzaScenario::init(config, 42);
+        for _ in 0..120 {
+            step(&mut left, &[]);
+            step(&mut right, &[]);
+            assert!(left.balls.len() <= 8);
+            assert_eq!(left.balls, right.balls);
+        }
+        assert_eq!(left.balls.len(), 8);
+    }
+
+    #[test]
+    fn pointer_press_creates_holds_and_releases_a_ball() {
+        let mut state = PizzaScenario::init(
+            PizzaConfig {
+                desired_ball_count: 0,
+                ..PizzaConfig::default()
+            },
+            7,
+        );
+        step(&mut state, &[pointer(0.5, 0.25, PointerPhase::Press)]);
+        assert_eq!(state.balls.len(), 1);
+        assert!(state.balls[0].invincible);
+        assert!(!state.balls[0].moving);
+
+        step(&mut state, &[pointer(0.7, 0.25, PointerPhase::Drag)]);
+        assert!(state.balls[0].velocity.x > 0.0);
+        step(&mut state, &[pointer(0.7, 0.25, PointerPhase::Release)]);
+        assert!(!state.balls[0].invincible);
+        assert!(state.balls[0].moving);
+        assert!(state.balls[0].velocity.x > 0.0);
+    }
+
+    #[test]
+    fn collision_separates_by_mass_and_applies_damage() {
+        let mut left = BallState::new(1, Vec2::new(0.4, 0.3), 0.08, Color::RED);
+        let mut right = BallState::new(2, Vec2::new(0.5, 0.3), 0.04, Color::BLUE);
+        left.velocity = Vec2::new(0.03, 0.0);
+        right.velocity = Vec2::new(-0.01, 0.0);
+        collide_balls(&mut left, &mut right);
+        assert!(left.position.distance_to(right.position) >= left.radius + right.radius - 1.0e-6);
+        assert!(left.hp < left.radius);
+        assert!(right.hp < right.radius);
+    }
+
+    #[test]
+    fn dead_ball_explodes_into_capped_fragments() {
+        let mut state = PizzaScenario::init(
+            PizzaConfig {
+                desired_ball_count: 0,
+                ..PizzaConfig::default()
+            },
+            3,
+        );
+        let mut ball = state.allocate_ball(Vec2::new(0.5, 0.25), 0.08, Color::GREEN);
+        ball.hp = 0.0;
+        state.balls.push(ball);
+        explode_dead_balls(&mut state);
+        assert!(!state.balls.is_empty());
+        assert!(state.balls.len() <= MAX_BALLS);
+        assert!(state.balls.iter().all(|fragment| fragment.radius < 0.08));
+    }
+
+    #[test]
+    fn camera_tracks_normalized_bounds_for_window_aspect() {
+        let mut state = PizzaScenario::init(PizzaConfig::default(), 0);
+        state.set_aspect_ratio(2.0);
+        let frame = PizzaScenario::render_frame(&state);
+        assert_eq!(frame.camera.center, RenderPoint::new(0.5, 0.25));
+        assert_eq!(frame.camera.height, 0.5);
+        assert_eq!(frame.camera.visible_width(2.0), 1.0);
+    }
+}

--- a/scenarios/pizza/src/lib.rs
+++ b/scenarios/pizza/src/lib.rs
@@ -199,6 +199,7 @@ impl PizzaState {
             PointerPhase::Press => self.press_pointer(),
             PointerPhase::Drag => {}
             PointerPhase::Release => self.release_pointer(),
+            PointerPhase::Cancel => self.cancel_pointer(),
         }
     }
 
@@ -245,6 +246,19 @@ impl PizzaState {
         if let Some(ball) = self.ball_mut(id) {
             ball.hp = ball.radius;
             ball.velocity = cursor_velocity;
+            ball.moving = true;
+            ball.invincible = false;
+        }
+        self.cursor_velocity = Vec2::ZERO;
+    }
+
+    fn cancel_pointer(&mut self) {
+        let Some(id) = self.held_ball_id.take() else {
+            return;
+        };
+        if let Some(ball) = self.ball_mut(id) {
+            ball.hp = ball.radius;
+            ball.velocity = Vec2::ZERO;
             ball.moving = true;
             ball.invincible = false;
         }
@@ -320,6 +334,10 @@ impl Scenario for PizzaScenario {
             if let Action::Pointer(pointer) = action {
                 state.apply_pointer_action(*pointer);
             }
+        }
+
+        if dt.is_zero() {
+            return StepResult::default();
         }
 
         let dt = dt.as_secs_f32();
@@ -606,6 +624,33 @@ mod tests {
         assert!(!state.balls[0].invincible);
         assert!(state.balls[0].moving);
         assert!(state.balls[0].velocity.x > 0.0);
+    }
+
+    #[test]
+    fn pointer_cancel_releases_without_throwing_the_ball() {
+        let mut state = PizzaScenario::init(
+            PizzaConfig {
+                desired_ball_count: 0,
+                ..PizzaConfig::default()
+            },
+            7,
+        );
+        step(&mut state, &[pointer(0.5, 0.25, PointerPhase::Press)]);
+        step(&mut state, &[pointer(0.7, 0.25, PointerPhase::Drag)]);
+        assert!(state.balls[0].velocity.x > 0.0);
+        let tick = state.tick;
+
+        PizzaScenario::step(
+            &mut state,
+            &[pointer(0.7, 0.25, PointerPhase::Cancel)],
+            Duration::ZERO,
+        );
+
+        assert_eq!(state.tick, tick);
+        assert!(state.held_ball_id.is_none());
+        assert!(!state.balls[0].invincible);
+        assert!(state.balls[0].moving);
+        assert_eq!(state.balls[0].velocity, Vec2::ZERO);
     }
 
     #[test]

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -556,14 +556,14 @@ impl SpacewarsAction {
     }
 
     pub fn encode(self) -> Action {
-        Action {
-            kind: self.kind as u32,
-            payload: vec![self.player as u8],
-        }
+        Action::scenario(self.kind as u32, vec![self.player as u8])
     }
 
     pub fn decode(action: &Action) -> Option<Self> {
-        let [player] = action.payload.as_slice() else {
+        let Action::Scenario { kind, payload } = action else {
+            return None;
+        };
+        let [player] = payload.as_slice() else {
             return None;
         };
         let player = *player as usize;
@@ -572,7 +572,7 @@ impl SpacewarsAction {
         }
         Some(Self {
             player,
-            kind: SpacewarsActionKind::from_u32(action.kind)?,
+            kind: SpacewarsActionKind::from_u32(*kind)?,
         })
     }
 
@@ -6935,10 +6935,7 @@ mod tests {
     fn invalid_actions_are_ignored() {
         let mut state = init_deathmatch();
         let start = state.ships[0].clone();
-        let invalid = Action {
-            kind: 999,
-            payload: vec![0],
-        };
+        let invalid = Action::scenario(999, vec![0]);
 
         step(&mut state, &[invalid]);
 


### PR DESCRIPTION
## Summary

- replace the Spacewars-specific hosted-scenario dispatch with a compile-time `ClientScenario` registry and adapters for Null, Pizza, and Spacewars
- add generic pointer press/drag/release actions with per-frame screen-to-world unprojection
- port the deterministic Pizza ball simulation with capped exact O(n²) gravity/collisions, wall containment, damage, explosions, and grab/spawn/fling interaction
- populate the launcher from the registry, add scenario-specific setup/capabilities, and persist Pizza settings through the existing safe settings path
- document M21 and deliberately defer quadtree/Barnes–Hut optimization until the exact implementation provides a measured baseline

## Validation

- `cargo +1.85 test --workspace` (250 tests)
- `cargo check -p engine-client`
- `cargo fmt --all -- --check`
- `git diff --check`
- manual launcher, Spacewars, Pizza, and mouse-interaction testing

Closes #6