### PR TITLE
Add controller-first kiosk UX and gameplay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "directories",
  "engine-common",
  "engine-core",
+ "gilrs",
  "png 0.17.16",
  "scenario-null",
  "scenario-pizza",
@@ -1892,6 +1893,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "gilrs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
+dependencies = [
+ "inotify",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.31.3",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "rusty-xinput",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,7 +2157,7 @@ dependencies = [
  "input",
  "libseat",
  "memmap2",
- "nix",
+ "nix 0.30.1",
  "raw-window-handle",
  "xkbcommon",
 ]
@@ -2533,6 +2569,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "input"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,9 +2790,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3087,6 +3143,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3450,6 +3518,17 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -4252,6 +4331,17 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-xinput"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3335c2b62e1e48dd927f6c8941705386e3697fa944aabcb10431bea7ee47ef3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "winapi",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -5397,6 +5487,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rust-version = "1.89"
 bincode = "1"
 clap = { version = "4", features = ["derive"] }
 directories = "6"
+gilrs = { version = "0.11.2", default-features = false, features = ["xinput"] }
 rand = { version = "0.9", features = ["std_rng"] }
 png = "0.17"
 rapier2d = { version = "0.34", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -54,18 +54,32 @@ reset.
 
 ## Raspberry Pi / kiosk launch
 
-The first-pass Pi launch mode is:
+The Pi image launches the scenario selector fullscreen:
 
 ```sh
-engine-client --kiosk --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
+engine-client --fullscreen --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
 ```
 
-`--kiosk` launches directly, requests fullscreen, and lets the image-selected
-Slint backend run instead of forcing the desktop `winit` backend. The same
-settings directory can also be selected with `SPACEWARS_CONFIG_DIR`.
+`--fullscreen` leaves the launcher visible so a scenario can be selected while
+requesting fullscreen presentation. The image selects Slint's LinuxKMS backend
+with `SLINT_BACKEND`; `--kiosk` remains available when booting directly into the
+saved scenario is preferred. The same settings directory can also be selected
+with `SPACEWARS_CONFIG_DIR`.
 
 See [`docs/pi-kiosk.md`](docs/pi-kiosk.md) for the current Pi runbook and
 example systemd service. The Yocto image scaffold is under [`yocto/`](yocto/).
+
+Once an OTA-capable image has been flashed, build and deploy an update from the
+repository root:
+
+```sh
+./update.sh
+```
+
+This updates `spacewars@spacewars.local` by default, reboots into the newly
+written A/B slot, and verifies that `spacewars-kiosk.service` is active. Use
+`./update.sh --skip-build` to deploy the existing image or `./update.sh --help`
+for target, user, image, SSH key, dry-run, and confirmation options.
 
 ## History
 

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -19,6 +19,7 @@ scenario-rover-lab = { workspace = true }
 scenario-spacewars = { workspace = true }
 clap = { workspace = true }
 directories = { workspace = true }
+gilrs = { workspace = true }
 png = { workspace = true }
 slint = { workspace = true }
 tempfile = { workspace = true }
@@ -43,7 +44,7 @@ pi-kiosk = [
     "slint/backend-linuxkms",
     "slint/compat-1-2",
     "slint/software-renderer-systemfonts",
-    # Game input currently uses Slint's Winit physical-key event adapter.
-    # Keep this until Pi validation confirms a backend-neutral replacement.
+    # Retain desktop keyboard compatibility; native pad input uses evdev through
+    # gilrs and does not depend on the display backend.
     "slint/unstable-winit-030",
 ]

--- a/crates/engine-client/src/client_scenarios/mod.rs
+++ b/crates/engine-client/src/client_scenarios/mod.rs
@@ -177,7 +177,7 @@ pub trait ClientScenario {
     fn registration(&self) -> &'static ScenarioRegistration;
     fn tick_model(&self) -> TickModel;
     fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult;
-    fn map_keyboard_input(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action>;
+    fn map_input(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action>;
     fn render_frames(&self, renderer: RenderBackend, viewport: Viewport) -> Vec<RenderFrame>;
     fn frame_layout(&self) -> FrameLayout;
 

--- a/crates/engine-client/src/client_scenarios/null.rs
+++ b/crates/engine-client/src/client_scenarios/null.rs
@@ -50,7 +50,7 @@ impl ClientScenario for NullClientScenario {
         NullScenario::step(&mut self.state, actions, dt)
     }
 
-    fn map_keyboard_input(&self, _input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
+    fn map_input(&self, _input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
         Vec::new()
     }
 

--- a/crates/engine-client/src/client_scenarios/pizza.rs
+++ b/crates/engine-client/src/client_scenarios/pizza.rs
@@ -65,7 +65,7 @@ impl ClientScenario for PizzaClientScenario {
         PizzaScenario::step(&mut self.state, actions, dt)
     }
 
-    fn map_keyboard_input(&self, _input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
+    fn map_input(&self, _input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
         Vec::new()
     }
 

--- a/crates/engine-client/src/client_scenarios/rover_lab.rs
+++ b/crates/engine-client/src/client_scenarios/rover_lab.rs
@@ -18,7 +18,7 @@ pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
         player_zoom: false,
         game_over: false,
     },
-    controls_help: "Rover Lab: W drives forward, S brakes, X drives in reverse, and R resets the articulated rover.",
+    controls_help: "Rover Lab: d-pad right drives forward, d-pad left drives in reverse, A brakes, and the pause menu can restart the lab. Keyboard: W forward, S brake, X reverse, R reset.",
     create,
 };
 
@@ -50,17 +50,8 @@ impl ClientScenario for RoverLabClientScenario {
         RoverLabScenario::step(&mut self.state, actions, dt)
     }
 
-    fn map_keyboard_input(&self, input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
-        let brake = input.is_pressed(GameKey::P1Brake);
-        let throttle = if brake {
-            0.0
-        } else if input.is_pressed(GameKey::P1Thrust) {
-            1.0
-        } else if input.is_pressed(GameKey::P1Reverse) {
-            -1.0
-        } else {
-            0.0
-        };
+    fn map_input(&self, input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
+        let (throttle, brake) = rover_controls(input);
         vec![RoverLabAction::drive(throttle, brake)]
     }
 
@@ -80,5 +71,86 @@ impl ClientScenario for RoverLabClientScenario {
     #[cfg(test)]
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+}
+
+fn rover_controls(input: &ClientInput) -> (f32, bool) {
+    let (gamepad_throttle, gamepad_brake) = input.rover_drive_input();
+    let brake = input.is_pressed(GameKey::P1Brake) || gamepad_brake;
+    let throttle = if brake {
+        0.0
+    } else if input.is_pressed(GameKey::P1Thrust) {
+        1.0
+    } else if input.is_pressed(GameKey::P1Reverse) {
+        -1.0
+    } else {
+        gamepad_throttle
+    };
+    (throttle, brake)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use super::*;
+    use crate::input::{GamepadInput, GamepadSeatInput};
+
+    fn client_input_with_gamepad(
+        state: GamepadSeatInput,
+    ) -> (ClientInput, Rc<RefCell<GamepadInput>>) {
+        let gamepads = Rc::new(RefCell::new(GamepadInput::default()));
+        gamepads.borrow_mut().set_seat(0, state);
+        (ClientInput::new(Rc::clone(&gamepads)), gamepads)
+    }
+
+    #[test]
+    fn nes_dpad_drives_in_both_directions() {
+        let (forward, _) = client_input_with_gamepad(GamepadSeatInput {
+            connected: true,
+            dpad_right: true,
+            ..GamepadSeatInput::default()
+        });
+        assert_eq!(rover_controls(&forward), (1.0, false));
+
+        let (reverse, _) = client_input_with_gamepad(GamepadSeatInput {
+            connected: true,
+            dpad_left: true,
+            ..GamepadSeatInput::default()
+        });
+        assert_eq!(rover_controls(&reverse), (-1.0, false));
+    }
+
+    #[test]
+    fn releasing_the_dpad_returns_to_neutral() {
+        let (input, gamepads) = client_input_with_gamepad(GamepadSeatInput {
+            connected: true,
+            dpad_right: true,
+            ..GamepadSeatInput::default()
+        });
+        assert_eq!(rover_controls(&input), (1.0, false));
+
+        gamepads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                ..GamepadSeatInput::default()
+            },
+        );
+        assert_eq!(rover_controls(&input), (0.0, false));
+    }
+
+    #[test]
+    fn nes_a_brake_overrides_gamepad_and_keyboard_throttle() {
+        let (mut input, _) = client_input_with_gamepad(GamepadSeatInput {
+            connected: true,
+            dpad_right: true,
+            south: true,
+            ..GamepadSeatInput::default()
+        });
+        input.press(GameKey::P1Thrust);
+
+        assert_eq!(rover_controls(&input), (0.0, true));
     }
 }

--- a/crates/engine-client/src/client_scenarios/spacewars.rs
+++ b/crates/engine-client/src/client_scenarios/spacewars.rs
@@ -20,7 +20,7 @@ pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
         player_zoom: true,
         game_over: true,
     },
-    controls_help: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon, U/I zoom.\nPlayer 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon, Insert/Home zoom.",
+    controls_help: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon, U/I zoom.\nPlayer 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon, Insert/Home zoom.\nPad: left stick turn, RT thrust, LT brake, B reverse, RB wings, A laser, X cannon, d-pad up/down zoom, Start pause, Select controls.",
     create,
 };
 
@@ -58,12 +58,8 @@ impl ClientScenario for SpacewarsClientScenario {
         SpacewarsScenario::step(&mut self.state, actions, dt)
     }
 
-    fn map_keyboard_input(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action> {
-        if benchmark_active {
-            SpacewarsScenario::benchmark_actions(&self.state)
-        } else {
-            input.actions_for_spacewars()
-        }
+    fn map_input(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action> {
+        input.actions_for_spacewars(&self.state, benchmark_active)
     }
 
     fn render_frames(&self, renderer: RenderBackend, viewport: Viewport) -> Vec<RenderFrame> {

--- a/crates/engine-client/src/client_scenarios/spacewars.rs
+++ b/crates/engine-client/src/client_scenarios/spacewars.rs
@@ -20,7 +20,7 @@ pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
         player_zoom: true,
         game_over: true,
     },
-    controls_help: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon, U/I zoom.\nPlayer 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon, Insert/Home zoom.\nPad: left stick turn, RT thrust, LT brake, B reverse, RB wings, A laser, X cannon, d-pad up/down zoom, Start pause, Select controls.",
+    controls_help: "Player 1: W thrust, S brake, X reverse, A/D turn, J wings, Space laser, K cannon, U/I zoom.\nPlayer 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon, Insert/Home zoom.\nPad: left stick or d-pad left/right turns, RT or d-pad up thrusts, LT or d-pad down brakes, B reverses, RB closes wings, A fires laser, X fires cannon, Start pauses, Select shows controls. Zoom is available in the pause menu.",
     create,
 };
 

--- a/crates/engine-client/src/gamepad.rs
+++ b/crates/engine-client/src/gamepad.rs
@@ -1,0 +1,473 @@
+//! Backend-neutral gamepad polling, seat assignment, and controller UI routing.
+
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+
+use gilrs::{Axis, Button, EventType, Gamepad, Gilrs};
+use slint::{ComponentHandle, SharedString, Timer, TimerMode};
+
+use crate::MainWindow;
+use crate::input::{self, GameKey, GamepadSeatInput, SharedGamepadInput, SharedInput};
+use crate::ui_navigation::UiAction;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(16);
+const UI_REPEAT_DELAY: Duration = Duration::from_millis(350);
+const UI_REPEAT_INTERVAL: Duration = Duration::from_millis(100);
+const UI_STICK_THRESHOLD: f32 = 0.55;
+
+pub(crate) fn start_gamepad_pump(
+    window: &MainWindow,
+    input: SharedInput,
+    gamepads: SharedGamepadInput,
+) -> Option<Timer> {
+    let gilrs = match Gilrs::new() {
+        Ok(gilrs) => gilrs,
+        Err(err) => {
+            tracing::warn!(error = %err, "gamepad backend unavailable; keyboard input remains active.");
+            return None;
+        }
+    };
+
+    let mut pump = GamepadPump::new(gilrs, input, gamepads);
+    pump.initialize(window);
+
+    let timer = Timer::default();
+    let weak_window = window.as_weak();
+    timer.start(TimerMode::Repeated, POLL_INTERVAL, move || {
+        let Some(window) = weak_window.upgrade() else {
+            return;
+        };
+        pump.tick(&window);
+    });
+    Some(timer)
+}
+
+struct GamepadPump {
+    gilrs: Gilrs,
+    assignments: SeatAssignments,
+    input: SharedInput,
+    gamepads: SharedGamepadInput,
+    ui_driver: Option<usize>,
+    ui_repeat: UiRepeat,
+}
+
+impl GamepadPump {
+    fn new(gilrs: Gilrs, input: SharedInput, gamepads: SharedGamepadInput) -> Self {
+        Self {
+            gilrs,
+            assignments: SeatAssignments::default(),
+            input,
+            gamepads,
+            ui_driver: None,
+            ui_repeat: UiRepeat::default(),
+        }
+    }
+
+    fn initialize(&mut self, window: &MainWindow) {
+        let connected = self
+            .gilrs
+            .gamepads()
+            .map(|(id, gamepad)| (usize::from(id), gamepad.name().to_owned()))
+            .collect::<Vec<_>>();
+        for (id, name) in connected {
+            if let Some(seat) = self.assignments.connect(id) {
+                tracing::info!(
+                    gamepad_id = id,
+                    player = seat + 1,
+                    gamepad = %name,
+                    "assigned connected gamepad."
+                );
+            }
+        }
+        self.sample_gamepads();
+        self.refresh_connection_ui(window);
+    }
+
+    fn tick(&mut self, window: &MainWindow) {
+        while let Some(event) = self.gilrs.next_event() {
+            let id = usize::from(event.id);
+            match event.event {
+                EventType::Connected => {
+                    let name = self.gilrs.gamepad(event.id).name().to_owned();
+                    if let Some(seat) = self.assignments.connect(id) {
+                        tracing::info!(
+                            gamepad_id = id,
+                            player = seat + 1,
+                            gamepad = %name,
+                            "gamepad connected."
+                        );
+                    } else {
+                        tracing::warn!(
+                            gamepad_id = id,
+                            gamepad = %name,
+                            "gamepad connected without an available player seat."
+                        );
+                    }
+                    self.refresh_connection_ui(window);
+                }
+                EventType::Disconnected => {
+                    if let Some(seat) = self.assignments.disconnect(id) {
+                        self.gamepads.borrow_mut().disconnect_seat(seat);
+                        tracing::warn!(gamepad_id = id, player = seat + 1, "gamepad disconnected.");
+                        if !window.get_launcher_visible() {
+                            let was_playing = is_game_mode(window);
+                            if was_playing {
+                                self.input.borrow_mut().press(GameKey::ForcePause);
+                            }
+                            window.set_controller_disconnected_visible(true);
+                            window.set_controller_disconnected_text(SharedString::from(format!(
+                                "P{} controller disconnected — {}",
+                                seat + 1,
+                                if was_playing {
+                                    "game paused; keyboard or touch remains available."
+                                } else {
+                                    "keyboard or touch remains available."
+                                }
+                            )));
+                        }
+                    }
+                    self.refresh_connection_ui(window);
+                }
+                event_type => {
+                    let Some(seat) = self.assignments.connected_seat(id) else {
+                        continue;
+                    };
+                    if is_pad_activity(event_type) {
+                        self.ui_driver = Some(seat);
+                    }
+                    self.route_button_edge(window, event_type);
+                }
+            }
+        }
+
+        self.sample_gamepads();
+        if is_ui_mode(window) {
+            self.update_ui_navigation(window);
+        } else {
+            self.ui_repeat.reset();
+        }
+    }
+
+    fn route_button_edge(&mut self, window: &MainWindow, event: EventType) {
+        let EventType::ButtonPressed(button, _) = event else {
+            return;
+        };
+
+        if is_ui_mode(window) {
+            let action = match button {
+                Button::South => Some(UiAction::Confirm),
+                Button::East => Some(UiAction::Back),
+                Button::Select => Some(UiAction::Controls),
+                Button::Start => Some(UiAction::Start),
+                _ => None,
+            };
+            if let Some(action) = action {
+                window.invoke_ui_action(action.code());
+            }
+            return;
+        }
+
+        match button {
+            Button::Start => self.input.borrow_mut().press(GameKey::Pause),
+            Button::Select => self.input.borrow_mut().press(GameKey::Controls),
+            _ => {}
+        }
+    }
+
+    fn sample_gamepads(&mut self) {
+        let snapshots = self
+            .gilrs
+            .gamepads()
+            .filter_map(|(id, gamepad)| {
+                let seat = self.assignments.connected_seat(usize::from(id))?;
+                Some((seat, snapshot(&gamepad)))
+            })
+            .collect::<Vec<_>>();
+        let mut gamepads = self.gamepads.borrow_mut();
+        for (seat, snapshot) in snapshots {
+            gamepads.set_seat(seat, snapshot);
+        }
+    }
+
+    fn update_ui_navigation(&mut self, window: &MainWindow) {
+        let Some(seat) = self.ui_driver else {
+            self.ui_repeat.reset();
+            return;
+        };
+        let gamepad = self
+            .gamepads
+            .borrow()
+            .seat(seat)
+            .cloned()
+            .unwrap_or_default();
+        if !gamepad.connected {
+            self.ui_repeat.reset();
+            return;
+        }
+
+        if let Some(action) = self
+            .ui_repeat
+            .update(ui_direction(&gamepad), Instant::now())
+        {
+            window.invoke_ui_action(action.code());
+        }
+    }
+
+    fn refresh_connection_ui(&self, window: &MainWindow) {
+        let connected = &self.assignments.connected;
+        let binding = |seat: usize| {
+            let player = seat + 1;
+            if self.assignments.seats[seat].is_some_and(|id| connected.contains(&id)) {
+                format!("P{player} PAD + KEY")
+            } else {
+                format!("P{player} KEY")
+            }
+        };
+        window.set_p1_input_binding(SharedString::from(binding(0)));
+        window.set_p2_input_binding(SharedString::from(binding(1)));
+        if !self.assignments.has_disconnected_seat() {
+            window.set_controller_disconnected_visible(false);
+            window.set_controller_disconnected_text(SharedString::from(""));
+        }
+    }
+}
+
+fn snapshot(gamepad: &Gamepad<'_>) -> GamepadSeatInput {
+    GamepadSeatInput {
+        connected: gamepad.is_connected(),
+        name: gamepad.name().to_owned(),
+        left_stick_x: gamepad.value(Axis::LeftStickX),
+        left_stick_y: gamepad.value(Axis::LeftStickY),
+        left_trigger: button_value(gamepad, Button::LeftTrigger2),
+        right_trigger: button_value(gamepad, Button::RightTrigger2),
+        dpad_up: gamepad.is_pressed(Button::DPadUp),
+        dpad_down: gamepad.is_pressed(Button::DPadDown),
+        dpad_left: gamepad.is_pressed(Button::DPadLeft),
+        dpad_right: gamepad.is_pressed(Button::DPadRight),
+        right_bumper: gamepad.is_pressed(Button::RightTrigger),
+        south: gamepad.is_pressed(Button::South),
+        east: gamepad.is_pressed(Button::East),
+        west: gamepad.is_pressed(Button::West),
+    }
+}
+
+fn button_value(gamepad: &Gamepad<'_>, button: Button) -> f32 {
+    gamepad
+        .button_data(button)
+        .map(|data| data.value())
+        .unwrap_or_else(|| f32::from(gamepad.is_pressed(button)))
+}
+
+fn is_pad_activity(event: EventType) -> bool {
+    match event {
+        EventType::ButtonPressed(..)
+        | EventType::ButtonReleased(..)
+        | EventType::ButtonRepeated(..) => true,
+        EventType::ButtonChanged(_, value, _) => value.abs() >= 0.05,
+        EventType::AxisChanged(_, value, _) => value.abs() >= 0.1,
+        _ => false,
+    }
+}
+
+fn is_ui_mode(window: &MainWindow) -> bool {
+    window.get_launcher_visible()
+        || window.get_ingame_menu_visible()
+        || window.get_game_over_visible()
+}
+
+fn is_game_mode(window: &MainWindow) -> bool {
+    !is_ui_mode(window)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UiDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl UiDirection {
+    const fn action(self) -> UiAction {
+        match self {
+            Self::Up => UiAction::Up,
+            Self::Down => UiAction::Down,
+            Self::Left => UiAction::Left,
+            Self::Right => UiAction::Right,
+        }
+    }
+}
+
+fn ui_direction(gamepad: &GamepadSeatInput) -> Option<UiDirection> {
+    if gamepad.dpad_up {
+        return Some(UiDirection::Up);
+    }
+    if gamepad.dpad_down {
+        return Some(UiDirection::Down);
+    }
+    if gamepad.dpad_left {
+        return Some(UiDirection::Left);
+    }
+    if gamepad.dpad_right {
+        return Some(UiDirection::Right);
+    }
+
+    let x = input::shape_stick(gamepad.left_stick_x);
+    let y = input::shape_stick(gamepad.left_stick_y);
+    if x.abs().max(y.abs()) < UI_STICK_THRESHOLD {
+        return None;
+    }
+    if x.abs() > y.abs() {
+        Some(if x < 0.0 {
+            UiDirection::Left
+        } else {
+            UiDirection::Right
+        })
+    } else {
+        Some(if y < 0.0 {
+            UiDirection::Down
+        } else {
+            UiDirection::Up
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct UiRepeat {
+    direction: Option<UiDirection>,
+    next_repeat: Option<Instant>,
+}
+
+impl UiRepeat {
+    fn update(&mut self, direction: Option<UiDirection>, now: Instant) -> Option<UiAction> {
+        if direction != self.direction {
+            self.direction = direction;
+            self.next_repeat = direction.map(|_| now + UI_REPEAT_DELAY);
+            return direction.map(UiDirection::action);
+        }
+
+        let direction = direction?;
+        let next_repeat = self.next_repeat?;
+        if now < next_repeat {
+            return None;
+        }
+        self.next_repeat = Some(now + UI_REPEAT_INTERVAL);
+        Some(direction.action())
+    }
+
+    fn reset(&mut self) {
+        self.direction = None;
+        self.next_repeat = None;
+    }
+}
+
+#[derive(Debug, Default)]
+struct SeatAssignments {
+    seats: [Option<usize>; 2],
+    connected: BTreeSet<usize>,
+}
+
+impl SeatAssignments {
+    fn connect(&mut self, id: usize) -> Option<usize> {
+        self.connected.insert(id);
+        if let Some(seat) = self.seats.iter().position(|assigned| *assigned == Some(id)) {
+            return Some(seat);
+        }
+        let seat = self.seats.iter().position(Option::is_none)?;
+        self.seats[seat] = Some(id);
+        Some(seat)
+    }
+
+    fn disconnect(&mut self, id: usize) -> Option<usize> {
+        self.connected.remove(&id);
+        self.seats.iter().position(|assigned| *assigned == Some(id))
+    }
+
+    fn connected_seat(&self, id: usize) -> Option<usize> {
+        self.connected
+            .contains(&id)
+            .then(|| self.seats.iter().position(|assigned| *assigned == Some(id)))
+            .flatten()
+    }
+
+    fn has_disconnected_seat(&self) -> bool {
+        self.seats
+            .iter()
+            .flatten()
+            .any(|id| !self.connected.contains(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gamepads_take_the_first_two_seats_in_connection_order() {
+        let mut assignments = SeatAssignments::default();
+
+        assert_eq!(assignments.connect(41), Some(0));
+        assert_eq!(assignments.connect(12), Some(1));
+        assert_eq!(assignments.connect(99), None);
+        assert_eq!(assignments.connected_seat(41), Some(0));
+        assert_eq!(assignments.connected_seat(12), Some(1));
+        assert_eq!(assignments.connected_seat(99), None);
+    }
+
+    #[test]
+    fn reconnect_reclaims_the_reserved_seat() {
+        let mut assignments = SeatAssignments::default();
+        assignments.connect(41);
+        assignments.connect(12);
+
+        assert_eq!(assignments.disconnect(41), Some(0));
+        assert!(assignments.has_disconnected_seat());
+        assert_eq!(assignments.connected_seat(41), None);
+        assert_eq!(assignments.connect(41), Some(0));
+        assert_eq!(assignments.connected_seat(41), Some(0));
+        assert!(!assignments.has_disconnected_seat());
+    }
+
+    #[test]
+    fn ui_direction_prefers_dpad_then_uses_the_dominant_stick_axis() {
+        let mut input = GamepadSeatInput {
+            connected: true,
+            left_stick_x: 1.0,
+            left_stick_y: 0.7,
+            ..GamepadSeatInput::default()
+        };
+        assert_eq!(ui_direction(&input), Some(UiDirection::Right));
+
+        input.dpad_up = true;
+        assert_eq!(ui_direction(&input), Some(UiDirection::Up));
+
+        input.dpad_up = false;
+        input.left_stick_x = 0.2;
+        input.left_stick_y = 0.2;
+        assert_eq!(ui_direction(&input), None);
+    }
+
+    #[test]
+    fn ui_repeat_emits_on_the_edge_then_after_the_repeat_delay() {
+        let start = Instant::now();
+        let mut repeat = UiRepeat::default();
+
+        assert_eq!(
+            repeat.update(Some(UiDirection::Down), start),
+            Some(UiAction::Down)
+        );
+        assert_eq!(
+            repeat.update(Some(UiDirection::Down), start + UI_REPEAT_DELAY / 2),
+            None
+        );
+        assert_eq!(
+            repeat.update(Some(UiDirection::Down), start + UI_REPEAT_DELAY),
+            Some(UiAction::Down)
+        );
+        assert_eq!(repeat.update(None, start + UI_REPEAT_DELAY), None);
+        assert_eq!(
+            repeat.update(Some(UiDirection::Down), start + UI_REPEAT_DELAY),
+            Some(UiAction::Down)
+        );
+    }
+}

--- a/crates/engine-client/src/gamepad.rs
+++ b/crates/engine-client/src/gamepad.rs
@@ -49,6 +49,7 @@ struct GamepadPump {
     gamepads: SharedGamepadInput,
     ui_driver: Option<usize>,
     ui_repeat: UiRepeat,
+    mode_handoff: ModeHandoff,
 }
 
 impl GamepadPump {
@@ -60,6 +61,7 @@ impl GamepadPump {
             gamepads,
             ui_driver: None,
             ui_repeat: UiRepeat::default(),
+            mode_handoff: ModeHandoff::default(),
         }
     }
 
@@ -79,17 +81,20 @@ impl GamepadPump {
                 );
             }
         }
+        self.observe_mode(window);
         self.sample_gamepads();
         self.refresh_connection_ui(window);
     }
 
     fn tick(&mut self, window: &MainWindow) {
+        self.observe_mode(window);
         while let Some(event) = self.gilrs.next_event() {
             let id = usize::from(event.id);
             match event.event {
                 EventType::Connected => {
                     let name = self.gilrs.gamepad(event.id).name().to_owned();
                     if let Some(seat) = self.assignments.connect(id) {
+                        self.mode_handoff.block(seat);
                         tracing::info!(
                             gamepad_id = id,
                             player = seat + 1,
@@ -107,6 +112,7 @@ impl GamepadPump {
                 }
                 EventType::Disconnected => {
                     if let Some(seat) = self.assignments.disconnect(id) {
+                        self.mode_handoff.block(seat);
                         self.gamepads.borrow_mut().disconnect_seat(seat);
                         tracing::warn!(gamepad_id = id, player = seat + 1, "gamepad disconnected.");
                         if !window.get_launcher_visible() {
@@ -135,11 +141,13 @@ impl GamepadPump {
                     if is_pad_activity(event_type) {
                         self.ui_driver = Some(seat);
                     }
-                    self.route_button_edge(window, event_type);
+                    self.route_button_edge(window, seat, event_type);
                 }
             }
+            self.observe_mode(window);
         }
 
+        self.observe_mode(window);
         self.sample_gamepads();
         if is_ui_mode(window) {
             self.update_ui_navigation(window);
@@ -148,7 +156,10 @@ impl GamepadPump {
         }
     }
 
-    fn route_button_edge(&mut self, window: &MainWindow, event: EventType) {
+    fn route_button_edge(&mut self, window: &MainWindow, seat: usize, event: EventType) {
+        if !self.mode_handoff.accepts_input(seat) {
+            return;
+        }
         let EventType::ButtonPressed(button, _) = event else {
             return;
         };
@@ -162,14 +173,21 @@ impl GamepadPump {
                 _ => None,
             };
             if let Some(action) = action {
+                self.begin_handoff();
                 window.invoke_ui_action(action.code());
             }
             return;
         }
 
         match button {
-            Button::Start => self.input.borrow_mut().press(GameKey::Pause),
-            Button::Select => self.input.borrow_mut().press(GameKey::Controls),
+            Button::Start => {
+                self.begin_handoff();
+                self.input.borrow_mut().press(GameKey::Pause);
+            }
+            Button::Select => {
+                self.begin_handoff();
+                self.input.borrow_mut().press(GameKey::Controls);
+            }
             _ => {}
         }
     }
@@ -183,10 +201,27 @@ impl GamepadPump {
                 Some((seat, snapshot(&gamepad)))
             })
             .collect::<Vec<_>>();
+        let snapshots = snapshots
+            .into_iter()
+            .map(|(seat, snapshot)| (seat, self.mode_handoff.filter(seat, snapshot)))
+            .collect::<Vec<_>>();
         let mut gamepads = self.gamepads.borrow_mut();
         for (seat, snapshot) in snapshots {
             gamepads.set_seat(seat, snapshot);
         }
+    }
+
+    fn observe_mode(&mut self, window: &MainWindow) {
+        if self.mode_handoff.observe(InputMode::from_window(window)) {
+            self.ui_driver = None;
+            self.ui_repeat.reset();
+        }
+    }
+
+    fn begin_handoff(&mut self) {
+        self.mode_handoff.block_all();
+        self.ui_driver = None;
+        self.ui_repeat.reset();
     }
 
     fn update_ui_navigation(&mut self, window: &MainWindow) {
@@ -248,6 +283,8 @@ fn snapshot(gamepad: &Gamepad<'_>) -> GamepadSeatInput {
         south: gamepad.is_pressed(Button::South),
         east: gamepad.is_pressed(Button::East),
         west: gamepad.is_pressed(Button::West),
+        start: gamepad.is_pressed(Button::Start),
+        select: gamepad.is_pressed(Button::Select),
     }
 }
 
@@ -270,13 +307,102 @@ fn is_pad_activity(event: EventType) -> bool {
 }
 
 fn is_ui_mode(window: &MainWindow) -> bool {
-    window.get_launcher_visible()
-        || window.get_ingame_menu_visible()
-        || window.get_game_over_visible()
+    InputMode::from_window(window) == InputMode::Ui
 }
 
 fn is_game_mode(window: &MainWindow) -> bool {
     !is_ui_mode(window)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputMode {
+    Ui,
+    Gameplay,
+}
+
+impl InputMode {
+    fn from_window(window: &MainWindow) -> Self {
+        if window.get_launcher_visible()
+            || window.get_ingame_menu_visible()
+            || window.get_game_over_visible()
+        {
+            Self::Ui
+        } else {
+            Self::Gameplay
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ModeHandoff {
+    mode: Option<InputMode>,
+    awaiting_neutral: [bool; 2],
+}
+
+impl ModeHandoff {
+    fn observe(&mut self, mode: InputMode) -> bool {
+        if self.mode == Some(mode) {
+            return false;
+        }
+        self.mode = Some(mode);
+        self.block_all();
+        true
+    }
+
+    fn block_all(&mut self) {
+        self.awaiting_neutral.fill(true);
+    }
+
+    fn block(&mut self, seat: usize) {
+        if let Some(awaiting_neutral) = self.awaiting_neutral.get_mut(seat) {
+            *awaiting_neutral = true;
+        }
+    }
+
+    fn accepts_input(&self, seat: usize) -> bool {
+        self.awaiting_neutral
+            .get(seat)
+            .is_some_and(|awaiting_neutral| !awaiting_neutral)
+    }
+
+    fn filter(&mut self, seat: usize, snapshot: GamepadSeatInput) -> GamepadSeatInput {
+        if self.accepts_input(seat) {
+            return snapshot;
+        }
+        if is_neutral(&snapshot) {
+            if let Some(awaiting_neutral) = self.awaiting_neutral.get_mut(seat) {
+                *awaiting_neutral = false;
+            }
+            snapshot
+        } else {
+            neutral_snapshot(&snapshot)
+        }
+    }
+}
+
+fn is_neutral(gamepad: &GamepadSeatInput) -> bool {
+    input::shape_stick(gamepad.left_stick_x) == 0.0
+        && input::shape_stick(gamepad.left_stick_y) == 0.0
+        && input::shape_trigger(gamepad.left_trigger) == 0.0
+        && input::shape_trigger(gamepad.right_trigger) == 0.0
+        && !gamepad.dpad_up
+        && !gamepad.dpad_down
+        && !gamepad.dpad_left
+        && !gamepad.dpad_right
+        && !gamepad.right_bumper
+        && !gamepad.south
+        && !gamepad.east
+        && !gamepad.west
+        && !gamepad.start
+        && !gamepad.select
+}
+
+fn neutral_snapshot(gamepad: &GamepadSeatInput) -> GamepadSeatInput {
+    GamepadSeatInput {
+        connected: gamepad.connected,
+        name: gamepad.name.clone(),
+        ..GamepadSeatInput::default()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -469,5 +595,69 @@ mod tests {
             repeat.update(Some(UiDirection::Down), start + UI_REPEAT_DELAY),
             Some(UiAction::Down)
         );
+    }
+
+    #[test]
+    fn held_steering_does_not_move_the_menu_after_a_mode_transition() {
+        let mut handoff = ModeHandoff::default();
+        handoff.observe(InputMode::Gameplay);
+        handoff.filter(0, GamepadSeatInput::default());
+
+        let steering = GamepadSeatInput {
+            connected: true,
+            left_stick_x: 1.0,
+            ..GamepadSeatInput::default()
+        };
+        assert_eq!(handoff.filter(0, steering.clone()).left_stick_x, 1.0);
+
+        assert!(handoff.observe(InputMode::Ui));
+        let filtered = handoff.filter(0, steering);
+        assert_eq!(ui_direction(&filtered), None);
+        assert!(!handoff.accepts_input(0));
+
+        handoff.filter(0, GamepadSeatInput::default());
+        assert!(handoff.accepts_input(0));
+        let next_press = GamepadSeatInput {
+            connected: true,
+            dpad_down: true,
+            ..GamepadSeatInput::default()
+        };
+        assert_eq!(
+            ui_direction(&handoff.filter(0, next_press)),
+            Some(UiDirection::Down)
+        );
+    }
+
+    #[test]
+    fn held_confirm_does_not_become_laser_after_a_mode_transition() {
+        let mut handoff = ModeHandoff::default();
+        handoff.observe(InputMode::Ui);
+        handoff.filter(0, GamepadSeatInput::default());
+
+        let confirm = GamepadSeatInput {
+            connected: true,
+            south: true,
+            ..GamepadSeatInput::default()
+        };
+        assert!(handoff.filter(0, confirm.clone()).south);
+
+        // Resume is queued for the next host tick, so the input handoff must
+        // begin before the visible mode catches up.
+        handoff.block_all();
+        assert!(!handoff.filter(0, confirm.clone()).south);
+        assert!(!handoff.accepts_input(0));
+
+        assert!(handoff.observe(InputMode::Gameplay));
+        assert!(!handoff.filter(0, confirm).south);
+        assert!(!handoff.accepts_input(0));
+
+        handoff.filter(0, GamepadSeatInput::default());
+        assert!(handoff.accepts_input(0));
+        let next_press = GamepadSeatInput {
+            connected: true,
+            south: true,
+            ..GamepadSeatInput::default()
+        };
+        assert!(handoff.filter(0, next_press).south);
     }
 }

--- a/crates/engine-client/src/gamepad.rs
+++ b/crates/engine-client/src/gamepad.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
 
-use gilrs::{Axis, Button, EventType, Gamepad, Gilrs};
+use gilrs::{Axis, Button, EventType, Gamepad, GamepadId, Gilrs, Mapping};
 use slint::{ComponentHandle, SharedString, Timer, TimerMode};
 
 use crate::MainWindow;
@@ -14,6 +14,42 @@ const POLL_INTERVAL: Duration = Duration::from_millis(16);
 const UI_REPEAT_DELAY: Duration = Duration::from_millis(350);
 const UI_REPEAT_INTERVAL: Duration = Duration::from_millis(100);
 const UI_STICK_THRESHOLD: f32 = 0.55;
+const AXIS_DPAD_THRESHOLD: f32 = 0.5;
+
+// Linux SDL GUID for USB 0079:0011, version 0110. Gilrs 0.11 parses
+// this controller's signed half-axis D-pad mappings as one mapping per
+// physical axis, leaving only Right and Up usable. Remap those axes to
+// ordinary stick axes and synthesize all four D-pad directions below.
+const RETRO_CONTROLLER_UUID: [u8; 16] = [
+    0x03, 0x00, 0x00, 0x00, 0x79, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x10, 0x01, 0x00, 0x00,
+];
+
+const REMAPPED_BUTTONS: [Button; 15] = [
+    Button::South,
+    Button::East,
+    Button::North,
+    Button::West,
+    Button::C,
+    Button::Z,
+    Button::LeftTrigger,
+    Button::LeftTrigger2,
+    Button::RightTrigger,
+    Button::RightTrigger2,
+    Button::Select,
+    Button::Start,
+    Button::Mode,
+    Button::LeftThumb,
+    Button::RightThumb,
+];
+
+const REMAPPED_AXES: [Axis; 6] = [
+    Axis::LeftStickX,
+    Axis::LeftStickY,
+    Axis::LeftZ,
+    Axis::RightStickX,
+    Axis::RightStickY,
+    Axis::RightZ,
+];
 
 pub(crate) fn start_gamepad_pump(
     window: &MainWindow,
@@ -66,12 +102,11 @@ impl GamepadPump {
     }
 
     fn initialize(&mut self, window: &MainWindow) {
-        let connected = self
-            .gilrs
-            .gamepads()
-            .map(|(id, gamepad)| (usize::from(id), gamepad.name().to_owned()))
-            .collect::<Vec<_>>();
-        for (id, name) in connected {
+        let connected = self.gilrs.gamepads().map(|(id, _)| id).collect::<Vec<_>>();
+        for id in connected {
+            apply_controller_profile(&mut self.gilrs, id);
+            let name = self.gilrs.gamepad(id).name().to_owned();
+            let id = usize::from(id);
             if let Some(seat) = self.assignments.connect(id) {
                 tracing::info!(
                     gamepad_id = id,
@@ -92,6 +127,7 @@ impl GamepadPump {
             let id = usize::from(event.id);
             match event.event {
                 EventType::Connected => {
+                    apply_controller_profile(&mut self.gilrs, event.id);
                     let name = self.gilrs.gamepad(event.id).name().to_owned();
                     if let Some(seat) = self.assignments.connect(id) {
                         self.mode_handoff.block(seat);
@@ -267,24 +303,116 @@ impl GamepadPump {
     }
 }
 
+fn apply_controller_profile(gilrs: &mut Gilrs, id: GamepadId) {
+    let profile = {
+        let gamepad = gilrs.gamepad(id);
+        if !uses_retro_axis_dpad(gamepad.uuid()) {
+            return;
+        }
+
+        let Some(x_axis) = gamepad
+            .button_code(Button::DPadRight)
+            .or_else(|| gamepad.button_code(Button::DPadLeft))
+        else {
+            tracing::warn!(
+                gamepad_id = usize::from(id),
+                "Retro Controller profile could not find its horizontal D-pad axis."
+            );
+            return;
+        };
+        let Some(y_axis) = gamepad
+            .button_code(Button::DPadUp)
+            .or_else(|| gamepad.button_code(Button::DPadDown))
+        else {
+            tracing::warn!(
+                gamepad_id = usize::from(id),
+                "Retro Controller profile could not find its vertical D-pad axis."
+            );
+            return;
+        };
+
+        let mut mapping = Mapping::new();
+        for button in REMAPPED_BUTTONS {
+            if let Some(code) = gamepad.button_code(button) {
+                mapping.insert_btn(code, button);
+            }
+        }
+        for axis in REMAPPED_AXES {
+            if let Some(code) = gamepad.axis_code(axis) {
+                if code != x_axis && code != y_axis {
+                    mapping.insert_axis(code, axis);
+                }
+            }
+        }
+        mapping.insert_axis(x_axis, Axis::LeftStickX);
+        mapping.insert_axis(y_axis, Axis::LeftStickY);
+        mapping
+    };
+
+    match gilrs.set_mapping(
+        usize::from(id),
+        &profile,
+        "Retro Controller (Space Wars axis D-pad)",
+    ) {
+        Ok(_) => tracing::info!(
+            gamepad_id = usize::from(id),
+            profile = "retro-axis-dpad",
+            "applied controller input profile."
+        ),
+        Err(err) => tracing::warn!(
+            gamepad_id = usize::from(id),
+            error = %err,
+            "failed to apply controller input profile."
+        ),
+    }
+}
+
 fn snapshot(gamepad: &Gamepad<'_>) -> GamepadSeatInput {
+    let left_stick_x = gamepad.value(Axis::LeftStickX);
+    let left_stick_y = gamepad.value(Axis::LeftStickY);
+    let axis_dpad = if uses_retro_axis_dpad(gamepad.uuid()) {
+        dpad_from_axes(left_stick_x, left_stick_y)
+    } else {
+        DpadInput::default()
+    };
     GamepadSeatInput {
         connected: gamepad.is_connected(),
         name: gamepad.name().to_owned(),
-        left_stick_x: gamepad.value(Axis::LeftStickX),
-        left_stick_y: gamepad.value(Axis::LeftStickY),
+        left_stick_x,
+        left_stick_y,
         left_trigger: button_value(gamepad, Button::LeftTrigger2),
         right_trigger: button_value(gamepad, Button::RightTrigger2),
-        dpad_up: gamepad.is_pressed(Button::DPadUp),
-        dpad_down: gamepad.is_pressed(Button::DPadDown),
-        dpad_left: gamepad.is_pressed(Button::DPadLeft),
-        dpad_right: gamepad.is_pressed(Button::DPadRight),
+        dpad_up: gamepad.is_pressed(Button::DPadUp) || axis_dpad.up,
+        dpad_down: gamepad.is_pressed(Button::DPadDown) || axis_dpad.down,
+        dpad_left: gamepad.is_pressed(Button::DPadLeft) || axis_dpad.left,
+        dpad_right: gamepad.is_pressed(Button::DPadRight) || axis_dpad.right,
         right_bumper: gamepad.is_pressed(Button::RightTrigger),
         south: gamepad.is_pressed(Button::South),
         east: gamepad.is_pressed(Button::East),
         west: gamepad.is_pressed(Button::West),
         start: gamepad.is_pressed(Button::Start),
         select: gamepad.is_pressed(Button::Select),
+    }
+}
+
+fn uses_retro_axis_dpad(uuid: [u8; 16]) -> bool {
+    uuid == RETRO_CONTROLLER_UUID
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct DpadInput {
+    up: bool,
+    down: bool,
+    left: bool,
+    right: bool,
+}
+
+fn dpad_from_axes(x: f32, y: f32) -> DpadInput {
+    DpadInput {
+        up: y >= AXIS_DPAD_THRESHOLD,
+        down: y <= -AXIS_DPAD_THRESHOLD,
+        left: x <= -AXIS_DPAD_THRESHOLD,
+        right: x >= AXIS_DPAD_THRESHOLD,
     }
 }
 
@@ -571,6 +699,48 @@ mod tests {
         input.left_stick_x = 0.2;
         input.left_stick_y = 0.2;
         assert_eq!(ui_direction(&input), None);
+    }
+
+    #[test]
+    fn retro_controller_profile_matches_only_the_exact_linux_uuid() {
+        assert!(uses_retro_axis_dpad(RETRO_CONTROLLER_UUID));
+
+        let mut other_version = RETRO_CONTROLLER_UUID;
+        other_version[12] = 0x11;
+        assert!(!uses_retro_axis_dpad(other_version));
+    }
+
+    #[test]
+    fn retro_controller_axes_produce_all_four_dpad_directions() {
+        assert_eq!(
+            dpad_from_axes(1.0, 0.0),
+            DpadInput {
+                right: true,
+                ..DpadInput::default()
+            }
+        );
+        assert_eq!(
+            dpad_from_axes(-1.0, 0.0),
+            DpadInput {
+                left: true,
+                ..DpadInput::default()
+            }
+        );
+        assert_eq!(
+            dpad_from_axes(0.0, 1.0),
+            DpadInput {
+                up: true,
+                ..DpadInput::default()
+            }
+        );
+        assert_eq!(
+            dpad_from_axes(0.0, -1.0),
+            DpadInput {
+                down: true,
+                ..DpadInput::default()
+            }
+        );
+        assert_eq!(dpad_from_axes(0.49, -0.49), DpadInput::default());
     }
 
     #[test]

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -21,7 +21,9 @@ use crate::client_scenarios::{
     ScenarioCreateError, ScenarioRegistration, ScenarioStartMode,
 };
 pub use crate::client_scenarios::{BenchmarkConfiguration, RenderBackend};
-use crate::input::{self, ClientInput};
+#[cfg(test)]
+use crate::input;
+use crate::input::{ClientInput, SharedInput};
 use crate::raster;
 use crate::render::{self, Viewport};
 
@@ -29,13 +31,14 @@ const TIMER_INTERVAL: Duration = Duration::from_millis(16);
 const MAX_FIXED_STEPS_PER_TICK: usize = 5;
 const BENCHMARK_VIEWPORT: Viewport = Viewport::new(1280.0, 720.0);
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ScenarioLoopOptions {
     pub start_benchmark: bool,
     pub benchmark_configuration: BenchmarkConfiguration,
     pub renderer: RenderBackend,
     pub raster_scale: f32,
     pub controls: Option<SharedScenarioControls>,
+    pub input: Option<SharedInput>,
     pub settings: Settings,
 }
 
@@ -47,6 +50,7 @@ impl Default for ScenarioLoopOptions {
             renderer: RenderBackend::default(),
             raster_scale: 1.0,
             controls: None,
+            input: None,
             settings: Settings::default(),
         }
     }
@@ -223,6 +227,7 @@ pub fn start_scenario_loop(
         renderer,
         raster_scale,
         controls,
+        input,
         settings,
     } = options;
     let scenario_name = scenario.to_string();
@@ -242,8 +247,12 @@ pub fn start_scenario_loop(
     scenario.set_viewport(initial_viewport);
     let tick_model = scenario.tick_model();
     let fixed_dt = fixed_step_duration(tick_model);
-    let input = std::rc::Rc::new(std::cell::RefCell::new(ClientInput::default()));
-    input::install_window_input(window, std::rc::Rc::clone(&input));
+    let input = input.unwrap_or_else(|| Rc::new(RefCell::new(ClientInput::default())));
+    {
+        let mut input = input.borrow_mut();
+        input.clear();
+        input.reset_spacewars_controls();
+    }
     let controls = controls.unwrap_or_else(new_scenario_controls);
 
     let timer = Timer::default();
@@ -319,7 +328,9 @@ pub fn start_scenario_loop(
             &window,
             scenario.center_panel_state(paused, benchmark_active, &performance_text),
         );
-        set_ingame_menu(&window, paused);
+        let game_over = scenario.is_game_over();
+        window.set_game_over_visible(game_over);
+        set_ingame_menu(&window, paused && !game_over);
         window.set_scenario_pointer_enabled(scenario.registration().capabilities.pointer_input);
         let frames = scenario.render_frames(renderer, viewport);
         input_projections = render::frame_projections(&frames, viewport, scenario.frame_layout());
@@ -503,10 +514,14 @@ fn step_scenario(
         return HostStepResult::default();
     }
 
-    if input.take_controls_requested() && *paused && !scenario.is_game_over() {
+    if input.take_controls_requested() && !scenario.is_game_over() {
         *accumulator = Duration::ZERO;
         deliver_pointer_cancellation(scenario, input, input_projections);
         input.clear();
+        if !*paused {
+            *paused = true;
+            return HostStepResult::set_ingame_controls_visible(true);
+        }
         return HostStepResult::set_ingame_controls_visible(!ingame_controls_visible);
     }
 
@@ -515,6 +530,18 @@ fn step_scenario(
         *accumulator = Duration::ZERO;
         input.clear();
         return HostStepResult::return_to_launcher();
+    }
+
+    if input.take_force_pause_requested() && !scenario.is_game_over() {
+        *paused = true;
+        *accumulator = Duration::ZERO;
+        deliver_pointer_cancellation(scenario, input, input_projections);
+        input.clear();
+        tracing::info!(
+            benchmark = *benchmark_active,
+            "paused after controller disconnect."
+        );
+        return HostStepResult::default();
     }
 
     if input.take_pause_requested() && !scenario.is_game_over() {
@@ -594,6 +621,7 @@ fn restart_scenario(
             *paused = false;
             *benchmark_active = false;
             input.clear();
+            input.reset_spacewars_controls();
             tracing::info!(scenario = scenario_name, seed, "started new game.");
         }
         Err(err) => {
@@ -627,6 +655,7 @@ fn start_benchmark_scenario(
     *paused = false;
     *benchmark_active = true;
     input.clear();
+    input.reset_spacewars_controls();
     tracing::info!(scenario = scenario_name, seed, "started visual benchmark.");
 }
 
@@ -1303,7 +1332,7 @@ impl HostedScenario {
         benchmark_active: bool,
         input_projections: &[render::FrameProjection],
     ) -> Vec<Action> {
-        let mut actions = self.inner.map_keyboard_input(input, benchmark_active);
+        let mut actions = self.inner.map_input(input, benchmark_active);
         actions.extend(self.pointer_actions(input, input_projections));
         actions
     }
@@ -1903,6 +1932,38 @@ mod tests {
     }
 
     #[test]
+    fn controller_disconnect_pause_is_idempotent() {
+        let mut scenario = hosted_scenario("spacewars", 42).unwrap();
+        let mut input = ClientInput::default();
+        let mut accumulator = Duration::from_secs(1);
+        let mut controls = ScenarioControls::default();
+        let mut paused = true;
+        let mut benchmark_active = false;
+
+        input.press(input::GameKey::ForcePause);
+        step_scenario(
+            &mut scenario,
+            "spacewars",
+            42,
+            TickModel::FixedTimestep { hz: 60 },
+            Some(Duration::from_secs_f64(1.0 / 60.0)),
+            Duration::ZERO,
+            &mut accumulator,
+            &mut input,
+            &mut controls,
+            &mut paused,
+            &mut benchmark_active,
+            false,
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
+        );
+
+        assert!(paused);
+        assert_eq!(accumulator, Duration::ZERO);
+    }
+
+    #[test]
     fn escape_toggles_pause_and_backs_out_of_controls() {
         let mut scenario = hosted_scenario("spacewars", 42).unwrap();
         let mut input = ClientInput::default();
@@ -2024,6 +2085,39 @@ mod tests {
             &[],
         );
         assert_eq!(result.ingame_controls_visible, Some(false));
+    }
+
+    #[test]
+    fn controls_key_opens_the_controls_screen_and_pauses_gameplay() {
+        let mut scenario = hosted_scenario("spacewars", 42).unwrap();
+        let mut input = ClientInput::default();
+        let mut accumulator = Duration::from_secs(1);
+        let mut controls = ScenarioControls::default();
+        let mut paused = false;
+        let mut benchmark_active = false;
+
+        input.press(input::GameKey::Controls);
+        let result = step_scenario(
+            &mut scenario,
+            "spacewars",
+            42,
+            TickModel::FixedTimestep { hz: 60 },
+            Some(Duration::from_secs_f64(1.0 / 60.0)),
+            Duration::ZERO,
+            &mut accumulator,
+            &mut input,
+            &mut controls,
+            &mut paused,
+            &mut benchmark_active,
+            false,
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
+        );
+
+        assert!(paused);
+        assert_eq!(result.ingame_controls_visible, Some(true));
+        assert_eq!(accumulator, Duration::ZERO);
     }
 
     #[test]

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -5,7 +5,10 @@ use std::collections::BTreeSet;
 use std::rc::Rc;
 
 use engine_common::{Action, PointerPhase, RenderPoint};
-use scenario_spacewars::SpacewarsAction;
+use scenario_spacewars::{
+    ControlSource, ShipIntent, ShipIntentEncoder, SpacewarsAction, SpacewarsScenario,
+    SpacewarsState,
+};
 use slint::ComponentHandle;
 use slint::winit_030::winit::event::{ElementState, WindowEvent};
 use slint::winit_030::winit::keyboard::{KeyCode, PhysicalKey};
@@ -14,13 +17,86 @@ use slint::winit_030::{EventResult, WinitWindowAccessor};
 use crate::MainWindow;
 
 pub(crate) type SharedInput = Rc<RefCell<ClientInput>>;
+pub(crate) type SharedGamepadInput = Rc<RefCell<GamepadInput>>;
+type SharedKeyboardState = Rc<RefCell<BTreeSet<GameKey>>>;
 
-#[derive(Debug, Default)]
+pub(crate) fn new_shared_input() -> (SharedInput, SharedGamepadInput) {
+    let gamepads = Rc::new(RefCell::new(GamepadInput::default()));
+    let input = Rc::new(RefCell::new(ClientInput::new(Rc::clone(&gamepads))));
+    (input, gamepads)
+}
+
 pub(crate) struct ClientInput {
-    pressed: BTreeSet<GameKey>,
-    released: BTreeSet<GameKey>,
+    pressed: SharedKeyboardState,
+    gamepads: SharedGamepadInput,
+    spacewars_controls: SpacewarsControls,
     pointer_events: Vec<ScreenPointerEvent>,
     active_pointer: Option<RenderPoint>,
+}
+
+impl Default for ClientInput {
+    fn default() -> Self {
+        Self::new(Rc::new(RefCell::new(GamepadInput::default())))
+    }
+}
+
+impl ClientInput {
+    pub(crate) fn new(gamepads: SharedGamepadInput) -> Self {
+        let pressed = Rc::new(RefCell::new(BTreeSet::new()));
+        Self {
+            spacewars_controls: SpacewarsControls::new(Rc::clone(&pressed), Rc::clone(&gamepads)),
+            pressed,
+            gamepads,
+            pointer_events: Vec::new(),
+            active_pointer: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct GamepadSeatInput {
+    pub connected: bool,
+    pub name: String,
+    pub left_stick_x: f32,
+    pub left_stick_y: f32,
+    pub left_trigger: f32,
+    pub right_trigger: f32,
+    pub dpad_up: bool,
+    pub dpad_down: bool,
+    pub dpad_left: bool,
+    pub dpad_right: bool,
+    pub right_bumper: bool,
+    pub south: bool,
+    pub east: bool,
+    pub west: bool,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct GamepadInput {
+    seats: [GamepadSeatInput; 2],
+}
+
+impl GamepadInput {
+    pub(crate) fn seat(&self, player: usize) -> Option<&GamepadSeatInput> {
+        self.seats.get(player)
+    }
+
+    pub(crate) fn set_seat(&mut self, player: usize, state: GamepadSeatInput) {
+        if let Some(seat) = self.seats.get_mut(player) {
+            *seat = state;
+        }
+    }
+
+    pub(crate) fn disconnect_seat(&mut self, player: usize) {
+        let Some(seat) = self.seats.get_mut(player) else {
+            return;
+        };
+        let name = std::mem::take(&mut seat.name);
+        *seat = GamepadSeatInput {
+            name,
+            ..GamepadSeatInput::default()
+        };
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -33,6 +109,7 @@ pub(crate) struct ScreenPointerEvent {
 pub(crate) enum GameKey {
     Reset,
     Pause,
+    ForcePause,
     Benchmark,
     Back,
     Controls,
@@ -101,83 +178,76 @@ pub(crate) fn install_window_input(window: &MainWindow, input: SharedInput) {
 
 impl ClientInput {
     pub(crate) fn is_pressed(&self, key: GameKey) -> bool {
-        self.pressed.contains(&key)
+        self.pressed.borrow().contains(&key)
     }
 
     pub(crate) fn take_reset_requested(&mut self) -> bool {
-        let requested = self.pressed.remove(&GameKey::Reset);
-        self.released.remove(&GameKey::Reset);
-        requested
+        self.pressed.borrow_mut().remove(&GameKey::Reset)
     }
 
     pub(crate) fn take_pause_requested(&mut self) -> bool {
-        let requested = self.pressed.remove(&GameKey::Pause);
-        self.released.remove(&GameKey::Pause);
-        requested
+        self.pressed.borrow_mut().remove(&GameKey::Pause)
+    }
+
+    pub(crate) fn take_force_pause_requested(&mut self) -> bool {
+        self.pressed.borrow_mut().remove(&GameKey::ForcePause)
     }
 
     pub(crate) fn take_benchmark_requested(&mut self) -> bool {
-        let requested = self.pressed.remove(&GameKey::Benchmark);
-        self.released.remove(&GameKey::Benchmark);
-        requested
+        self.pressed.borrow_mut().remove(&GameKey::Benchmark)
     }
 
     pub(crate) fn take_back_requested(&mut self) -> bool {
-        let requested = self.pressed.remove(&GameKey::Back);
-        self.released.remove(&GameKey::Back);
-        requested
+        self.pressed.borrow_mut().remove(&GameKey::Back)
     }
 
     pub(crate) fn take_controls_requested(&mut self) -> bool {
-        let requested = self.pressed.remove(&GameKey::Controls);
-        self.released.remove(&GameKey::Controls);
-        requested
+        self.pressed.borrow_mut().remove(&GameKey::Controls)
     }
 
     pub(crate) fn take_return_launcher_requested(&mut self) -> bool {
-        let requested = self.pressed.remove(&GameKey::ReturnLauncher);
-        self.released.remove(&GameKey::ReturnLauncher);
-        requested
+        self.pressed.borrow_mut().remove(&GameKey::ReturnLauncher)
     }
 
-    pub(crate) fn actions_for_spacewars(&mut self) -> Vec<Action> {
-        let mut actions = Vec::new();
-
-        self.append_player_actions(
-            PlayerControlMap {
-                player: 0,
-                wing: GameKey::P1Wing,
-                thrust: GameKey::P1Thrust,
-                brake: GameKey::P1Brake,
-                reverse: GameKey::P1Reverse,
-                turn_left: GameKey::P1TurnLeft,
-                turn_right: GameKey::P1TurnRight,
-                laser: GameKey::P1Laser,
-                cannon: GameKey::P1Cannon,
-                zoom_in: GameKey::P1ZoomIn,
-                zoom_out: GameKey::P1ZoomOut,
-            },
-            &mut actions,
-        );
-        self.append_player_actions(
-            PlayerControlMap {
-                player: 1,
-                wing: GameKey::P2Wing,
-                thrust: GameKey::P2Thrust,
-                brake: GameKey::P2Brake,
-                reverse: GameKey::P2Reverse,
-                turn_left: GameKey::P2TurnLeft,
-                turn_right: GameKey::P2TurnRight,
-                laser: GameKey::P2Laser,
-                cannon: GameKey::P2Cannon,
-                zoom_in: GameKey::P2ZoomIn,
-                zoom_out: GameKey::P2ZoomOut,
-            },
-            &mut actions,
-        );
-
-        self.released.clear();
+    pub(crate) fn actions_for_spacewars(
+        &mut self,
+        state: &SpacewarsState,
+        benchmark_active: bool,
+    ) -> Vec<Action> {
+        let mut actions = self.spacewars_controls.actions(state, benchmark_active);
+        let pressed = self.pressed.borrow();
+        let gamepads = self.gamepads.borrow();
+        for controls in [P1_CONTROLS, P2_CONTROLS] {
+            let gamepad = gamepads.seat(controls.player);
+            if pressed.contains(&controls.zoom_in)
+                || gamepad.is_some_and(|gamepad| gamepad.connected && gamepad.dpad_up)
+            {
+                actions.push(SpacewarsAction::zoom_in(controls.player));
+            } else if pressed.contains(&controls.zoom_out)
+                || gamepad.is_some_and(|gamepad| gamepad.connected && gamepad.dpad_down)
+            {
+                actions.push(SpacewarsAction::zoom_out(controls.player));
+            }
+        }
         actions
+    }
+
+    pub(crate) fn rover_drive_input(&self) -> (f32, bool) {
+        let gamepads = self.gamepads.borrow();
+        let Some(gamepad) = gamepads.seat(0).filter(|gamepad| gamepad.connected) else {
+            return (0.0, false);
+        };
+        let brake = gamepad.south;
+        let throttle = match (gamepad.dpad_left, gamepad.dpad_right) {
+            (false, true) if !brake => 1.0,
+            (true, false) if !brake => -1.0,
+            _ => 0.0,
+        };
+        (throttle, brake)
+    }
+
+    pub(crate) fn reset_spacewars_controls(&mut self) {
+        self.spacewars_controls.reset();
     }
 
     pub(crate) fn clear(&mut self) {
@@ -187,8 +257,7 @@ impl ClientInput {
     }
 
     fn clear_keyboard(&mut self) {
-        self.pressed.clear();
-        self.released.clear();
+        self.pressed.borrow_mut().clear();
     }
 
     pub(crate) fn take_pointer_events(&mut self) -> Vec<ScreenPointerEvent> {
@@ -240,70 +309,11 @@ impl ClientInput {
     }
 
     pub(crate) fn press(&mut self, key: GameKey) {
-        self.pressed.insert(key);
-        self.released.remove(&key);
+        self.pressed.borrow_mut().insert(key);
     }
 
     pub(crate) fn release(&mut self, key: GameKey) {
-        if self.pressed.remove(&key) {
-            self.released.insert(key);
-        }
-    }
-
-    fn append_player_actions(&self, controls: PlayerControlMap, actions: &mut Vec<Action>) {
-        let wing_control_active = if self.pressed.contains(&controls.wing) {
-            actions.push(SpacewarsAction::close_wings(controls.player));
-            true
-        } else if self.released.contains(&controls.wing) {
-            actions.push(SpacewarsAction::open_wings(controls.player));
-            true
-        } else {
-            false
-        };
-
-        if self.pressed.contains(&controls.brake) {
-            actions.push(SpacewarsAction::brake(controls.player));
-        } else if self.released.contains(&controls.brake) {
-            actions.push(SpacewarsAction::brake_halt(controls.player));
-        } else if !wing_control_active {
-            if self.pressed.contains(&controls.thrust) {
-                actions.push(SpacewarsAction::thrust(controls.player));
-            } else if self.pressed.contains(&controls.reverse) {
-                actions.push(SpacewarsAction::reverse(controls.player));
-            } else if self.released.contains(&controls.thrust)
-                || self.released.contains(&controls.reverse)
-            {
-                actions.push(SpacewarsAction::thrust_halt(controls.player));
-            }
-        }
-
-        if self.pressed.contains(&controls.turn_left) {
-            actions.push(SpacewarsAction::turn_left(controls.player));
-        } else if self.pressed.contains(&controls.turn_right) {
-            actions.push(SpacewarsAction::turn_right(controls.player));
-        } else if self.released.contains(&controls.turn_left)
-            || self.released.contains(&controls.turn_right)
-        {
-            actions.push(SpacewarsAction::turn_halt(controls.player));
-        }
-
-        if self.pressed.contains(&controls.laser) {
-            actions.push(SpacewarsAction::fire_laser(controls.player));
-        } else if self.released.contains(&controls.laser) {
-            actions.push(SpacewarsAction::fire_laser_halt(controls.player));
-        }
-
-        if self.pressed.contains(&controls.cannon) {
-            actions.push(SpacewarsAction::fire_cannon(controls.player));
-        } else {
-            actions.push(SpacewarsAction::fire_cannon_halt(controls.player));
-        }
-
-        if self.pressed.contains(&controls.zoom_in) {
-            actions.push(SpacewarsAction::zoom_in(controls.player));
-        } else if self.pressed.contains(&controls.zoom_out) {
-            actions.push(SpacewarsAction::zoom_out(controls.player));
-        }
+        self.pressed.borrow_mut().remove(&key);
     }
 }
 
@@ -320,6 +330,219 @@ struct PlayerControlMap {
     cannon: GameKey,
     zoom_in: GameKey,
     zoom_out: GameKey,
+}
+
+const P1_CONTROLS: PlayerControlMap = PlayerControlMap {
+    player: 0,
+    wing: GameKey::P1Wing,
+    thrust: GameKey::P1Thrust,
+    brake: GameKey::P1Brake,
+    reverse: GameKey::P1Reverse,
+    turn_left: GameKey::P1TurnLeft,
+    turn_right: GameKey::P1TurnRight,
+    laser: GameKey::P1Laser,
+    cannon: GameKey::P1Cannon,
+    zoom_in: GameKey::P1ZoomIn,
+    zoom_out: GameKey::P1ZoomOut,
+};
+
+const P2_CONTROLS: PlayerControlMap = PlayerControlMap {
+    player: 1,
+    wing: GameKey::P2Wing,
+    thrust: GameKey::P2Thrust,
+    brake: GameKey::P2Brake,
+    reverse: GameKey::P2Reverse,
+    turn_left: GameKey::P2TurnLeft,
+    turn_right: GameKey::P2TurnRight,
+    laser: GameKey::P2Laser,
+    cannon: GameKey::P2Cannon,
+    zoom_in: GameKey::P2ZoomIn,
+    zoom_out: GameKey::P2ZoomOut,
+};
+
+struct SpacewarsControls {
+    seats: [ControlSeat; 2],
+    benchmark_sources: [BenchmarkSource; 2],
+    encoder: ShipIntentEncoder,
+}
+
+impl SpacewarsControls {
+    fn new(pressed: SharedKeyboardState, gamepads: SharedGamepadInput) -> Self {
+        let mut p1 =
+            ControlSeat::with_source(KeyboardSource::new(Rc::clone(&pressed), P1_CONTROLS));
+        p1.add_source(GamepadSource::new(Rc::clone(&gamepads), 0));
+        let mut p2 = ControlSeat::with_source(KeyboardSource::new(pressed, P2_CONTROLS));
+        p2.add_source(GamepadSource::new(gamepads, 1));
+        Self {
+            seats: [p1, p2],
+            benchmark_sources: [BenchmarkSource, BenchmarkSource],
+            encoder: ShipIntentEncoder::default(),
+        }
+    }
+
+    fn actions(&mut self, state: &SpacewarsState, benchmark_active: bool) -> Vec<Action> {
+        let mut actions = Vec::new();
+        for player in 0..self.seats.len() {
+            let intent = if benchmark_active {
+                self.benchmark_sources[player].intent(state, player)
+            } else {
+                self.seats[player].intent(state, player)
+            };
+            actions.extend(self.encoder.encode(player, intent));
+        }
+        actions
+    }
+
+    fn reset(&mut self) {
+        self.encoder.reset();
+    }
+}
+
+struct ControlSeat {
+    sources: Vec<Box<dyn ControlSource>>,
+}
+
+impl ControlSeat {
+    fn with_source(source: impl ControlSource + 'static) -> Self {
+        Self {
+            sources: vec![Box::new(source)],
+        }
+    }
+
+    fn add_source(&mut self, source: impl ControlSource + 'static) {
+        self.sources.push(Box::new(source));
+    }
+
+    fn intent(&mut self, state: &SpacewarsState, player: usize) -> ShipIntent {
+        self.sources
+            .iter_mut()
+            .fold(ShipIntent::default(), |intent, source| {
+                intent.merged_with(source.intent(state, player))
+            })
+    }
+}
+
+struct KeyboardSource {
+    pressed: SharedKeyboardState,
+    controls: PlayerControlMap,
+}
+
+impl KeyboardSource {
+    fn new(pressed: SharedKeyboardState, controls: PlayerControlMap) -> Self {
+        Self { pressed, controls }
+    }
+}
+
+impl ControlSource for KeyboardSource {
+    fn intent(&mut self, _state: &SpacewarsState, _player: usize) -> ShipIntent {
+        let pressed = self.pressed.borrow();
+        let thrust = if pressed.contains(&self.controls.thrust) {
+            1.0
+        } else if pressed.contains(&self.controls.reverse) {
+            -1.0
+        } else {
+            0.0
+        };
+        let turn = if pressed.contains(&self.controls.turn_left) {
+            -1.0
+        } else if pressed.contains(&self.controls.turn_right) {
+            1.0
+        } else {
+            0.0
+        };
+        ShipIntent {
+            turn,
+            thrust,
+            brake: if pressed.contains(&self.controls.brake) {
+                1.0
+            } else {
+                0.0
+            },
+            wings_closed: pressed.contains(&self.controls.wing),
+            laser: pressed.contains(&self.controls.laser),
+            cannon: pressed.contains(&self.controls.cannon),
+        }
+    }
+}
+
+struct GamepadSource {
+    gamepads: SharedGamepadInput,
+    seat: usize,
+}
+
+impl GamepadSource {
+    fn new(gamepads: SharedGamepadInput, seat: usize) -> Self {
+        Self { gamepads, seat }
+    }
+}
+
+impl ControlSource for GamepadSource {
+    fn intent(&mut self, _state: &SpacewarsState, _player: usize) -> ShipIntent {
+        let gamepads = self.gamepads.borrow();
+        let Some(gamepad) = gamepads.seat(self.seat) else {
+            return ShipIntent::default();
+        };
+        if !gamepad.connected {
+            return ShipIntent::default();
+        }
+
+        let turn = if gamepad.dpad_left {
+            -1.0
+        } else if gamepad.dpad_right {
+            1.0
+        } else {
+            shape_stick(gamepad.left_stick_x)
+        };
+        ShipIntent {
+            turn,
+            thrust: if gamepad.east {
+                -1.0
+            } else {
+                shape_trigger(gamepad.right_trigger)
+            },
+            brake: shape_trigger(gamepad.left_trigger),
+            wings_closed: gamepad.right_bumper,
+            laser: gamepad.south,
+            cannon: gamepad.west,
+        }
+    }
+}
+
+const STICK_DEADZONE: f32 = 0.15;
+const TRIGGER_DEADZONE: f32 = 0.05;
+
+pub(crate) fn shape_stick(value: f32) -> f32 {
+    shape_axis(value, STICK_DEADZONE, true)
+}
+
+pub(crate) fn shape_trigger(value: f32) -> f32 {
+    shape_axis(value.clamp(0.0, 1.0), TRIGGER_DEADZONE, false)
+}
+
+fn shape_axis(value: f32, deadzone: f32, signed: bool) -> f32 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    let value = if signed {
+        value.clamp(-1.0, 1.0)
+    } else {
+        value.clamp(0.0, 1.0)
+    };
+    let magnitude = value.abs();
+    if magnitude <= deadzone {
+        return 0.0;
+    }
+
+    let normalized = (magnitude - deadzone) / (1.0 - deadzone);
+    normalized * normalized * value.signum()
+}
+
+struct BenchmarkSource;
+
+impl ControlSource for BenchmarkSource {
+    fn intent(&mut self, state: &SpacewarsState, player: usize) -> ShipIntent {
+        SpacewarsScenario::benchmark_intent(state, player)
+    }
 }
 
 fn mapped_key_event(event: &WindowEvent) -> Option<(GameKey, ElementState)> {
@@ -371,6 +594,8 @@ fn game_key_from_key_code(code: KeyCode) -> Option<GameKey> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use engine_common::Scenario;
+    use engine_core::SpacewarsConfig;
     use scenario_spacewars::{SpacewarsAction as ScenarioAction, SpacewarsActionKind};
 
     fn decoded(actions: &[Action]) -> Vec<ScenarioAction> {
@@ -380,7 +605,12 @@ mod tests {
     fn has_action(actions: &[ScenarioAction], player: usize, kind: SpacewarsActionKind) -> bool {
         actions
             .iter()
-            .any(|action| action.player == player && action.kind == kind)
+            .any(|action| action.player() == player && action.kind() == kind)
+    }
+
+    fn take_spacewars_actions(input: &mut ClientInput) -> Vec<Action> {
+        let state = SpacewarsScenario::init(SpacewarsConfig::deathmatch(), 0);
+        input.actions_for_spacewars(&state, false)
     }
 
     #[test]
@@ -421,45 +651,61 @@ mod tests {
 
         input.clear_keyboard();
 
-        assert!(!input.pressed.contains(&GameKey::P1Thrust));
+        assert!(!input.pressed.borrow().contains(&GameKey::P1Thrust));
         assert!(input.has_pointer_cancellation());
     }
 
     #[test]
-    fn original_p1_wing_priority_suppresses_thrust_until_release_is_consumed() {
+    fn keyboard_source_emits_changed_full_scale_setpoints() {
         let mut input = ClientInput::default();
         input.press(GameKey::P1Wing);
         input.press(GameKey::P1Thrust);
 
-        let actions = decoded(&input.actions_for_spacewars());
-        assert!(has_action(&actions, 0, SpacewarsActionKind::CloseWings));
-        assert!(!has_action(&actions, 0, SpacewarsActionKind::Thrust));
+        let actions = decoded(&take_spacewars_actions(&mut input));
+        assert!(actions.contains(&ScenarioAction::SetWings {
+            player: 0,
+            closed: true,
+        }));
+        assert!(actions.contains(&ScenarioAction::SetThrust {
+            player: 0,
+            amount: 1.0,
+        }));
 
         input.release(GameKey::P1Wing);
-        let actions = decoded(&input.actions_for_spacewars());
-        assert!(has_action(&actions, 0, SpacewarsActionKind::OpenWings));
-        assert!(!has_action(&actions, 0, SpacewarsActionKind::Thrust));
+        let actions = decoded(&take_spacewars_actions(&mut input));
+        assert_eq!(
+            actions,
+            vec![ScenarioAction::SetWings {
+                player: 0,
+                closed: false,
+            }]
+        );
 
-        let actions = decoded(&input.actions_for_spacewars());
-        assert!(has_action(&actions, 0, SpacewarsActionKind::Thrust));
+        let actions = decoded(&take_spacewars_actions(&mut input));
+        assert!(actions.is_empty());
     }
 
     #[test]
-    fn release_emits_one_tick_halt_for_continuous_controls() {
+    fn release_emits_one_changed_zero_setpoint() {
         let mut input = ClientInput::default();
         input.press(GameKey::P1TurnLeft);
         input.press(GameKey::P1Laser);
-        input.actions_for_spacewars();
+        take_spacewars_actions(&mut input);
 
         input.release(GameKey::P1TurnLeft);
         input.release(GameKey::P1Laser);
-        let actions = decoded(&input.actions_for_spacewars());
-        assert!(has_action(&actions, 0, SpacewarsActionKind::TurnHalt));
-        assert!(has_action(&actions, 0, SpacewarsActionKind::FireLaserHalt));
+        let actions = decoded(&take_spacewars_actions(&mut input));
+        assert!(actions.contains(&ScenarioAction::SetTurn {
+            player: 0,
+            rate: 0.0,
+        }));
+        assert!(actions.contains(&ScenarioAction::SetLaser {
+            player: 0,
+            on: false,
+        }));
 
-        let actions = decoded(&input.actions_for_spacewars());
-        assert!(!has_action(&actions, 0, SpacewarsActionKind::TurnHalt));
-        assert!(!has_action(&actions, 0, SpacewarsActionKind::FireLaserHalt));
+        let actions = decoded(&take_spacewars_actions(&mut input));
+        assert!(actions.is_empty());
     }
 
     #[test]
@@ -483,33 +729,47 @@ mod tests {
     }
 
     #[test]
-    fn brake_has_propulsion_priority_and_remains_available_with_wings() {
+    fn keyboard_source_reports_brake_and_propulsion_independently() {
         let mut input = ClientInput::default();
         input.press(GameKey::P1Wing);
         input.press(GameKey::P1Thrust);
         input.press(GameKey::P1Reverse);
         input.press(GameKey::P1Brake);
 
-        let actions = decoded(&input.actions_for_spacewars());
+        let actions = decoded(&take_spacewars_actions(&mut input));
 
-        assert!(has_action(&actions, 0, SpacewarsActionKind::CloseWings));
-        assert!(has_action(&actions, 0, SpacewarsActionKind::Brake));
-        assert!(!has_action(&actions, 0, SpacewarsActionKind::Thrust));
-        assert!(!has_action(&actions, 0, SpacewarsActionKind::Reverse));
+        assert!(actions.contains(&ScenarioAction::SetWings {
+            player: 0,
+            closed: true,
+        }));
+        assert!(actions.contains(&ScenarioAction::SetBrake {
+            player: 0,
+            amount: 1.0,
+        }));
+        assert!(actions.contains(&ScenarioAction::SetThrust {
+            player: 0,
+            amount: 1.0,
+        }));
     }
 
     #[test]
-    fn brake_release_emits_one_tick_brake_halt() {
+    fn brake_release_emits_one_zero_setpoint() {
         let mut input = ClientInput::default();
         input.press(GameKey::P1Brake);
-        input.actions_for_spacewars();
+        take_spacewars_actions(&mut input);
 
         input.release(GameKey::P1Brake);
-        let actions = decoded(&input.actions_for_spacewars());
-        assert!(has_action(&actions, 0, SpacewarsActionKind::BrakeHalt));
+        let actions = decoded(&take_spacewars_actions(&mut input));
+        assert_eq!(
+            actions,
+            vec![ScenarioAction::SetBrake {
+                player: 0,
+                amount: 0.0,
+            }]
+        );
 
-        let actions = decoded(&input.actions_for_spacewars());
-        assert!(!has_action(&actions, 0, SpacewarsActionKind::BrakeHalt));
+        let actions = decoded(&take_spacewars_actions(&mut input));
+        assert!(actions.is_empty());
     }
 
     #[test]
@@ -578,7 +838,7 @@ mod tests {
         let mut input = ClientInput::default();
         input.press(GameKey::P1ZoomIn);
         input.press(GameKey::P2ZoomOut);
-        let actions = decoded(&input.actions_for_spacewars());
+        let actions = decoded(&take_spacewars_actions(&mut input));
 
         assert!(has_action(&actions, 0, SpacewarsActionKind::ZoomIn));
         assert!(has_action(&actions, 1, SpacewarsActionKind::ZoomOut));
@@ -652,5 +912,88 @@ mod tests {
             game_key_from_key_code(KeyCode::KeyQ),
             Some(GameKey::ReturnLauncher)
         );
+    }
+
+    #[test]
+    fn gamepad_curves_apply_deadzones_and_reach_full_scale() {
+        assert_eq!(shape_stick(0.14), 0.0);
+        assert_eq!(shape_stick(-0.15), 0.0);
+        assert!((shape_stick(0.575) - 0.25).abs() < 0.001);
+        assert_eq!(shape_stick(-1.0), -1.0);
+        assert_eq!(shape_trigger(0.04), 0.0);
+        assert_eq!(shape_trigger(1.0), 1.0);
+        assert_eq!(shape_stick(f32::NAN), 0.0);
+    }
+
+    #[test]
+    fn gamepad_source_maps_ship_controls_and_reverse_wins() {
+        let gamepads = Rc::new(RefCell::new(GamepadInput::default()));
+        gamepads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                left_stick_x: 1.0,
+                left_trigger: 0.5,
+                right_trigger: 0.75,
+                right_bumper: true,
+                south: true,
+                east: true,
+                west: true,
+                ..GamepadSeatInput::default()
+            },
+        );
+        let mut input = ClientInput::new(gamepads);
+        let actions = decoded(&take_spacewars_actions(&mut input));
+
+        assert!(actions.contains(&ScenarioAction::SetTurn {
+            player: 0,
+            rate: 1.0,
+        }));
+        assert!(actions.contains(&ScenarioAction::SetThrust {
+            player: 0,
+            amount: -1.0,
+        }));
+        assert!(actions.iter().any(|action| matches!(
+            action,
+            ScenarioAction::SetBrake {
+                player: 0,
+                amount,
+            } if *amount > 0.0 && *amount < 0.5
+        )));
+        assert!(actions.contains(&ScenarioAction::SetWings {
+            player: 0,
+            closed: true,
+        }));
+        assert!(actions.contains(&ScenarioAction::SetLaser {
+            player: 0,
+            on: true,
+        }));
+        assert!(actions.contains(&ScenarioAction::SetCannon {
+            player: 0,
+            on: true,
+        }));
+    }
+
+    #[test]
+    fn pad_wins_equal_magnitude_merge_and_dpad_controls_zoom() {
+        let gamepads = Rc::new(RefCell::new(GamepadInput::default()));
+        gamepads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                dpad_right: true,
+                dpad_up: true,
+                ..GamepadSeatInput::default()
+            },
+        );
+        let mut input = ClientInput::new(gamepads);
+        input.press(GameKey::P1TurnLeft);
+        let actions = decoded(&take_spacewars_actions(&mut input));
+
+        assert!(actions.contains(&ScenarioAction::SetTurn {
+            player: 0,
+            rate: 1.0,
+        }));
+        assert!(has_action(&actions, 0, SpacewarsActionKind::ZoomIn));
     }
 }

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -69,6 +69,8 @@ pub(crate) struct GamepadSeatInput {
     pub south: bool,
     pub east: bool,
     pub west: bool,
+    pub start: bool,
+    pub select: bool,
 }
 
 #[derive(Debug, Default)]

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -218,16 +218,10 @@ impl ClientInput {
     ) -> Vec<Action> {
         let mut actions = self.spacewars_controls.actions(state, benchmark_active);
         let pressed = self.pressed.borrow();
-        let gamepads = self.gamepads.borrow();
         for controls in [P1_CONTROLS, P2_CONTROLS] {
-            let gamepad = gamepads.seat(controls.player);
-            if pressed.contains(&controls.zoom_in)
-                || gamepad.is_some_and(|gamepad| gamepad.connected && gamepad.dpad_up)
-            {
+            if pressed.contains(&controls.zoom_in) {
                 actions.push(SpacewarsAction::zoom_in(controls.player));
-            } else if pressed.contains(&controls.zoom_out)
-                || gamepad.is_some_and(|gamepad| gamepad.connected && gamepad.dpad_down)
-            {
+            } else if pressed.contains(&controls.zoom_out) {
                 actions.push(SpacewarsAction::zoom_out(controls.player));
             }
         }
@@ -495,14 +489,20 @@ impl ControlSource for GamepadSource {
         } else {
             shape_stick(gamepad.left_stick_x)
         };
+        let forward_thrust = if gamepad.dpad_up {
+            1.0
+        } else {
+            shape_trigger(gamepad.right_trigger)
+        };
+        let brake = if gamepad.dpad_down {
+            1.0
+        } else {
+            shape_trigger(gamepad.left_trigger)
+        };
         ShipIntent {
             turn,
-            thrust: if gamepad.east {
-                -1.0
-            } else {
-                shape_trigger(gamepad.right_trigger)
-            },
-            brake: shape_trigger(gamepad.left_trigger),
+            thrust: if gamepad.east { -1.0 } else { forward_thrust },
+            brake,
             wings_closed: gamepad.right_bumper,
             laser: gamepad.south,
             cannon: gamepad.west,
@@ -937,6 +937,7 @@ mod tests {
                 left_stick_x: 1.0,
                 left_trigger: 0.5,
                 right_trigger: 0.75,
+                dpad_up: true,
                 right_bumper: true,
                 south: true,
                 east: true,
@@ -977,7 +978,7 @@ mod tests {
     }
 
     #[test]
-    fn pad_wins_equal_magnitude_merge_and_dpad_controls_zoom() {
+    fn dpad_controls_digital_flight_without_changing_zoom() {
         let gamepads = Rc::new(RefCell::new(GamepadInput::default()));
         gamepads.borrow_mut().set_seat(
             0,
@@ -996,6 +997,26 @@ mod tests {
             player: 0,
             rate: 1.0,
         }));
-        assert!(has_action(&actions, 0, SpacewarsActionKind::ZoomIn));
+        assert!(actions.contains(&ScenarioAction::SetThrust {
+            player: 0,
+            amount: 1.0,
+        }));
+        assert!(!has_action(&actions, 0, SpacewarsActionKind::ZoomIn));
+
+        input.gamepads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                dpad_down: true,
+                ..GamepadSeatInput::default()
+            },
+        );
+        let actions = decoded(&take_spacewars_actions(&mut input));
+
+        assert!(actions.contains(&ScenarioAction::SetBrake {
+            player: 0,
+            amount: 1.0,
+        }));
+        assert!(!has_action(&actions, 0, SpacewarsActionKind::ZoomOut));
     }
 }

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -4,12 +4,14 @@
 //! from the launcher, with Null retained as a hidden test scenario.
 
 mod client_scenarios;
+mod gamepad;
 mod host;
 mod input;
 mod ipc;
 mod raster;
 mod render;
 mod settings;
+mod ui_navigation;
 
 use std::cell::RefCell;
 use std::env;
@@ -33,8 +35,9 @@ use scenario_pizza::{
     PizzaPhysicsBackend,
 };
 use settings::LoadStatus;
-use slint::{ComponentHandle, ModelRc, SharedString, Timer, VecModel};
+use slint::{ComponentHandle, Model, ModelRc, SharedString, Timer, VecModel};
 use tracing_subscriber::EnvFilter;
+use ui_navigation::UiAction;
 
 slint::include_modules!();
 
@@ -313,12 +316,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     select_slint_backend(&args)?;
     let window = MainWindow::new()?;
     let _control_server = ipc::start_control_server(&window, ipc::control_socket_path());
+    let (input, gamepad_input) = input::new_shared_input();
+    input::install_window_input(&window, Rc::clone(&input));
     let render_timer = Rc::new(RefCell::new(None));
     let scenario_controls = host::new_scenario_controls();
     install_launcher_callbacks(
         &window,
         Rc::clone(&render_timer),
         Rc::clone(&scenario_controls),
+        Rc::clone(&input),
         Arc::clone(&settings),
         settings_path.clone(),
     );
@@ -326,9 +332,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &window,
         Rc::clone(&render_timer),
         Rc::clone(&scenario_controls),
+        Rc::clone(&input),
         Arc::clone(&settings),
     );
+    install_ui_navigation(&window);
     apply_video_settings(&window, &args, &settings.read().unwrap());
+    let _gamepad_timer = gamepad::start_gamepad_pump(&window, Rc::clone(&input), gamepad_input);
 
     if args.uses_debug_render() {
         *render_timer.borrow_mut() = Some(host::start_debug_render_loop(
@@ -344,6 +353,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             args.benchmark,
             args.benchmark_configuration(),
             Rc::clone(&scenario_controls),
+            Rc::clone(&input),
             scenario_settings,
         )?);
     } else {
@@ -464,6 +474,7 @@ fn show_launcher(window: &MainWindow, launch: &EffectiveLaunch, settings: &Setti
     window.set_scenario_pointer_enabled(false);
     window.set_ingame_menu_visible(false);
     window.set_ingame_controls_visible(false);
+    window.set_game_over_visible(false);
     let scenario_names = host::launcher_scenario_names()
         .into_iter()
         .map(SharedString::from)
@@ -494,6 +505,9 @@ fn show_launcher(window: &MainWindow, launch: &EffectiveLaunch, settings: &Setti
         pizza.ball_spawn_rate,
     )));
     window.set_launcher_error_text(SharedString::from(""));
+    window.set_launcher_focus_index(0);
+    window.set_launcher_settings_focus_index(0);
+    window.set_launcher_settings_visible(false);
     window.set_launcher_controls_visible(false);
     window.set_launcher_visible(true);
 }
@@ -549,12 +563,14 @@ fn install_launcher_callbacks(
     window: &MainWindow,
     render_timer: Rc<RefCell<Option<Timer>>>,
     scenario_controls: host::SharedScenarioControls,
+    input: input::SharedInput,
     settings: Arc<RwLock<Settings>>,
     settings_path: PathBuf,
 ) {
     let weak = window.as_weak();
     let game_timer = Rc::clone(&render_timer);
     let game_controls = Rc::clone(&scenario_controls);
+    let game_input = Rc::clone(&input);
     let game_settings = Arc::clone(&settings);
     let game_settings_path = settings_path.clone();
     window.on_launcher_start_game(move || {
@@ -562,6 +578,7 @@ fn install_launcher_callbacks(
             &weak,
             &game_timer,
             &game_controls,
+            &game_input,
             &game_settings,
             &game_settings_path,
             false,
@@ -571,12 +588,14 @@ fn install_launcher_callbacks(
     let weak = window.as_weak();
     let benchmark_timer = Rc::clone(&render_timer);
     let benchmark_controls = Rc::clone(&scenario_controls);
+    let benchmark_input = Rc::clone(&input);
     let benchmark_settings = Arc::clone(&settings);
     window.on_launcher_start_benchmark(move || {
         handle_launcher_start(
             &weak,
             &benchmark_timer,
             &benchmark_controls,
+            &benchmark_input,
             &benchmark_settings,
             &settings_path,
             true,
@@ -627,6 +646,7 @@ fn install_ingame_menu_callbacks(
     window: &MainWindow,
     render_timer: Rc<RefCell<Option<Timer>>>,
     scenario_controls: host::SharedScenarioControls,
+    input: input::SharedInput,
     settings: Arc<RwLock<Settings>>,
 ) {
     let controls = Rc::clone(&scenario_controls);
@@ -666,14 +686,326 @@ fn install_ingame_menu_callbacks(
 
     let weak = window.as_weak();
     window.on_ingame_return_launcher(move || {
-        handle_return_to_launcher(&weak, &render_timer, &scenario_controls, &settings);
+        handle_return_to_launcher(&weak, &render_timer, &scenario_controls, &input, &settings);
     });
+}
+
+fn install_ui_navigation(window: &MainWindow) {
+    let weak = window.as_weak();
+    window.on_ui_action(move |code| {
+        let Some(window) = weak.upgrade() else {
+            return;
+        };
+        let Some(action) = UiAction::from_code(code) else {
+            return;
+        };
+        handle_ui_action(&window, action);
+    });
+}
+
+fn handle_ui_action(window: &MainWindow, action: UiAction) {
+    if window.get_launcher_visible() {
+        handle_launcher_ui_action(window, action);
+    } else if window.get_game_over_visible() {
+        handle_game_over_ui_action(window, action);
+    } else if window.get_ingame_menu_visible() {
+        handle_ingame_menu_ui_action(window, action);
+    }
+}
+
+fn handle_launcher_ui_action(window: &MainWindow, action: UiAction) {
+    if window.get_launcher_controls_visible() {
+        match action {
+            UiAction::Back | UiAction::Confirm | UiAction::Controls => {
+                window.set_launcher_controls_visible(false);
+            }
+            UiAction::Start => window.invoke_launcher_start_game(),
+            _ => {}
+        }
+        return;
+    }
+
+    if window.get_launcher_settings_visible() {
+        let item_count = launcher_settings_item_count(window);
+        match action {
+            UiAction::Up => {
+                window.set_launcher_settings_focus_index(ui_navigation::moved_selection(
+                    window.get_launcher_settings_focus_index(),
+                    item_count,
+                    -1,
+                ))
+            }
+            UiAction::Down => {
+                window.set_launcher_settings_focus_index(ui_navigation::moved_selection(
+                    window.get_launcher_settings_focus_index(),
+                    item_count,
+                    1,
+                ))
+            }
+            UiAction::Left => adjust_launcher_setting(window, -1),
+            UiAction::Right => adjust_launcher_setting(window, 1),
+            UiAction::Confirm => {
+                if window.get_launcher_settings_focus_index() == item_count - 1 {
+                    window.set_launcher_settings_visible(false);
+                } else {
+                    adjust_launcher_setting(window, 1);
+                }
+            }
+            UiAction::Back => window.set_launcher_settings_visible(false),
+            UiAction::Start => window.invoke_launcher_start_game(),
+            UiAction::Controls => {
+                window.set_launcher_settings_visible(false);
+                window.set_launcher_controls_visible(true);
+            }
+        }
+        return;
+    }
+
+    match action {
+        UiAction::Up | UiAction::Down => window.set_launcher_focus_index(
+            ui_navigation::moved_launcher_selection(window.get_launcher_focus_index(), action),
+        ),
+        UiAction::Left => {
+            if window.get_launcher_focus_index() == 0 {
+                cycle_launcher_scenario(window, -1);
+            } else {
+                window.set_launcher_focus_index(ui_navigation::moved_launcher_selection(
+                    window.get_launcher_focus_index(),
+                    action,
+                ));
+            }
+        }
+        UiAction::Right => {
+            if window.get_launcher_focus_index() == 0 {
+                cycle_launcher_scenario(window, 1);
+            } else {
+                window.set_launcher_focus_index(ui_navigation::moved_launcher_selection(
+                    window.get_launcher_focus_index(),
+                    action,
+                ));
+            }
+        }
+        UiAction::Confirm => match window.get_launcher_focus_index() {
+            0 => cycle_launcher_scenario(window, 1),
+            1 => window.invoke_launcher_start_game(),
+            2 => window.set_launcher_settings_visible(true),
+            3 => window.set_launcher_controls_visible(true),
+            4 => window.invoke_launcher_quit(),
+            _ => {}
+        },
+        // Back never exits the root kiosk screen. Quit is an explicit menu item.
+        UiAction::Back => {}
+        UiAction::Start => window.invoke_launcher_start_game(),
+        UiAction::Controls => window.set_launcher_controls_visible(true),
+    }
+}
+
+fn handle_game_over_ui_action(window: &MainWindow, action: UiAction) {
+    match action {
+        UiAction::Up | UiAction::Left => window.set_game_over_focus_index(
+            ui_navigation::moved_selection(window.get_game_over_focus_index(), 2, -1),
+        ),
+        UiAction::Down | UiAction::Right => window.set_game_over_focus_index(
+            ui_navigation::moved_selection(window.get_game_over_focus_index(), 2, 1),
+        ),
+        UiAction::Confirm => {
+            if window.get_game_over_focus_index() == 0 {
+                window.invoke_ingame_restart();
+            } else {
+                window.invoke_ingame_return_launcher();
+            }
+        }
+        UiAction::Start => window.invoke_ingame_restart(),
+        UiAction::Back => window.invoke_ingame_return_launcher(),
+        UiAction::Controls => {}
+    }
+}
+
+fn handle_ingame_menu_ui_action(window: &MainWindow, action: UiAction) {
+    if window.get_ingame_controls_visible() {
+        match action {
+            UiAction::Back | UiAction::Confirm | UiAction::Controls => {
+                window.set_ingame_controls_visible(false);
+            }
+            UiAction::Start => window.invoke_ingame_resume(),
+            _ => {}
+        }
+        return;
+    }
+
+    let benchmark_offset = i32::from(window.get_scenario_benchmark_available());
+    match action {
+        UiAction::Up | UiAction::Down | UiAction::Left | UiAction::Right => {
+            window.set_ingame_menu_focus_index(ui_navigation::moved_ingame_selection(
+                window.get_ingame_menu_focus_index(),
+                benchmark_offset == 1,
+                action,
+            ));
+        }
+        UiAction::Confirm => {
+            let selected = window.get_ingame_menu_focus_index();
+            if selected == 0 {
+                window.invoke_ingame_resume();
+            } else if selected == 1 {
+                window.invoke_ingame_restart();
+            } else if benchmark_offset == 1 && selected == 2 {
+                window.invoke_ingame_start_benchmark();
+            } else if selected == 2 + benchmark_offset {
+                window.set_ingame_controls_visible(true);
+            } else if selected == 3 + benchmark_offset {
+                window.invoke_ingame_return_launcher();
+            }
+        }
+        UiAction::Back | UiAction::Start => window.invoke_ingame_resume(),
+        UiAction::Controls => window.set_ingame_controls_visible(true),
+    }
+}
+
+fn cycle_launcher_scenario(window: &MainWindow, delta: i32) {
+    let scenarios = window.get_launcher_scenarios();
+    let count = scenarios.row_count() as i32;
+    if count <= 0 {
+        return;
+    }
+    let current = (0..count as usize)
+        .find(|&index| {
+            scenarios
+                .row_data(index)
+                .is_some_and(|scenario| scenario == window.get_launcher_scenario())
+        })
+        .unwrap_or(0) as i32;
+    let index = ui_navigation::moved_selection(current, count, delta);
+    let Some(scenario) = scenarios.row_data(index as usize) else {
+        return;
+    };
+    window.set_launcher_scenario(scenario.clone());
+    window.invoke_launcher_scenario_selected(scenario);
+    window.set_launcher_settings_focus_index(0);
+}
+
+fn launcher_settings_item_count(window: &MainWindow) -> i32 {
+    match window.get_launcher_scenario().as_str() {
+        "spacewars" => 7,
+        "pizza" => 5,
+        _ => 3,
+    }
+}
+
+fn adjust_launcher_setting(window: &MainWindow, delta: i32) {
+    let focus = window.get_launcher_settings_focus_index();
+    if focus == 0 {
+        let next = cycle_label(
+            window.get_launcher_renderer().as_str(),
+            &["vector", "raster"],
+            delta,
+        );
+        window.set_launcher_renderer(SharedString::from(next));
+        return;
+    }
+    if focus == 1 {
+        let next = cycle_label(
+            window.get_launcher_raster_scale_text().as_str(),
+            &["1.0", "1.5", "2.0", "3.0"],
+            delta,
+        );
+        window.set_launcher_raster_scale_text(SharedString::from(next));
+        return;
+    }
+
+    match window.get_launcher_scenario().as_str() {
+        "spacewars" => adjust_spacewars_launcher_setting(window, focus, delta),
+        "pizza" => adjust_pizza_launcher_setting(window, focus, delta),
+        _ => {}
+    }
+}
+
+fn adjust_spacewars_launcher_setting(window: &MainWindow, focus: i32, delta: i32) {
+    match focus {
+        2 => {
+            let next = cycle_label(
+                window.get_launcher_spacewars_preset().as_str(),
+                &[
+                    PRESET_ORIGINAL,
+                    PRESET_SMALL_DUEL,
+                    PRESET_DENSE_ASTEROIDS,
+                    PRESET_LONG_GAME,
+                ],
+                delta,
+            );
+            window.set_launcher_spacewars_preset(SharedString::from(next));
+            window.invoke_launcher_apply_preset();
+        }
+        3 => {
+            let next = cycle_label(
+                window.get_launcher_use_planets().as_str(),
+                &["on", "off"],
+                delta,
+            );
+            window.set_launcher_use_planets(SharedString::from(next));
+            window.set_launcher_spacewars_preset(SharedString::from(PRESET_CUSTOM));
+        }
+        4 => {
+            let next = cycle_label(
+                window.get_launcher_asteroids_enabled().as_str(),
+                &["on", "off"],
+                delta,
+            );
+            window.set_launcher_asteroids_enabled(SharedString::from(next));
+            window.set_launcher_spacewars_preset(SharedString::from(PRESET_CUSTOM));
+        }
+        5 => {
+            let current = window
+                .get_launcher_player_health_text()
+                .parse::<i32>()
+                .unwrap_or(100);
+            let next = (current + delta.signum() * 25).clamp(
+                MIN_SPACEWARS_PLAYER_HEALTH_PERCENT as i32,
+                MAX_SPACEWARS_PLAYER_HEALTH_PERCENT as i32,
+            );
+            window.set_launcher_player_health_text(SharedString::from(next.to_string()));
+            window.set_launcher_spacewars_preset(SharedString::from(PRESET_CUSTOM));
+        }
+        _ => {}
+    }
+}
+
+fn adjust_pizza_launcher_setting(window: &MainWindow, focus: i32, delta: i32) {
+    match focus {
+        2 => {
+            let current = window
+                .get_launcher_pizza_desired_balls_text()
+                .parse::<i32>()
+                .unwrap_or(24);
+            let next = (current + delta.signum() * 25).clamp(1, MAX_PIZZA_DESIRED_BALLS as i32);
+            window.set_launcher_pizza_desired_balls_text(SharedString::from(next.to_string()));
+        }
+        3 => {
+            let current = window
+                .get_launcher_pizza_spawn_rate_text()
+                .parse::<f32>()
+                .unwrap_or(0.1);
+            let next = (current + delta.signum() as f32 * 0.05)
+                .clamp(MIN_PIZZA_BALL_SPAWN_RATE, MAX_PIZZA_BALL_SPAWN_RATE);
+            window
+                .set_launcher_pizza_spawn_rate_text(SharedString::from(format_float_setting(next)));
+        }
+        _ => {}
+    }
+}
+
+fn cycle_label<'a>(current: &str, values: &'a [&'a str], delta: i32) -> &'a str {
+    let current = values
+        .iter()
+        .position(|value| *value == current)
+        .unwrap_or(0) as i32;
+    values[ui_navigation::moved_selection(current, values.len() as i32, delta) as usize]
 }
 
 fn handle_return_to_launcher(
     weak_window: &slint::Weak<MainWindow>,
     render_timer: &Rc<RefCell<Option<Timer>>>,
     scenario_controls: &host::SharedScenarioControls,
+    input: &input::SharedInput,
     settings: &Arc<RwLock<Settings>>,
 ) {
     let Some(window) = weak_window.upgrade() else {
@@ -684,6 +1016,8 @@ fn handle_return_to_launcher(
         timer.stop();
     }
     scenario_controls.borrow_mut().clear();
+    input.borrow_mut().clear();
+    input.borrow_mut().reset_spacewars_controls();
     let settings = settings.read().unwrap();
     let launch = launch_from_settings(&settings);
     show_launcher(&window, &launch, &settings);
@@ -754,6 +1088,7 @@ fn handle_launcher_start(
     weak_window: &slint::Weak<MainWindow>,
     render_timer: &Rc<RefCell<Option<Timer>>>,
     scenario_controls: &host::SharedScenarioControls,
+    input: &input::SharedInput,
     settings: &Arc<RwLock<Settings>>,
     settings_path: &Path,
     start_benchmark: bool,
@@ -794,6 +1129,7 @@ fn handle_launcher_start(
         start_benchmark,
         host::BenchmarkConfiguration::default(),
         Rc::clone(scenario_controls),
+        Rc::clone(input),
         scenario_settings,
     ) {
         Ok(timer) => {
@@ -804,9 +1140,11 @@ fn handle_launcher_start(
             scenario_controls.borrow_mut().clear();
             *timer_slot = Some(timer);
             window.set_launcher_visible(false);
+            window.set_launcher_settings_visible(false);
             window.set_launcher_controls_visible(false);
             window.set_ingame_menu_visible(false);
             window.set_ingame_controls_visible(false);
+            window.set_game_over_visible(false);
         }
         Err(err) => {
             window.set_launcher_error_text(SharedString::from(err.to_string()));
@@ -1191,6 +1529,7 @@ fn start_scenario_from_launch(
     start_benchmark: bool,
     benchmark_configuration: host::BenchmarkConfiguration,
     controls: host::SharedScenarioControls,
+    input: input::SharedInput,
     settings: Settings,
 ) -> Result<Timer, host::HostError> {
     controls.borrow_mut().clear();
@@ -1205,6 +1544,7 @@ fn start_scenario_from_launch(
             renderer: launch.renderer,
             raster_scale: launch.raster_scale,
             controls: Some(controls),
+            input: Some(input),
             settings,
         },
     )

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -213,12 +213,8 @@ impl Args {
         self.benchmark || self.benchmark_headless
     }
 
-    fn has_launch_override(&self) -> bool {
-        self.scenario.is_some()
-            || self.seed.is_some()
-            || self.renderer.is_some()
-            || self.raster_scale.is_some()
-            || self.kiosk
+    fn requests_direct_launch(&self) -> bool {
+        self.scenario.is_some() || self.kiosk
     }
 
     fn benchmark_configuration(&self) -> host::BenchmarkConfiguration {
@@ -457,7 +453,7 @@ fn normalize_raster_scale(value: f32) -> f32 {
 }
 
 fn should_launch_directly(args: &Args) -> bool {
-    args.uses_debug_render() || args.uses_benchmark() || args.has_launch_override()
+    args.uses_debug_render() || args.uses_benchmark() || args.requests_direct_launch()
 }
 
 fn show_launcher(window: &MainWindow, launch: &EffectiveLaunch, settings: &Settings) {
@@ -1578,6 +1574,12 @@ mod tests {
 
         let mut args = base_args();
         args.fullscreen = true;
+        assert!(!should_launch_directly(&args));
+
+        let mut args = base_args();
+        args.seed = Some(42);
+        args.renderer = Some(RendererArg::Raster);
+        args.raster_scale = Some(2.0);
         assert!(!should_launch_directly(&args));
     }
 

--- a/crates/engine-client/src/ui_navigation.rs
+++ b/crates/engine-client/src/ui_navigation.rs
@@ -1,0 +1,121 @@
+//! Backend-neutral menu actions shared by keyboards and gamepads.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub(crate) enum UiAction {
+    Up = 0,
+    Down = 1,
+    Left = 2,
+    Right = 3,
+    Confirm = 4,
+    Back = 5,
+    Start = 6,
+    Controls = 7,
+}
+
+impl UiAction {
+    pub(crate) const fn code(self) -> i32 {
+        self as i32
+    }
+
+    pub(crate) const fn from_code(code: i32) -> Option<Self> {
+        match code {
+            0 => Some(Self::Up),
+            1 => Some(Self::Down),
+            2 => Some(Self::Left),
+            3 => Some(Self::Right),
+            4 => Some(Self::Confirm),
+            5 => Some(Self::Back),
+            6 => Some(Self::Start),
+            7 => Some(Self::Controls),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn moved_selection(current: i32, item_count: i32, delta: i32) -> i32 {
+    if item_count <= 0 {
+        return 0;
+    }
+    (current.clamp(0, item_count - 1) + delta).rem_euclid(item_count)
+}
+
+pub(crate) fn moved_launcher_selection(current: i32, action: UiAction) -> i32 {
+    let current = current.clamp(0, 4);
+    match action {
+        UiAction::Up => [3, 0, 0, 1, 2][current as usize],
+        UiAction::Down => [1, 3, 4, 0, 0][current as usize],
+        UiAction::Left | UiAction::Right => [0, 2, 1, 4, 3][current as usize],
+        _ => current,
+    }
+}
+
+pub(crate) fn moved_ingame_selection(
+    current: i32,
+    benchmark_available: bool,
+    action: UiAction,
+) -> i32 {
+    if benchmark_available {
+        let current = current.clamp(0, 4);
+        match action {
+            UiAction::Up => [4, 4, 0, 1, 2][current as usize],
+            UiAction::Down => [2, 3, 4, 4, 0][current as usize],
+            UiAction::Left | UiAction::Right => [1, 0, 3, 2, 4][current as usize],
+            _ => current,
+        }
+    } else {
+        let current = current.clamp(0, 3);
+        match action {
+            UiAction::Up | UiAction::Down => [2, 3, 0, 1][current as usize],
+            UiAction::Left | UiAction::Right => [1, 0, 3, 2][current as usize],
+            _ => current,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selection_wraps_in_both_directions() {
+        assert_eq!(moved_selection(0, 5, -1), 4);
+        assert_eq!(moved_selection(4, 5, 1), 0);
+        assert_eq!(moved_selection(2, 5, 1), 3);
+    }
+
+    #[test]
+    fn action_codes_round_trip() {
+        for action in [
+            UiAction::Up,
+            UiAction::Down,
+            UiAction::Left,
+            UiAction::Right,
+            UiAction::Confirm,
+            UiAction::Back,
+            UiAction::Start,
+            UiAction::Controls,
+        ] {
+            assert_eq!(UiAction::from_code(action.code()), Some(action));
+        }
+        assert_eq!(UiAction::from_code(99), None);
+    }
+
+    #[test]
+    fn launcher_navigation_matches_the_visible_grid() {
+        assert_eq!(moved_launcher_selection(0, UiAction::Down), 1);
+        assert_eq!(moved_launcher_selection(1, UiAction::Right), 2);
+        assert_eq!(moved_launcher_selection(2, UiAction::Down), 4);
+        assert_eq!(moved_launcher_selection(4, UiAction::Left), 3);
+        assert_eq!(moved_launcher_selection(3, UiAction::Down), 0);
+    }
+
+    #[test]
+    fn pause_navigation_accounts_for_optional_benchmark() {
+        assert_eq!(moved_ingame_selection(0, true, UiAction::Down), 2);
+        assert_eq!(moved_ingame_selection(2, true, UiAction::Down), 4);
+        assert_eq!(moved_ingame_selection(4, true, UiAction::Down), 0);
+        assert_eq!(moved_ingame_selection(0, false, UiAction::Down), 2);
+        assert_eq!(moved_ingame_selection(2, false, UiAction::Right), 3);
+    }
+}

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -1,7 +1,5 @@
 // Root window for the engine-client.
 
-import { Button, ComboBox, LineEdit } from "std-widgets.slint";
-
 export enum PrimitiveKind {
     path,
     text,
@@ -113,6 +111,96 @@ component PlayerStatusPanel inherits Rectangle {
     }
 }
 
+component MenuButton inherits Rectangle {
+    in property <string> text;
+    in property <bool> selected: false;
+    callback activated();
+
+    background: root.selected ? #174f70 : #151a27;
+    border-color: root.selected ? #80d8ff : #596273;
+    border-width: root.selected ? 3px : 1px;
+    border-radius: 6px;
+
+    Text {
+        x: 12px;
+        width: parent.width - 24px;
+        height: parent.height;
+        text: root.text;
+        color: root.selected ? #ffffff : #d9e1ec;
+        font-size: 16px;
+        font-weight: root.selected ? 700 : 500;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+
+    TouchArea {
+        width: parent.width;
+        height: parent.height;
+        mouse-cursor: pointer;
+        clicked => {
+            root.activated();
+        }
+    }
+}
+
+component ChoiceRow inherits Rectangle {
+    in property <string> label;
+    in property <string> value;
+    in property <bool> selected: false;
+    callback previous();
+    callback next();
+
+    background: root.selected ? #122f44 : #10141f;
+    border-color: root.selected ? #80d8ff : #424a5a;
+    border-width: root.selected ? 3px : 1px;
+    border-radius: 6px;
+
+    Text {
+        x: 14px;
+        width: parent.width * 0.38;
+        height: parent.height;
+        text: root.label;
+        color: #c7d0dc;
+        font-size: 14px;
+        vertical-alignment: center;
+    }
+
+    MenuButton {
+        x: parent.width * 0.40;
+        y: 6px;
+        width: 48px;
+        height: parent.height - 12px;
+        text: "‹";
+        activated => {
+            root.previous();
+        }
+    }
+
+    Text {
+        x: parent.width * 0.40 + 56px;
+        width: parent.width * 0.60 - 112px;
+        height: parent.height;
+        text: root.value;
+        color: #ffffff;
+        font-size: 15px;
+        font-weight: 600;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        overflow: elide;
+    }
+
+    MenuButton {
+        x: parent.width - 54px;
+        y: 6px;
+        width: 48px;
+        height: parent.height - 12px;
+        text: "›";
+        activated => {
+            root.next();
+        }
+    }
+}
+
 export component MainWindow inherits Window {
     in property <bool> app-full-screen: false;
     in property <[ScenePrimitive]> primitives;
@@ -131,8 +219,14 @@ export component MainWindow inherits Window {
     in property <bool> scenario-pointer-enabled: false;
     in-out property <bool> launcher-visible: false;
     in-out property <bool> launcher-controls-visible: false;
+    in-out property <bool> launcher-settings-visible: false;
+    in-out property <int> launcher-focus-index: 0;
+    in-out property <int> launcher-settings-focus-index: 0;
     in-out property <bool> ingame-menu-visible: false;
     in-out property <bool> ingame-controls-visible: false;
+    in-out property <int> ingame-menu-focus-index: 0;
+    in-out property <bool> game-over-visible: false;
+    in-out property <int> game-over-focus-index: 0;
     in property <[string]> launcher-scenarios;
     in-out property <string> launcher-scenario: "spacewars";
     in-out property <string> launcher-seed-text: "0";
@@ -152,6 +246,10 @@ export component MainWindow inherits Window {
     in property <bool> scenario-benchmark-available: false;
     in property <bool> scenario-player-zoom-available: false;
     in property <string> scenario-controls-help: "";
+    in property <string> p1-input-binding: "P1 ⌨";
+    in property <string> p2-input-binding: "P2 ⌨";
+    in-out property <bool> controller-disconnected-visible: false;
+    in-out property <string> controller-disconnected-text: "";
     in property <bool> spacewars-ui-visible: false;
     in property <string> p1-name: "";
     in property <string> p1-status: "";
@@ -188,6 +286,7 @@ export component MainWindow inherits Window {
     callback ingame-p2-zoom-in();
     callback ingame-p2-zoom-out();
     callback scenario-pointer(float, float, int);
+    callback ui-action(int);
 
     forward-focus: launcher-shortcuts;
 
@@ -200,6 +299,24 @@ export component MainWindow inherits Window {
     changed launcher-controls-visible => {
         if (root.launcher-visible) {
             launcher-shortcuts.focus();
+        }
+    }
+
+    changed launcher-settings-visible => {
+        if (root.launcher-visible) {
+            launcher-shortcuts.focus();
+        }
+    }
+
+    changed ingame-menu-visible => {
+        if (root.ingame-menu-visible) {
+            root.ingame-menu-focus-index = 0;
+        }
+    }
+
+    changed game-over-visible => {
+        if (root.game-over-visible) {
+            root.game-over-focus-index = 0;
         }
     }
 
@@ -242,7 +359,10 @@ export component MainWindow inherits Window {
     }
 
     scenario-pointer-area := TouchArea {
-        enabled: root.scenario-pointer-enabled && !root.launcher-visible && !root.ingame-menu-visible;
+        enabled: root.scenario-pointer-enabled
+            && !root.launcher-visible
+            && !root.ingame-menu-visible
+            && !root.game-over-visible;
         width: parent.width;
         height: parent.height;
         mouse-cursor: crosshair;
@@ -412,48 +532,124 @@ export component MainWindow inherits Window {
         visible: root.ingame-menu-visible;
         width: parent.width;
         height: parent.height;
-        background: #050514bb;
+        background: #050514cc;
 
         Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
-            width: 560px;
-            height: root.ingame-controls-visible ? 470px : 310px;
-            background: #080a12f2;
+            width: root.width < 632px ? root.width - 32px : 600px;
+            height: root.ingame-controls-visible ? (root.height < 456px ? root.height - 24px : 432px) : 326px;
+            background: #080a12f7;
             border-color: #596273;
             border-width: 1px;
+            border-radius: 8px;
 
             Text {
                 x: 24px;
-                y: 22px;
+                y: 18px;
                 text: root.ingame-controls-visible ? "Controls" : "Paused";
-                color: #e6edf7;
-                font-size: 24px;
+                color: #ffffff;
+                font-size: 26px;
+                font-weight: 700;
             }
 
             Text {
                 visible: !root.ingame-controls-visible;
                 x: 24px;
-                y: 66px;
+                y: 54px;
                 width: parent.width - 48px;
-                text: "P or Esc resumes from the keyboard. Q returns to the launcher.";
-                color: #c7d0dc;
-                font-size: 13px;
+                text: "D-pad chooses  ·  A selects  ·  B or Start resumes";
+                color: #80d8ff;
+                font-size: 14px;
+                horizontal-alignment: center;
+            }
+
+            MenuButton {
+                visible: !root.ingame-controls-visible;
+                x: 24px;
+                y: 84px;
+                width: (parent.width - 58px) / 2;
+                height: 54px;
+                text: "Resume";
+                selected: root.ingame-menu-focus-index == 0;
+                activated => {
+                    root.ingame-menu-focus-index = 0;
+                    root.ingame-resume();
+                }
+            }
+
+            MenuButton {
+                visible: !root.ingame-controls-visible;
+                x: parent.width / 2 + 5px;
+                y: 84px;
+                width: (parent.width - 58px) / 2;
+                height: 54px;
+                text: "Restart Round";
+                selected: root.ingame-menu-focus-index == 1;
+                activated => {
+                    root.ingame-menu-focus-index = 1;
+                    root.ingame-restart();
+                }
+            }
+
+            MenuButton {
+                visible: !root.ingame-controls-visible && root.scenario-benchmark-available;
+                x: 24px;
+                y: 148px;
+                width: (parent.width - 58px) / 2;
+                height: 54px;
+                text: "Benchmark";
+                selected: root.ingame-menu-focus-index == 2;
+                activated => {
+                    root.ingame-menu-focus-index = 2;
+                    root.ingame-start-benchmark();
+                }
+            }
+
+            MenuButton {
+                visible: !root.ingame-controls-visible;
+                x: root.scenario-benchmark-available ? parent.width / 2 + 5px : 24px;
+                y: 148px;
+                width: (parent.width - 58px) / 2;
+                height: 54px;
+                text: "Controls";
+                selected: root.ingame-menu-focus-index == (root.scenario-benchmark-available ? 3 : 2);
+                activated => {
+                    root.ingame-menu-focus-index = root.scenario-benchmark-available ? 3 : 2;
+                    root.ingame-controls-visible = true;
+                }
+            }
+
+            MenuButton {
+                visible: !root.ingame-controls-visible;
+                x: root.scenario-benchmark-available ? 24px : parent.width / 2 + 5px;
+                y: root.scenario-benchmark-available ? 212px : 148px;
+                width: root.scenario-benchmark-available ? parent.width - 48px : (parent.width - 58px) / 2;
+                height: 54px;
+                text: "Return to Launcher";
+                selected: root.ingame-menu-focus-index == (root.scenario-benchmark-available ? 4 : 3);
+                activated => {
+                    root.ingame-menu-focus-index = root.scenario-benchmark-available ? 4 : 3;
+                    root.ingame-return-launcher();
+                }
             }
 
             Rectangle {
                 visible: root.ingame-controls-visible;
                 x: 24px;
-                y: 74px;
+                y: 62px;
                 width: parent.width - 48px;
-                height: 250px;
-                background: #00000000;
+                height: parent.height - 132px;
+                background: #10141f;
+                border-color: #424a5a;
+                border-width: 1px;
+                border-radius: 6px;
 
                 Text {
-                    x: 0px;
-                    y: 0px;
-                    width: parent.width;
-                    height: 132px;
+                    x: 16px;
+                    y: 12px;
+                    width: parent.width - 32px;
+                    height: 145px;
                     text: root.scenario-controls-help;
                     color: #e6edf7;
                     font-size: 13px;
@@ -461,169 +657,126 @@ export component MainWindow inherits Window {
                 }
 
                 Text {
-                    visible: false;
-                    x: 0px;
-                    y: 54px;
-                    width: parent.width;
-                    text: "Player 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon";
-                    color: #e6edf7;
+                    x: 16px;
+                    y: 160px;
+                    width: parent.width - 32px;
+                    height: 80px;
+                    text: "Controller menus: D-pad or left stick navigates, A selects, B goes back, Start resumes. Disconnecting a controller pauses the round.";
+                    color: #80d8ff;
                     font-size: 13px;
                     wrap: word-wrap;
                 }
 
                 Text {
-                    visible: root.scenario-player-zoom-available;
-                    x: 0px;
-                    y: 126px;
-                    width: parent.width;
-                    text: "Zoom: P1 U/I, P2 Insert/Home.";
+                    x: 16px;
+                    y: 238px;
+                    width: parent.width - 32px;
+                    height: 52px;
+                    text: "Keyboard: P/Esc pause, R restart, " + (root.scenario-benchmark-available ? "B benchmark, " : "") + "Q launcher, C/F1 controls.";
                     color: #c7d0dc;
-                    font-size: 13px;
-                    wrap: word-wrap;
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 0px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P1 In";
-                    clicked => {
-                        root.ingame-p1-zoom-in();
-                    }
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 114px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P1 Out";
-                    clicked => {
-                        root.ingame-p1-zoom-out();
-                    }
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 228px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P2 In";
-                    clicked => {
-                        root.ingame-p2-zoom-in();
-                    }
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 342px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P2 Out";
-                    clicked => {
-                        root.ingame-p2-zoom-out();
-                    }
-                }
-
-                Text {
-                    x: 0px;
-                    y: 214px;
-                    width: parent.width;
-                    text: "Global: P/Esc pause/resume, R restart, " + (root.scenario-benchmark-available ? "B benchmark, " : "") + "Q launcher, C or F1 controls/back. Losing window focus clears held input.";
-                    color: #c7d0dc;
-                    font-size: 13px;
+                    font-size: 12px;
                     wrap: word-wrap;
                 }
             }
 
-            Button {
-                visible: !root.ingame-controls-visible;
-                x: 24px;
-                y: 106px;
-                width: 160px;
-                height: 36px;
-                text: "Resume (P/Esc)";
-                primary: true;
-                clicked => {
-                    root.ingame-resume();
-                }
-            }
-
-            Button {
-                visible: !root.ingame-controls-visible;
-                x: 194px;
-                y: 106px;
-                width: 150px;
-                height: 36px;
-                text: "Restart (R)";
-                clicked => {
-                    root.ingame-restart();
-                }
-            }
-
-            Button {
-                visible: !root.ingame-controls-visible && root.scenario-benchmark-available;
-                x: 354px;
-                y: 106px;
-                width: 160px;
-                height: 36px;
-                text: "Benchmark (B)";
-                clicked => {
-                    root.ingame-start-benchmark();
-                }
-            }
-
-            Button {
-                visible: !root.ingame-controls-visible;
-                x: 24px;
-                y: 158px;
-                width: 246px;
-                height: 36px;
-                text: "Return to Launcher (Q)";
-                clicked => {
-                    root.ingame-return-launcher();
-                }
-            }
-
-            Button {
-                visible: !root.ingame-controls-visible;
-                x: 290px;
-                y: 158px;
-                width: 246px;
-                height: 36px;
-                text: "Controls (F1)";
-                clicked => {
-                    root.ingame-controls-visible = true;
-                }
-            }
-
-            Button {
+            MenuButton {
                 visible: root.ingame-controls-visible;
                 x: 24px;
-                y: 390px;
-                width: 140px;
-                height: 36px;
-                text: "Back (Esc)";
-                clicked => {
+                y: parent.height - 58px;
+                width: 150px;
+                height: 42px;
+                text: "Back";
+                selected: true;
+                activated => {
                     root.ingame-controls-visible = false;
                 }
             }
 
-            Button {
+            MenuButton {
                 visible: root.ingame-controls-visible;
-                x: parent.width - 164px;
-                y: 390px;
-                width: 140px;
-                height: 36px;
-                text: "Resume (P)";
-                primary: true;
-                clicked => {
+                x: parent.width - 174px;
+                y: parent.height - 58px;
+                width: 150px;
+                height: 42px;
+                text: "Resume";
+                activated => {
                     root.ingame-resume();
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        visible: root.game-over-visible && !root.launcher-visible;
+        width: parent.width;
+        height: parent.height;
+        background: #050514c8;
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: root.width < 592px ? root.width - 32px : 560px;
+            height: 254px;
+            background: #080a12f8;
+            border-color: #f6f2a6;
+            border-width: 2px;
+            border-radius: 10px;
+
+            Text {
+                y: 24px;
+                width: parent.width;
+                text: "Round Complete";
+                color: #ffffff;
+                font-size: 30px;
+                font-weight: 700;
+                horizontal-alignment: center;
+            }
+
+            Text {
+                x: 24px;
+                y: 72px;
+                width: parent.width - 48px;
+                height: 38px;
+                text: root.spacewars-message-text;
+                color: #f6f2a6;
+                font-size: 17px;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+
+            Text {
+                x: 24px;
+                y: 112px;
+                width: parent.width - 48px;
+                text: "A selects  ·  Start plays again  ·  B returns to launcher";
+                color: #80d8ff;
+                font-size: 13px;
+                horizontal-alignment: center;
+            }
+
+            MenuButton {
+                x: 24px;
+                y: 150px;
+                width: (parent.width - 58px) / 2;
+                height: 64px;
+                text: "Play Again";
+                selected: root.game-over-focus-index == 0;
+                activated => {
+                    root.game-over-focus-index = 0;
+                    root.ingame-restart();
+                }
+            }
+
+            MenuButton {
+                x: parent.width / 2 + 5px;
+                y: 150px;
+                width: (parent.width - 58px) / 2;
+                height: 64px;
+                text: "Launcher";
+                selected: root.game-over-focus-index == 1;
+                activated => {
+                    root.game-over-focus-index = 1;
+                    root.ingame-return-launcher();
                 }
             }
         }
@@ -643,44 +796,41 @@ export component MainWindow inherits Window {
             }
 
             if (event.text == Key.Escape) {
-                if (root.launcher-controls-visible) {
-                    root.launcher-controls-visible = false;
-                } else {
-                    root.launcher-quit();
-                }
+                root.ui-action(5);
                 return accept;
             }
-
-            if (event.text == Key.F1) {
-                root.launcher-controls-visible = !root.launcher-controls-visible;
+            if (event.text == Key.UpArrow) {
+                root.ui-action(0);
                 return accept;
             }
-
-            if (root.launcher-controls-visible) {
-                if (event.text == "c" || event.text == "C") {
-                    root.launcher-controls-visible = false;
-                    return accept;
-                }
-                return reject;
+            if (event.text == Key.DownArrow) {
+                root.ui-action(1);
+                return accept;
             }
-
-            if (seed-edit.has-focus || universe-radius-edit.has-focus || asteroid-rate-edit.has-focus || player-health-edit.has-focus || pizza-balls-edit.has-focus || pizza-spawn-rate-edit.has-focus) {
-                return reject;
+            if (event.text == Key.LeftArrow) {
+                root.ui-action(2);
+                return accept;
             }
-
+            if (event.text == Key.RightArrow) {
+                root.ui-action(3);
+                return accept;
+            }
             if (event.text == Key.Return) {
-                root.launcher-start-game();
+                root.ui-action(4);
                 return accept;
-            } else if (event.text == "b" || event.text == "B") {
+            }
+            if (event.text == Key.F1 || event.text == "c" || event.text == "C") {
+                root.ui-action(7);
+                return accept;
+            }
+            if (event.text == "b" || event.text == "B") {
                 root.launcher-start-benchmark();
-                return accept;
-            } else if (event.text == "c" || event.text == "C") {
-                root.launcher-controls-visible = true;
                 return accept;
             }
 
             return reject;
         }
+
 
         Rectangle {
             width: parent.width;
@@ -690,556 +840,458 @@ export component MainWindow inherits Window {
             Rectangle {
                 x: (parent.width - self.width) / 2;
                 y: (parent.height - self.height) / 2;
-                width: root.launcher-controls-visible ? 500px : 580px;
-                height: root.launcher-controls-visible ? 540px : root.launcher-scenario == "spacewars" ? 710px : root.launcher-scenario == "pizza" ? 592px : 430px;
-                background: #080a12f2;
+                width: root.width < 792px ? root.width - 32px : 760px;
+                height: root.height < 464px ? root.height - 24px : 440px;
+                background: #080a12f8;
                 border-color: #596273;
                 border-width: 1px;
+                border-radius: 10px;
 
-            Text {
-                x: 24px;
-                y: 22px;
-                text: "Space-Wars";
-                color: #e6edf7;
-                font-size: 28px;
-            }
-
-            Text {
-                x: 24px;
-                y: 62px;
-                text: root.launcher-controls-visible ? "Controls" : "Launch";
-                color: #c7d0dc;
-                font-size: 14px;
-            }
-
-            VerticalLayout {
-                visible: !root.launcher-controls-visible;
-                x: 24px;
-                y: 96px;
-                width: parent.width - 48px;
-                height: parent.height - 118px;
-                spacing: 6px;
-
-                HorizontalLayout {
-                    height: 34px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Scenario";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    ComboBox {
-                        horizontal-stretch: 1;
-                        model: root.launcher-scenarios;
-                        current-value <=> root.launcher-scenario;
-                        selected(value) => {
-                            root.launcher-scenario-selected(value);
-                        }
-                    }
-                }
-
-                HorizontalLayout {
-                    height: 34px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Seed";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    seed-edit := LineEdit {
-                        horizontal-stretch: 1;
-                        text <=> root.launcher-seed-text;
-                        placeholder-text: "0";
-                        accepted => {
-                            root.launcher-start-game();
-                        }
-                    }
-                }
-
-                HorizontalLayout {
-                    height: 34px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Renderer";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    ComboBox {
-                        horizontal-stretch: 1;
-                        model: ["vector", "raster"];
-                        current-value <=> root.launcher-renderer;
-                    }
-                }
-
-                HorizontalLayout {
-                    height: 34px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Raster Scale";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    ComboBox {
-                        horizontal-stretch: 1;
-                        model: ["1.0", "1.5", "2.0", "3.0"];
-                        current-value <=> root.launcher-raster-scale-text;
-                    }
+                Text {
+                    x: 24px;
+                    y: 16px;
+                    text: "Space-Wars";
+                    color: #ffffff;
+                    font-size: 28px;
+                    font-weight: 700;
                 }
 
                 Text {
-                    visible: root.launcher-scenario == "rover-lab";
-                    height: root.launcher-scenario == "rover-lab" ? 44px : 0px;
-                    text: "Rapier 2D feasibility lab: a pin-slot suspension rover on a rotating circular planet with a raised bump.";
-                    color: #c7d0dc;
-                    font-size: 12px;
-                    wrap: word-wrap;
-                }
-
-                Text {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 22px : 0px;
-                    text: "Game Setup";
-                    color: #e6edf7;
+                    x: 24px;
+                    y: 50px;
+                    width: parent.width - 48px;
+                    text: root.launcher-error-text != "" ? root.launcher-error-text : root.launcher-controls-visible ? "Controls" : root.launcher-settings-visible ? "Settings · left/right adjusts the highlighted value" : "Choose a scenario";
+                    color: root.launcher-error-text != "" ? #ff7184 : #9fb4cc;
                     font-size: 13px;
-                    vertical-alignment: bottom;
-                }
-
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Preset";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    ComboBox {
-                        horizontal-stretch: 1;
-                        model: ["Custom", "Original", "Small Duel", "Dense Asteroids", "Long Game"];
-                        current-value <=> root.launcher-spacewars-preset;
-                    }
-
-                    Button {
-                        width: 150px;
-                        text: "Apply";
-                        clicked => {
-                            root.launcher-apply-preset();
-                        }
-                    }
-                }
-
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "World Radius";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    universe-radius-edit := LineEdit {
-                        horizontal-stretch: 1;
-                        text <=> root.launcher-universe-radius-text;
-                        placeholder-text: "1200";
-                        accepted => {
-                            root.launcher-start-game();
-                        }
-                    }
-                }
-
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Planets";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    ComboBox {
-                        horizontal-stretch: 1;
-                        model: ["on", "off"];
-                        current-value <=> root.launcher-use-planets;
-                    }
-                }
-
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Asteroids";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    ComboBox {
-                        horizontal-stretch: 1;
-                        model: ["on", "off"];
-                        current-value <=> root.launcher-asteroids-enabled;
-                    }
-                }
-
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Asteroid Rate";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    asteroid-rate-edit := LineEdit {
-                        horizontal-stretch: 1;
-                        text <=> root.launcher-asteroid-probability-text;
-                        placeholder-text: "20.0";
-                        accepted => {
-                            root.launcher-start-game();
-                        }
-                    }
-                }
-
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 34px : 0px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Player Health";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    player-health-edit := LineEdit {
-                        horizontal-stretch: 1;
-                        text <=> root.launcher-player-health-text;
-                        placeholder-text: "100";
-                        accepted => {
-                            root.launcher-start-game();
-                        }
-                    }
                 }
 
                 Text {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 16px : 0px;
-                    text: "Setup: " + root.launcher-spacewars-preset + " | radius " + root.launcher-universe-radius-text + " | health " + root.launcher-player-health-text + "%";
-                    color: #c7d0dc;
-                    font-size: 12px;
+                    x: parent.width - 300px;
+                    y: 22px;
+                    width: 276px;
+                    text: root.p1-input-binding + "   " + root.p2-input-binding;
+                    color: #80d8ff;
+                    font-size: 14px;
+                    horizontal-alignment: right;
                 }
 
-                Text {
-                    visible: root.launcher-scenario == "spacewars";
-                    height: root.launcher-scenario == "spacewars" ? 16px : 0px;
-                    text: "Planets " + root.launcher-use-planets + " | asteroids " + root.launcher-asteroids-enabled + " @ " + root.launcher-asteroid-probability-text + "/s";
-                    color: #c7d0dc;
-                    font-size: 12px;
-                }
+                Rectangle {
+                    visible: !root.launcher-controls-visible && !root.launcher-settings-visible;
+                    x: 24px;
+                    y: 72px;
+                    width: parent.width - 48px;
+                    height: parent.height - 92px;
+                    background: #00000000;
 
-                Text {
-                    visible: root.launcher-scenario == "pizza";
-                    height: root.launcher-scenario == "pizza" ? 22px : 0px;
-                    text: "Pizza Setup";
-                    color: #e6edf7;
-                    font-size: 13px;
-                    vertical-alignment: bottom;
-                }
-
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "pizza";
-                    height: root.launcher-scenario == "pizza" ? 34px : 0px;
-                    spacing: 10px;
-
-                    Text {
-                        text: "Desired Balls";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
-
-                    pizza-balls-edit := LineEdit {
-                        horizontal-stretch: 1;
-                        text <=> root.launcher-pizza-desired-balls-text;
-                        placeholder-text: "24";
-                        accepted => {
-                            root.launcher-start-game();
+                    ChoiceRow {
+                        x: 0px;
+                        y: 0px;
+                        width: parent.width;
+                        height: 58px;
+                        label: "Scenario";
+                        value: root.launcher-scenario;
+                        selected: root.launcher-focus-index == 0;
+                        previous => {
+                            root.launcher-focus-index = 0;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-focus-index = 0;
+                            root.ui-action(3);
                         }
                     }
-                }
 
-                HorizontalLayout {
-                    visible: root.launcher-scenario == "pizza";
-                    height: root.launcher-scenario == "pizza" ? 34px : 0px;
-                    spacing: 10px;
+                    Rectangle {
+                        x: 0px;
+                        y: 68px;
+                        width: parent.width;
+                        height: 74px;
+                        background: #10141f;
+                        border-color: #424a5a;
+                        border-width: 1px;
+                        border-radius: 6px;
 
-                    Text {
-                        text: "Spawn Rate";
-                        color: #c7d0dc;
-                        font-size: 13px;
-                        vertical-alignment: center;
-                        width: 150px;
-                    }
+                        Text {
+                            x: 14px;
+                            y: 9px;
+                            width: parent.width - 28px;
+                            height: 24px;
+                            text: root.launcher-scenario == "spacewars" ? "Two-player orbital combat and planet capture" : root.launcher-scenario == "pizza" ? "Interactive many-body collision sandbox" : "Rapier rover and wheel mechanics lab";
+                            color: #e6edf7;
+                            font-size: 15px;
+                        }
 
-                    pizza-spawn-rate-edit := LineEdit {
-                        horizontal-stretch: 1;
-                        text <=> root.launcher-pizza-spawn-rate-text;
-                        placeholder-text: "0.10";
-                        accepted => {
-                            root.launcher-start-game();
+                        Text {
+                            x: 14px;
+                            y: 38px;
+                            width: parent.width - 28px;
+                            height: 22px;
+                            text: root.launcher-scenario == "spacewars" ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : "A semi-interactive mechanics scenario";
+                            color: #9fb4cc;
+                            font-size: 13px;
                         }
                     }
-                }
 
-                Text {
-                    visible: root.launcher-scenario == "pizza";
-                    height: root.launcher-scenario == "pizza" ? 16px : 0px;
-                    text: "Spawns up to " + root.launcher-pizza-desired-balls-text + " balls at " + root.launcher-pizza-spawn-rate-text + " chance/tick.";
-                    color: #c7d0dc;
-                    font-size: 12px;
-                }
-
-                Text {
-                    visible: root.launcher-scenario == "pizza";
-                    height: root.launcher-scenario == "pizza" ? 30px : 0px;
-                    text: "Benchmark starts an immediate, deterministic 300-ball dense Rapier workload. CLI options select other populations, backends, and workloads.";
-                    color: #9fb4cc;
-                    font-size: 11px;
-                    wrap: word-wrap;
-                }
-
-                Text {
-                    text: root.launcher-error-text;
-                    color: #ff6f6f;
-                    font-size: 13px;
-                    height: 18px;
-                }
-
-                HorizontalLayout {
-                    height: 36px;
-                    spacing: 10px;
-
-                    Button {
-                        width: 170px;
-                        text: "Start Game (Enter)";
-                        primary: true;
-                        clicked => {
+                    MenuButton {
+                        x: 0px;
+                        y: 154px;
+                        width: (parent.width - 12px) / 2;
+                        height: 64px;
+                        text: "Start Game";
+                        selected: root.launcher-focus-index == 1;
+                        activated => {
+                            root.launcher-focus-index = 1;
                             root.launcher-start-game();
                         }
                     }
 
-                    Button {
-                        visible: root.scenario-benchmark-available;
-                        width: 150px;
-                        text: "Benchmark (B)";
-                        clicked => {
-                            root.launcher-start-benchmark();
+                    MenuButton {
+                        x: parent.width / 2 + 6px;
+                        y: 154px;
+                        width: (parent.width - 12px) / 2;
+                        height: 64px;
+                        text: "Settings";
+                        selected: root.launcher-focus-index == 2;
+                        activated => {
+                            root.launcher-focus-index = 2;
+                            root.launcher-settings-visible = true;
                         }
                     }
 
-                    Button {
-                        width: 150px;
-                        text: "Controls (F1)";
-                        clicked => {
+                    MenuButton {
+                        x: 0px;
+                        y: 228px;
+                        width: (parent.width - 12px) / 2;
+                        height: 56px;
+                        text: "Controls";
+                        selected: root.launcher-focus-index == 3;
+                        activated => {
+                            root.launcher-focus-index = 3;
                             root.launcher-controls-visible = true;
                         }
                     }
 
-                    Rectangle {
-                        horizontal-stretch: 1;
-                        background: #00000000;
+                    MenuButton {
+                        x: parent.width / 2 + 6px;
+                        y: 228px;
+                        width: (parent.width - 12px) / 2;
+                        height: 56px;
+                        text: "Quit";
+                        selected: root.launcher-focus-index == 4;
+                        activated => {
+                            root.launcher-focus-index = 4;
+                            root.launcher-quit();
+                        }
+                    }
+
+                    Text {
+                        x: 0px;
+                        y: 296px;
+                        width: parent.width;
+                        text: "D-pad / left stick chooses  ·  A selects  ·  Start launches";
+                        color: #80d8ff;
+                        font-size: 14px;
+                        horizontal-alignment: center;
+                    }
+
+                    Text {
+                        x: 0px;
+                        y: 322px;
+                        width: parent.width;
+                        text: root.scenario-benchmark-available ? "Keyboard: arrows + Enter  ·  B starts benchmark  ·  F1 opens controls" : "Keyboard: arrows + Enter  ·  F1 opens controls";
+                        color: #7d8494;
+                        font-size: 11px;
+                        horizontal-alignment: center;
                     }
                 }
 
-                HorizontalLayout {
-                    height: 36px;
+                Rectangle {
+                    visible: root.launcher-settings-visible;
+                    x: 24px;
+                    y: 72px;
+                    width: parent.width - 48px;
+                    height: parent.height - 88px;
+                    background: #00000000;
 
-                    Rectangle {
-                        horizontal-stretch: 1;
-                        background: #00000000;
+                    ChoiceRow {
+                        x: 0px;
+                        y: 0px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Renderer";
+                        value: root.launcher-renderer;
+                        selected: root.launcher-settings-focus-index == 0;
+                        previous => {
+                            root.launcher-settings-focus-index = 0;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 0;
+                            root.ui-action(3);
+                        }
                     }
 
-                    Button {
-                        width: 140px;
-                        text: "Quit (Esc)";
-                        clicked => {
-                            root.launcher-quit();
+                    ChoiceRow {
+                        x: 0px;
+                        y: 52px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Raster Scale";
+                        value: root.launcher-raster-scale-text + "×";
+                        selected: root.launcher-settings-focus-index == 1;
+                        previous => {
+                            root.launcher-settings-focus-index = 1;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 1;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
+                        visible: root.launcher-scenario == "spacewars";
+                        x: 0px;
+                        y: 104px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Preset";
+                        value: root.launcher-spacewars-preset;
+                        selected: root.launcher-settings-focus-index == 2;
+                        previous => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
+                        visible: root.launcher-scenario == "spacewars";
+                        x: 0px;
+                        y: 156px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Planets";
+                        value: root.launcher-use-planets;
+                        selected: root.launcher-settings-focus-index == 3;
+                        previous => {
+                            root.launcher-settings-focus-index = 3;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 3;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
+                        visible: root.launcher-scenario == "spacewars";
+                        x: 0px;
+                        y: 208px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Asteroids";
+                        value: root.launcher-asteroids-enabled;
+                        selected: root.launcher-settings-focus-index == 4;
+                        previous => {
+                            root.launcher-settings-focus-index = 4;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 4;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
+                        visible: root.launcher-scenario == "spacewars";
+                        x: 0px;
+                        y: 260px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Player Health";
+                        value: root.launcher-player-health-text + "%";
+                        selected: root.launcher-settings-focus-index == 5;
+                        previous => {
+                            root.launcher-settings-focus-index = 5;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 5;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
+                        visible: root.launcher-scenario == "pizza";
+                        x: 0px;
+                        y: 104px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Desired Balls";
+                        value: root.launcher-pizza-desired-balls-text;
+                        selected: root.launcher-settings-focus-index == 2;
+                        previous => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
+                        visible: root.launcher-scenario == "pizza";
+                        x: 0px;
+                        y: 156px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Spawn Rate";
+                        value: root.launcher-pizza-spawn-rate-text;
+                        selected: root.launcher-settings-focus-index == 3;
+                        previous => {
+                            root.launcher-settings-focus-index = 3;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 3;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    Text {
+                        visible: root.launcher-scenario == "rover-lab";
+                        x: 0px;
+                        y: 114px;
+                        width: parent.width;
+                        height: 74px;
+                        text: "Rover Lab currently uses its built-in deterministic setup.";
+                        color: #c7d0dc;
+                        font-size: 14px;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+
+                    MenuButton {
+                        x: 0px;
+                        y: root.launcher-scenario == "spacewars" ? 314px : root.launcher-scenario == "pizza" ? 218px : 166px;
+                        width: 150px;
+                        height: 44px;
+                        text: "Back";
+                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 6 : root.launcher-scenario == "pizza" ? 4 : 2);
+                        activated => {
+                            root.launcher-settings-visible = false;
+                        }
+                    }
+
+                    MenuButton {
+                        x: parent.width - 180px;
+                        y: root.launcher-scenario == "spacewars" ? 314px : root.launcher-scenario == "pizza" ? 218px : 166px;
+                        width: 180px;
+                        height: 44px;
+                        text: "Start Game";
+                        activated => {
+                            root.launcher-start-game();
+                        }
+                    }
+                }
+
+                Rectangle {
+                    visible: root.launcher-controls-visible;
+                    x: 24px;
+                    y: 72px;
+                    width: parent.width - 48px;
+                    height: parent.height - 88px;
+                    background: #10141f;
+                    border-color: #424a5a;
+                    border-width: 1px;
+                    border-radius: 6px;
+
+                    Text {
+                        x: 18px;
+                        y: 14px;
+                        width: parent.width - 36px;
+                        height: 150px;
+                        text: root.scenario-controls-help;
+                        color: #e6edf7;
+                        font-size: 13px;
+                        wrap: word-wrap;
+                    }
+
+                    Text {
+                        x: 18px;
+                        y: 168px;
+                        width: parent.width - 36px;
+                        height: 76px;
+                        text: "Menus: D-pad or left stick navigates, A selects, B goes back, Start launches or resumes. Pads are assigned P1 then P2 in connection order; keyboard remains available.";
+                        color: #80d8ff;
+                        font-size: 13px;
+                        wrap: word-wrap;
+                    }
+
+                    Text {
+                        x: 18px;
+                        y: 248px;
+                        width: parent.width - 36px;
+                        height: 42px;
+                        text: "A disconnected active controller pauses the game. Reconnecting restores its reserved seat.";
+                        color: #9fb4cc;
+                        font-size: 12px;
+                        wrap: word-wrap;
+                    }
+
+                    MenuButton {
+                        x: 18px;
+                        y: parent.height - 58px;
+                        width: 150px;
+                        height: 44px;
+                        text: "Back";
+                        selected: true;
+                        activated => {
+                            root.launcher-controls-visible = false;
+                        }
+                    }
+
+                    MenuButton {
+                        x: parent.width - 198px;
+                        y: parent.height - 58px;
+                        width: 180px;
+                        height: 44px;
+                        text: "Start Game";
+                        activated => {
+                            root.launcher-start-game();
                         }
                     }
                 }
             }
-
-            Rectangle {
-                visible: root.launcher-controls-visible;
-                x: 24px;
-                y: 100px;
-                width: parent.width - 48px;
-                height: 330px;
-                background: #00000000;
-
-                Text {
-                    x: 0px;
-                    y: 0px;
-                    width: parent.width;
-                    height: 132px;
-                    text: root.scenario-controls-help;
-                    color: #e6edf7;
-                    font-size: 13px;
-                    wrap: word-wrap;
-                }
-
-                Text {
-                    visible: false;
-                    x: 0px;
-                    y: 54px;
-                    width: parent.width;
-                    text: "Player 2: Numpad 8 thrust, Numpad 5 brake, Numpad 2 reverse, Numpad 4/6 turn, PageDown wings, Delete laser, End cannon";
-                    color: #e6edf7;
-                    font-size: 13px;
-                    wrap: word-wrap;
-                }
-
-                Text {
-                    visible: root.scenario-player-zoom-available;
-                    x: 0px;
-                    y: 126px;
-                    width: parent.width;
-                    text: "Zoom: P1 " + root.launcher-p1-zoom-text + ", P2 " + root.launcher-p2-zoom-text + ". Keys: U/I and Insert/Home.";
-                    color: #c7d0dc;
-                    font-size: 13px;
-                    wrap: word-wrap;
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 0px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P1 In";
-                    clicked => {
-                        root.launcher-p1-zoom-in();
-                    }
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 114px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P1 Out";
-                    clicked => {
-                        root.launcher-p1-zoom-out();
-                    }
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 228px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P2 In";
-                    clicked => {
-                        root.launcher-p2-zoom-in();
-                    }
-                }
-
-                Button {
-                    visible: root.scenario-player-zoom-available;
-                    x: 342px;
-                    y: 154px;
-                    width: 104px;
-                    height: 32px;
-                    text: "P2 Out";
-                    clicked => {
-                        root.launcher-p2-zoom-out();
-                    }
-                }
-
-                Text {
-                    x: 0px;
-                    y: 214px;
-                    width: parent.width;
-                    text: "Launcher: Enter start, B benchmark, C or F1 controls/back, Esc back/quit.";
-                    color: #c7d0dc;
-                    font-size: 13px;
-                    wrap: word-wrap;
-                }
-
-                Text {
-                    x: 0px;
-                    y: 270px;
-                    width: parent.width;
-                    text: "In game: P pause, R restart, B benchmark. Wings close while held and open on release.";
-                    color: #c7d0dc;
-                    font-size: 13px;
-                    wrap: word-wrap;
-                }
-            }
-
-            Button {
-                visible: root.launcher-controls-visible;
-                x: 24px;
-                y: 456px;
-                width: 140px;
-                height: 36px;
-                text: "Back (Esc)";
-                clicked => {
-                    root.launcher-controls-visible = false;
-                }
-            }
-
-            Button {
-                visible: root.launcher-controls-visible;
-                x: parent.width - 164px;
-                y: 456px;
-                width: 140px;
-                height: 36px;
-                text: "Quit (Esc)";
-                clicked => {
-                    root.launcher-quit();
-                }
-            }
-            }
         }
     }
+
+    Rectangle {
+        visible: root.controller-disconnected-visible && !root.launcher-visible;
+        x: (parent.width - self.width) / 2;
+        y: 20px;
+        width: root.width < 552px ? root.width - 32px : 520px;
+        height: 44px;
+        background: #42191ff2;
+        border-color: #ff7184;
+        border-width: 1px;
+        border-radius: 4px;
+
+        Text {
+            x: 12px;
+            width: parent.width - 24px;
+            height: parent.height;
+            text: root.controller-disconnected-text;
+            color: #ffe7ea;
+            font-size: 14px;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
+    }
+
 }

--- a/deploy/systemd/spacewars-kiosk.service
+++ b/deploy/systemd/spacewars-kiosk.service
@@ -11,7 +11,7 @@ StateDirectoryMode=0755
 Environment=SPACEWARS_CONFIG_DIR=/var/lib/spacewars
 Environment=SLINT_BACKEND=linuxkms-software
 Environment=SLINT_KMS_ROTATION=90
-ExecStart=/usr/bin/engine-client --kiosk --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
+ExecStart=/usr/bin/engine-client --fullscreen --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
 Restart=on-failure
 RestartSec=2
 NoNewPrivileges=true

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -46,16 +46,16 @@ display backend.
 
 ## Launch Command
 
-The current kiosk launch command is:
+The current Pi launch command is:
 
 ```sh
-engine-client --kiosk --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
+engine-client --fullscreen --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
 ```
 
-`--kiosk` launches the saved/default scenario directly, requests fullscreen, and
-does not force Slint's desktop `winit` backend. The Pi image should either set
-`SLINT_BACKEND` explicitly or provide a default backend suitable for its display
-stack.
+`--fullscreen` shows the launcher and requests fullscreen presentation. The
+service sets `SLINT_BACKEND` explicitly so the client uses the image's LinuxKMS
+backend instead of the desktop `winit` backend. Use `--kiosk` instead when the
+saved/default scenario should launch directly.
 
 The current Yocto service sets:
 
@@ -115,7 +115,7 @@ dependent.
 1. Confirm the binary starts with `--help`.
 2. Confirm `/var/lib/spacewars` exists and is writable by the service user.
 3. Run the headless benchmark command on the Pi with `--benchmark-seconds 10`.
-4. Launch `engine-client --kiosk --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0`.
+4. Launch `engine-client --fullscreen --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0`.
 5. Confirm fullscreen display startup.
 6. Confirm both players' controls work with the attached keyboard.
 7. Confirm pause, quit-to-launcher, restart, benchmark, and exit shortcuts.
@@ -171,20 +171,21 @@ injects the selected SSH public key, writes `/boot/hostname.txt`, grows the
 Wi-Fi credentials.
 
 After the first OTA-capable image is flashed, root filesystem updates can use
-the A/B updater over SSH:
+the project-root A/B updater over SSH:
 
 ```sh
-cd yocto
-npm run update
-npm run update -- --skip-build
+./update.sh
+./update.sh --skip-build
 ```
 
 The OTA path builds unless `--skip-build` is passed, transfers the latest
 `spacewars-image-raspberrypi5.rootfs.ext4.gz` to the Pi, verifies its checksum,
 flashes it to the inactive slot with SSH key injection, switches boot slots,
-and reboots. The image includes a narrow sudoers entry for the `spacewars` user
-so the node script can run `sudo /usr/sbin/ab-update-with-key ...` and
-`sudo systemctl reboot`, matching DirtSim's no-local-sudo update model.
+reboots, and verifies that `spacewars-kiosk.service` is active. The image
+includes a narrow sudoers entry for the `spacewars` user so the node script can
+run `sudo /usr/sbin/ab-update-with-key ...` and `sudo systemctl reboot`, matching
+DirtSim's no-local-sudo update model. The lower-level command remains available
+as `cd yocto && npm run update`.
 
 SSH host keys live under `/data/ssh` so reflashes and A/B updates keep a stable
 device identity.

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -39,10 +39,11 @@ Yocto's own Rust bootstrap does not accidentally discover Space-Wars'
 
 The image recipe builds `engine-client` with the `engine-client/pi-kiosk`
 feature, which selects Slint `linuxkms` plus the software renderer instead of
-the full desktop backend set. The feature still includes Slint's Winit
-physical-key adapter because the current game input path uses it for original
-key mappings; Pi validation must confirm keyboard behavior on the selected
-display backend.
+the full desktop backend set. Gamepads are read directly from
+`/dev/input/event*` through gilrs/libudev and do not depend on the Slint display
+backend. The feature still includes Slint's Winit physical-key adapter for the
+desktop keyboard fallback; Pi validation must separately confirm whether
+keyboard events are available on the selected display backend.
 
 ## Launch Command
 
@@ -117,10 +118,20 @@ dependent.
 3. Run the headless benchmark command on the Pi with `--benchmark-seconds 10`.
 4. Launch `engine-client --fullscreen --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0`.
 5. Confirm fullscreen display startup.
-6. Confirm both players' controls work with the attached keyboard.
-7. Confirm pause, quit-to-launcher, restart, benchmark, and exit shortcuts.
-8. Confirm settings are written back to `/var/lib/spacewars/settings.toml`.
-9. Capture benchmark FPS at raster scales `1.0`, `2.0`, and `3.0`.
+6. Confirm `spacewars` belongs to the `input` group and can read the attached
+   controller's `/dev/input/event*` node.
+7. At the launcher, confirm the pad badge appears and Start launches the saved
+   scenario without a mouse.
+8. Confirm analog turn/thrust/brake, weapons, wings, zoom, pause, and controls
+   overlay mappings work for both player seats.
+9. Confirm disconnect auto-pauses with a banner, keyboard remains usable, and
+   reconnect returns the pad to its original seat.
+10. Confirm the D-pad or left stick moves the highlighted launcher, pause, and
+    game-over choices; A selects, B goes back, and Start launches or resumes.
+11. Confirm both players' controls work with the attached keyboard where the
+    selected backend exposes keyboard events.
+12. Confirm settings are written back to `/var/lib/spacewars/settings.toml`.
+13. Capture benchmark FPS at raster scales `1.0`, `2.0`, and `3.0`.
 
 ## Service Installation Sketch
 
@@ -178,7 +189,8 @@ the project-root A/B updater over SSH:
 ./update.sh --skip-build
 ```
 
-The OTA path builds unless `--skip-build` is passed, transfers the latest
+Run these from the repository root. The OTA path builds unless `--skip-build`
+is passed, transfers the latest
 `spacewars-image-raspberrypi5.rootfs.ext4.gz` to the Pi, verifies its checksum,
 flashes it to the inactive slot with SSH key injection, switches boot slots,
 reboots, and verifies that `spacewars-kiosk.service` is active. The image

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -158,6 +158,8 @@ const GRAVITY_SHIP_TAG: u64 = 2;
 const GRAVITY_DEBRIS_TAG: u64 = 3;
 const GRAVITY_PARTICLE_TAG: u64 = 4;
 
+pub const SPACEWARS_PLAYER_COUNT: usize = 2;
+
 const SHIP_THRUST_FORCE: f32 = 50_000.0;
 const SHIP_TURN_FORCE: f32 = 200.0;
 const SHIP_MASS: f32 = 31.25;
@@ -493,8 +495,10 @@ pub struct ShipState {
     pub wing_theta: f32,
     pub wing_state: WingState,
     pub wing_behavior: WingBehavior,
-    pub thrust_behavior: ThrustBehavior,
-    pub turn_behavior: TurnBehavior,
+    pub wings_closed: bool,
+    pub thrust: f32,
+    pub brake: f32,
+    pub turn: f32,
     pub laser_firing: bool,
     pub cannon_firing: bool,
     pub laser_beam: Option<LaserBeamState>,
@@ -534,21 +538,6 @@ pub enum WingBehavior {
     Open,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ThrustBehavior {
-    None,
-    Full,
-    Brake,
-    Reverse,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TurnBehavior {
-    None,
-    Left,
-    Right,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ExhaustTrailState {
     pub start: Vec2,
@@ -569,140 +558,282 @@ pub struct ParticleState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum SpacewarsActionKind {
-    CloseWings = 1,
-    OpenWings = 2,
-    Thrust = 3,
-    ThrustHalt = 4,
-    Reverse = 5,
-    Brake = 6,
-    BrakeHalt = 7,
-    TurnLeft = 8,
-    TurnRight = 9,
-    TurnHalt = 10,
-    FireLaser = 11,
-    FireLaserHalt = 12,
-    FireCannon = 13,
-    FireCannonHalt = 14,
-    ZoomIn = 15,
-    ZoomOut = 16,
+    SetWings = 1,
+    SetThrust = 2,
+    SetBrake = 3,
+    SetTurn = 4,
+    SetLaser = 5,
+    SetCannon = 6,
+    ZoomIn = 7,
+    ZoomOut = 8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SpacewarsAction {
-    pub player: usize,
-    pub kind: SpacewarsActionKind,
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SpacewarsAction {
+    SetWings { player: usize, closed: bool },
+    SetThrust { player: usize, amount: f32 },
+    SetBrake { player: usize, amount: f32 },
+    SetTurn { player: usize, rate: f32 },
+    SetLaser { player: usize, on: bool },
+    SetCannon { player: usize, on: bool },
+    ZoomIn { player: usize },
+    ZoomOut { player: usize },
+}
+
+/// What one control source wants a ship to do this tick.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct ShipIntent {
+    pub turn: f32,
+    pub thrust: f32,
+    pub brake: f32,
+    pub wings_closed: bool,
+    pub laser: bool,
+    pub cannon: bool,
+}
+
+impl ShipIntent {
+    pub fn normalized(self) -> Self {
+        Self {
+            turn: quantize_control(self.turn, -1.0, 1.0),
+            thrust: quantize_control(self.thrust, -1.0, 1.0),
+            brake: quantize_control(self.brake, 0.0, 1.0),
+            ..self
+        }
+    }
+
+    pub fn merged_with(self, other: Self) -> Self {
+        let self_intent = self.normalized();
+        let other = other.normalized();
+        Self {
+            turn: larger_magnitude(self_intent.turn, other.turn),
+            thrust: larger_magnitude(self_intent.thrust, other.thrust),
+            brake: self_intent.brake.max(other.brake),
+            wings_closed: self_intent.wings_closed || other.wings_closed,
+            laser: self_intent.laser || other.laser,
+            cannon: self_intent.cannon || other.cannon,
+        }
+    }
+}
+
+/// Host-side sources implement this without leaking device events into the sim.
+pub trait ControlSource {
+    fn intent(&mut self, state: &SpacewarsState, player: usize) -> ShipIntent;
+}
+
+#[derive(Debug, Clone)]
+pub struct ShipIntentEncoder {
+    last_sent: [ShipIntent; SPACEWARS_PLAYER_COUNT],
+}
+
+impl Default for ShipIntentEncoder {
+    fn default() -> Self {
+        Self {
+            last_sent: [ShipIntent::default(); SPACEWARS_PLAYER_COUNT],
+        }
+    }
+}
+
+impl ShipIntentEncoder {
+    pub fn encode(&mut self, player: usize, intent: ShipIntent) -> Vec<Action> {
+        let Some(previous) = self.last_sent.get_mut(player) else {
+            return Vec::new();
+        };
+        let intent = intent.normalized();
+        let mut actions = Vec::new();
+
+        if intent.turn != previous.turn {
+            actions.push(SpacewarsAction::set_turn(player, intent.turn));
+        }
+        if intent.thrust != previous.thrust {
+            actions.push(SpacewarsAction::set_thrust(player, intent.thrust));
+        }
+        if intent.brake != previous.brake {
+            actions.push(SpacewarsAction::set_brake(player, intent.brake));
+        }
+        if intent.wings_closed != previous.wings_closed {
+            actions.push(SpacewarsAction::set_wings(player, intent.wings_closed));
+        }
+        if intent.laser != previous.laser {
+            actions.push(SpacewarsAction::set_laser(player, intent.laser));
+        }
+        if intent.cannon != previous.cannon {
+            actions.push(SpacewarsAction::set_cannon(player, intent.cannon));
+        }
+
+        *previous = intent;
+        actions
+    }
+
+    pub fn reset(&mut self) {
+        self.last_sent = [ShipIntent::default(); SPACEWARS_PLAYER_COUNT];
+    }
+}
+
+fn quantize_control(value: f32, min: f32, max: f32) -> f32 {
+    let value = if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(min, max)
+    };
+    let quantized = (value * 100.0).round() / 100.0;
+    if quantized == -0.0 { 0.0 } else { quantized }
+}
+
+fn larger_magnitude(current: f32, candidate: f32) -> f32 {
+    if candidate.abs() >= current.abs() {
+        candidate
+    } else {
+        current
+    }
 }
 
 impl SpacewarsAction {
-    pub fn new(player: usize, kind: SpacewarsActionKind) -> Self {
-        Self { player, kind }
-    }
-
     pub fn encode(self) -> Action {
-        Action::scenario(self.kind as u32, vec![self.player as u8])
+        let player = u8::try_from(self.player()).unwrap_or(u8::MAX);
+        let mut payload = vec![player];
+        match self {
+            Self::SetWings { closed, .. } => payload.push(u8::from(closed)),
+            Self::SetThrust { amount, .. } | Self::SetBrake { amount, .. } => {
+                payload.extend_from_slice(&amount.to_le_bytes());
+            }
+            Self::SetTurn { rate, .. } => payload.extend_from_slice(&rate.to_le_bytes()),
+            Self::SetLaser { on, .. } | Self::SetCannon { on, .. } => {
+                payload.push(u8::from(on));
+            }
+            Self::ZoomIn { .. } | Self::ZoomOut { .. } => {}
+        }
+        Action::scenario(self.kind() as u32, payload)
     }
 
     pub fn decode(action: &Action) -> Option<Self> {
         let Action::Scenario { kind, payload } = action else {
             return None;
         };
-        let [player] = payload.as_slice() else {
-            return None;
-        };
-        let player = *player as usize;
-        if player >= 2 {
+        let (&player, value) = payload.split_first()?;
+        let player = player as usize;
+        if player >= SPACEWARS_PLAYER_COUNT {
             return None;
         }
-        Some(Self {
-            player,
-            kind: SpacewarsActionKind::from_u32(*kind)?,
-        })
+
+        match SpacewarsActionKind::from_u32(*kind)? {
+            SpacewarsActionKind::SetWings => Some(Self::SetWings {
+                player,
+                closed: decode_bool(value)?,
+            }),
+            SpacewarsActionKind::SetThrust => Some(Self::SetThrust {
+                player,
+                amount: decode_f32(value, -1.0, 1.0)?,
+            }),
+            SpacewarsActionKind::SetBrake => Some(Self::SetBrake {
+                player,
+                amount: decode_f32(value, 0.0, 1.0)?,
+            }),
+            SpacewarsActionKind::SetTurn => Some(Self::SetTurn {
+                player,
+                rate: decode_f32(value, -1.0, 1.0)?,
+            }),
+            SpacewarsActionKind::SetLaser => Some(Self::SetLaser {
+                player,
+                on: decode_bool(value)?,
+            }),
+            SpacewarsActionKind::SetCannon => Some(Self::SetCannon {
+                player,
+                on: decode_bool(value)?,
+            }),
+            SpacewarsActionKind::ZoomIn if value.is_empty() => Some(Self::ZoomIn { player }),
+            SpacewarsActionKind::ZoomOut if value.is_empty() => Some(Self::ZoomOut { player }),
+            SpacewarsActionKind::ZoomIn | SpacewarsActionKind::ZoomOut => None,
+        }
     }
 
-    pub fn close_wings(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::CloseWings).encode()
+    pub const fn player(self) -> usize {
+        match self {
+            Self::SetWings { player, .. }
+            | Self::SetThrust { player, .. }
+            | Self::SetBrake { player, .. }
+            | Self::SetTurn { player, .. }
+            | Self::SetLaser { player, .. }
+            | Self::SetCannon { player, .. }
+            | Self::ZoomIn { player }
+            | Self::ZoomOut { player } => player,
+        }
     }
 
-    pub fn open_wings(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::OpenWings).encode()
+    pub const fn kind(self) -> SpacewarsActionKind {
+        match self {
+            Self::SetWings { .. } => SpacewarsActionKind::SetWings,
+            Self::SetThrust { .. } => SpacewarsActionKind::SetThrust,
+            Self::SetBrake { .. } => SpacewarsActionKind::SetBrake,
+            Self::SetTurn { .. } => SpacewarsActionKind::SetTurn,
+            Self::SetLaser { .. } => SpacewarsActionKind::SetLaser,
+            Self::SetCannon { .. } => SpacewarsActionKind::SetCannon,
+            Self::ZoomIn { .. } => SpacewarsActionKind::ZoomIn,
+            Self::ZoomOut { .. } => SpacewarsActionKind::ZoomOut,
+        }
     }
 
-    pub fn thrust(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::Thrust).encode()
+    pub fn set_wings(player: usize, closed: bool) -> Action {
+        Self::SetWings { player, closed }.encode()
     }
 
-    pub fn thrust_halt(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::ThrustHalt).encode()
+    pub fn set_thrust(player: usize, amount: f32) -> Action {
+        Self::SetThrust { player, amount }.encode()
     }
 
-    pub fn reverse(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::Reverse).encode()
+    pub fn set_brake(player: usize, amount: f32) -> Action {
+        Self::SetBrake { player, amount }.encode()
     }
 
-    pub fn brake(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::Brake).encode()
+    pub fn set_turn(player: usize, rate: f32) -> Action {
+        Self::SetTurn { player, rate }.encode()
     }
 
-    pub fn brake_halt(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::BrakeHalt).encode()
+    pub fn set_laser(player: usize, on: bool) -> Action {
+        Self::SetLaser { player, on }.encode()
     }
 
-    pub fn turn_left(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::TurnLeft).encode()
-    }
-
-    pub fn turn_right(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::TurnRight).encode()
-    }
-
-    pub fn turn_halt(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::TurnHalt).encode()
-    }
-
-    pub fn fire_laser(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::FireLaser).encode()
-    }
-
-    pub fn fire_laser_halt(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::FireLaserHalt).encode()
-    }
-
-    pub fn fire_cannon(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::FireCannon).encode()
-    }
-
-    pub fn fire_cannon_halt(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::FireCannonHalt).encode()
+    pub fn set_cannon(player: usize, on: bool) -> Action {
+        Self::SetCannon { player, on }.encode()
     }
 
     pub fn zoom_in(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::ZoomIn).encode()
+        Self::ZoomIn { player }.encode()
     }
 
     pub fn zoom_out(player: usize) -> Action {
-        Self::new(player, SpacewarsActionKind::ZoomOut).encode()
+        Self::ZoomOut { player }.encode()
     }
+}
+
+fn decode_bool(bytes: &[u8]) -> Option<bool> {
+    match bytes {
+        [0] => Some(false),
+        [1] => Some(true),
+        _ => None,
+    }
+}
+
+fn decode_f32(bytes: &[u8], min: f32, max: f32) -> Option<f32> {
+    let bytes: [u8; 4] = bytes.try_into().ok()?;
+    let value = f32::from_le_bytes(bytes);
+    Some(if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(min, max)
+    })
 }
 
 impl SpacewarsActionKind {
     fn from_u32(value: u32) -> Option<Self> {
         match value {
-            1 => Some(Self::CloseWings),
-            2 => Some(Self::OpenWings),
-            3 => Some(Self::Thrust),
-            4 => Some(Self::ThrustHalt),
-            5 => Some(Self::Reverse),
-            6 => Some(Self::Brake),
-            7 => Some(Self::BrakeHalt),
-            8 => Some(Self::TurnLeft),
-            9 => Some(Self::TurnRight),
-            10 => Some(Self::TurnHalt),
-            11 => Some(Self::FireLaser),
-            12 => Some(Self::FireLaserHalt),
-            13 => Some(Self::FireCannon),
-            14 => Some(Self::FireCannonHalt),
-            15 => Some(Self::ZoomIn),
-            16 => Some(Self::ZoomOut),
+            1 => Some(Self::SetWings),
+            2 => Some(Self::SetThrust),
+            3 => Some(Self::SetBrake),
+            4 => Some(Self::SetTurn),
+            5 => Some(Self::SetLaser),
+            6 => Some(Self::SetCannon),
+            7 => Some(Self::ZoomIn),
+            8 => Some(Self::ZoomOut),
             _ => None,
         }
     }
@@ -863,47 +994,40 @@ impl Scenario for SpacewarsScenario {
 
 impl SpacewarsState {
     fn apply_action(&mut self, action: SpacewarsAction) {
-        match action.kind {
-            SpacewarsActionKind::ZoomIn => {
-                self.zoom_player_in(action.player);
+        match action {
+            SpacewarsAction::ZoomIn { player } => {
+                self.zoom_player_in(player);
                 return;
             }
-            SpacewarsActionKind::ZoomOut => {
-                self.zoom_player_out(action.player);
+            SpacewarsAction::ZoomOut { player } => {
+                self.zoom_player_out(player);
                 return;
             }
             _ => {}
         }
 
+        let player = action.player();
         if self
             .players
-            .get(action.player)
+            .get(player)
             .map(|player| player.eliminated)
             .unwrap_or(true)
         {
             return;
         }
 
-        let Some(ship) = self.ships.get_mut(action.player) else {
+        let Some(ship) = self.ships.get_mut(player) else {
             return;
         };
 
-        match action.kind {
-            SpacewarsActionKind::CloseWings => ship.close_wings(),
-            SpacewarsActionKind::OpenWings => ship.open_wings(),
-            SpacewarsActionKind::Thrust => ship.thrust(),
-            SpacewarsActionKind::ThrustHalt => ship.thrust_halt(),
-            SpacewarsActionKind::Reverse => ship.reverse(),
-            SpacewarsActionKind::Brake => ship.brake(),
-            SpacewarsActionKind::BrakeHalt => ship.brake_halt(),
-            SpacewarsActionKind::TurnLeft => ship.turn_left(),
-            SpacewarsActionKind::TurnRight => ship.turn_right(),
-            SpacewarsActionKind::TurnHalt => ship.turn_halt(),
-            SpacewarsActionKind::FireLaser => ship.fire_laser(),
-            SpacewarsActionKind::FireLaserHalt => ship.fire_laser_halt(),
-            SpacewarsActionKind::FireCannon => ship.fire_cannon(),
-            SpacewarsActionKind::FireCannonHalt => ship.fire_cannon_halt(),
-            SpacewarsActionKind::ZoomIn | SpacewarsActionKind::ZoomOut => unreachable!(),
+        match action {
+            SpacewarsAction::SetWings { closed, .. } => ship.set_wings(closed),
+            SpacewarsAction::SetThrust { amount, .. } => ship.set_thrust(amount),
+            SpacewarsAction::SetBrake { amount, .. } => ship.set_brake(amount),
+            SpacewarsAction::SetTurn { rate, .. } => ship.set_turn(rate),
+            SpacewarsAction::SetLaser { on, .. } => ship.set_laser(on),
+            SpacewarsAction::SetCannon { on, .. } => ship.set_cannon(on),
+            SpacewarsAction::ZoomIn { .. } | SpacewarsAction::ZoomOut { .. } => unreachable!(),
         }
     }
 
@@ -936,24 +1060,29 @@ impl SpacewarsScenario {
     }
 
     pub fn benchmark_actions(state: &SpacewarsState) -> Vec<Action> {
-        let mut actions = vec![
-            SpacewarsAction::thrust(0),
-            SpacewarsAction::fire_laser(0),
-            SpacewarsAction::fire_cannon(0),
-            SpacewarsAction::thrust(1),
-            SpacewarsAction::fire_laser(1),
-            SpacewarsAction::fire_cannon(1),
-        ];
-
-        if (state.tick / 90) % 2 == 0 {
-            actions.push(SpacewarsAction::turn_right(0));
-            actions.push(SpacewarsAction::turn_left(1));
-        } else {
-            actions.push(SpacewarsAction::turn_left(0));
-            actions.push(SpacewarsAction::turn_right(1));
+        let mut encoder = ShipIntentEncoder::default();
+        let mut actions = Vec::new();
+        for player in 0..SPACEWARS_PLAYER_COUNT {
+            actions.extend(encoder.encode(player, Self::benchmark_intent(state, player)));
         }
-
         actions
+    }
+
+    pub fn benchmark_intent(state: &SpacewarsState, player: usize) -> ShipIntent {
+        let turn = if (state.tick / 90) % 2 == 0 {
+            if player == 0 { 1.0 } else { -1.0 }
+        } else if player == 0 {
+            -1.0
+        } else {
+            1.0
+        };
+        ShipIntent {
+            turn,
+            thrust: 1.0,
+            laser: true,
+            cannon: true,
+            ..ShipIntent::default()
+        }
     }
 
     pub fn benchmark_counts(state: &SpacewarsState) -> SpacewarsBenchmarkCounts {
@@ -3786,8 +3915,10 @@ impl ShipState {
             wing_theta: 0.0,
             wing_state: WingState::Opened,
             wing_behavior: WingBehavior::None,
-            thrust_behavior: ThrustBehavior::None,
-            turn_behavior: TurnBehavior::None,
+            wings_closed: false,
+            thrust: 0.0,
+            brake: 0.0,
+            turn: 0.0,
             laser_firing: false,
             cannon_firing: false,
             laser_beam: None,
@@ -3853,12 +3984,20 @@ impl ShipState {
         self.life = self.life_max * progress.clamp(0.0, 1.0);
     }
 
+    fn set_wings(&mut self, closed: bool) {
+        self.wings_closed = closed;
+        if closed {
+            self.close_wings();
+        } else {
+            self.open_wings();
+        }
+    }
+
     fn close_wings(&mut self) {
         if self.form == ShipForm::EscapePod {
             self.wing_state = WingState::Closed;
             self.wing_behavior = WingBehavior::None;
             self.wing_theta = MAX_WING_THETA;
-            self.thrust_behavior = ThrustBehavior::None;
             return;
         }
         self.wing_behavior = WingBehavior::Close;
@@ -3869,67 +4008,31 @@ impl ShipState {
             self.wing_state = WingState::Opened;
             self.wing_behavior = WingBehavior::None;
             self.wing_theta = 0.0;
-            self.thrust_behavior = ThrustBehavior::None;
             self.cap_speed(POD_CRUISE_SPEED);
             return;
         }
         self.wing_behavior = WingBehavior::Open;
-        self.thrust_behavior = ThrustBehavior::None;
         self.cap_speed(MAX_SPEED);
     }
 
-    fn thrust(&mut self) {
-        self.thrust_behavior = ThrustBehavior::Full;
+    fn set_thrust(&mut self, amount: f32) {
+        self.thrust = amount.clamp(-1.0, 1.0);
     }
 
-    fn thrust_halt(&mut self) {
-        self.thrust_behavior = ThrustBehavior::None;
+    fn set_brake(&mut self, amount: f32) {
+        self.brake = amount.clamp(0.0, 1.0);
     }
 
-    fn reverse(&mut self) {
-        self.thrust_behavior = ThrustBehavior::Reverse;
+    fn set_turn(&mut self, rate: f32) {
+        self.turn = rate.clamp(-1.0, 1.0);
     }
 
-    fn brake(&mut self) {
-        self.thrust_behavior = ThrustBehavior::Brake;
+    fn set_laser(&mut self, on: bool) {
+        self.laser_firing = on;
     }
 
-    fn brake_halt(&mut self) {
-        self.thrust_behavior = ThrustBehavior::None;
-    }
-
-    fn turn_left(&mut self) {
-        self.turn_behavior = TurnBehavior::Left;
-    }
-
-    fn turn_right(&mut self) {
-        self.turn_behavior = TurnBehavior::Right;
-    }
-
-    fn turn_halt(&mut self) {
-        self.turn_behavior = TurnBehavior::None;
-    }
-
-    fn fire_laser(&mut self) {
-        if self.form == ShipForm::EscapePod {
-            return;
-        }
-        self.laser_firing = true;
-    }
-
-    fn fire_laser_halt(&mut self) {
-        self.laser_firing = false;
-    }
-
-    fn fire_cannon(&mut self) {
-        if self.form == ShipForm::EscapePod {
-            return;
-        }
-        self.cannon_firing = true;
-    }
-
-    fn fire_cannon_halt(&mut self) {
-        self.cannon_firing = false;
+    fn set_cannon(&mut self, on: bool) {
+        self.cannon_firing = on;
     }
 
     fn update_cannon(&mut self, dt: f32, tick: u64) -> Option<DebrisState> {
@@ -3970,7 +4073,6 @@ impl ShipState {
     fn update_laser(&mut self) {
         if self.form == ShipForm::EscapePod {
             self.laser_beam = None;
-            self.laser_firing = false;
             self.queued_laser_fire = false;
             return;
         }
@@ -4074,7 +4176,6 @@ impl ShipState {
     }
 
     fn update_wings(&mut self, dt: f32) {
-        let braking = self.thrust_behavior == ThrustBehavior::Brake;
         match self.wing_behavior {
             WingBehavior::None => {}
             WingBehavior::Close => {
@@ -4085,9 +4186,6 @@ impl ShipState {
                     self.wing_theta = MAX_WING_THETA;
                 }
                 self.update_wing_position();
-                if !braking {
-                    self.thrust_behavior = ThrustBehavior::Full;
-                }
             }
             WingBehavior::Open => {
                 self.wing_theta -= dt * WING_DELTA_SPEED;
@@ -4099,22 +4197,12 @@ impl ShipState {
                 }
                 self.update_wing_position();
                 self.cap_speed(MAX_SPEED);
-                if self.wing_behavior == WingBehavior::None && !braking {
-                    self.thrust_behavior = ThrustBehavior::None;
-                }
             }
-        }
-
-        if self.wing_state == WingState::Closed
-            && self.wing_behavior != WingBehavior::Open
-            && !braking
-        {
-            self.thrust_behavior = ThrustBehavior::Full;
         }
     }
 
     fn update_wing_position(&mut self) {
-        if self.thrust_behavior != ThrustBehavior::Brake {
+        if self.brake <= 0.0 {
             let max_velocity =
                 (self.wing_theta + 0.46) / MAX_WING_THETA * WING_CLOSED_SPEED + MAX_SPEED;
             let speed = self.velocity.length();
@@ -4125,61 +4213,80 @@ impl ShipState {
     }
 
     fn update_thrust(&mut self, rng: &mut SpacewarsRng, tick: u64) {
-        match self.thrust_behavior {
-            ThrustBehavior::None => {}
-            ThrustBehavior::Full => {
-                self.velocity += self.direction * self.thrust_power;
-                if self.wing_state == WingState::Closed && self.wing_behavior != WingBehavior::Open
-                {
-                    self.velocity +=
-                        self.direction * (self.wing_theta / MAX_WING_THETA * WING_CLOSED_SPEED);
-                    self.cap_speed(WING_CLOSED_SPEED);
-                } else {
-                    self.cap_speed(MAX_SPEED);
-                }
-                self.fire_exhaust(self.direction, rng, tick);
+        if self.brake > 0.0 {
+            if self.velocity.length() > MAX_SPEED * 0.25 {
+                self.velocity -= self.velocity.normalized() * (self.thrust_power * self.brake);
+            } else {
+                self.velocity *= 1.0 - 0.1 * self.brake;
             }
-            ThrustBehavior::Brake => {
-                if self.velocity.length() > MAX_SPEED * 0.25 {
-                    self.velocity -= self.velocity.normalized() * self.thrust_power;
-                } else {
-                    self.velocity *= 0.9;
-                }
 
-                if self.omega.abs() > 0.01 {
-                    self.omega -= self.omega.signum() * self.turn_power;
-                } else {
+            if self.omega.abs() > 0.01 {
+                let turn_delta = self.turn_power * self.brake;
+                if self.omega.abs() <= turn_delta {
                     self.omega = 0.0;
+                } else {
+                    self.omega -= self.omega.signum() * turn_delta;
                 }
+            } else {
+                self.omega = 0.0;
             }
-            ThrustBehavior::Reverse => {
-                self.velocity -= self.direction * self.thrust_power;
-                self.cap_speed(MAX_SPEED);
-                self.fire_exhaust(self.direction * -10.0, rng, tick);
-            }
+            return;
+        }
+
+        let wings_supply_thrust = self.wing_behavior == WingBehavior::Close
+            || (self.wing_state == WingState::Closed && self.wing_behavior != WingBehavior::Open);
+        let amount = if wings_supply_thrust {
+            self.thrust.max(1.0)
+        } else {
+            self.thrust
+        };
+        if amount == 0.0 {
+            return;
+        }
+
+        self.velocity += self.direction * (self.thrust_power * amount);
+        if amount > 0.0
+            && self.wing_state == WingState::Closed
+            && self.wing_behavior != WingBehavior::Open
+        {
+            self.velocity +=
+                self.direction * (self.wing_theta / MAX_WING_THETA * WING_CLOSED_SPEED * amount);
+            self.cap_speed(WING_CLOSED_SPEED);
+        } else {
+            self.cap_speed(MAX_SPEED);
+        }
+
+        if amount > 0.0 {
+            self.fire_exhaust(self.direction * amount, rng, tick);
+        } else {
+            self.fire_exhaust(self.direction * amount * 10.0, rng, tick);
         }
     }
 
     fn update_pod_thrust(&mut self, rng: &mut SpacewarsRng, tick: u64) {
-        match self.thrust_behavior {
-            ThrustBehavior::None | ThrustBehavior::Full => {
-                let max_speed = if self.wing_state == WingState::Closed {
-                    POD_MAX_SPEED
-                } else {
-                    POD_CRUISE_SPEED
-                };
-                self.velocity += self.direction * self.thrust_power;
-                self.cap_speed(max_speed);
-                self.fire_exhaust(self.direction, rng, tick);
-            }
-            ThrustBehavior::Brake | ThrustBehavior::Reverse => {
-                if self.omega.abs() > 0.01 {
-                    self.omega -= self.omega.signum() * self.turn_power;
-                } else {
+        if self.brake > 0.0 || self.thrust < 0.0 {
+            let amount = self.brake.max(-self.thrust);
+            if self.omega.abs() > 0.01 {
+                let turn_delta = self.turn_power * amount;
+                if self.omega.abs() <= turn_delta {
                     self.omega = 0.0;
+                } else {
+                    self.omega -= self.omega.signum() * turn_delta;
                 }
+            } else {
+                self.omega = 0.0;
             }
+            return;
         }
+
+        let max_speed = if self.wing_state == WingState::Closed {
+            POD_MAX_SPEED
+        } else {
+            POD_CRUISE_SPEED
+        };
+        self.velocity += self.direction * self.thrust_power;
+        self.cap_speed(max_speed);
+        self.fire_exhaust(self.direction, rng, tick);
     }
 
     fn update_exhaust_trails(&mut self, dt: f32) {
@@ -4241,19 +4348,12 @@ impl ShipState {
     }
 
     fn update_turn(&mut self) {
-        match self.turn_behavior {
-            TurnBehavior::None => {
-                self.omega = 0.0;
-            }
-            TurnBehavior::Left => {
-                self.omega = (self.omega - self.turn_power).max(-self.current_max_omega);
-                self.turn_behavior = TurnBehavior::None;
-            }
-            TurnBehavior::Right => {
-                self.omega = (self.omega + self.turn_power).min(self.current_max_omega);
-                self.turn_behavior = TurnBehavior::None;
-            }
+        if self.turn == 0.0 {
+            self.omega = 0.0;
+            return;
         }
+        self.omega = (self.omega + self.turn_power * self.turn)
+            .clamp(-self.current_max_omega, self.current_max_omega);
     }
 
     fn cap_speed(&mut self, max_speed: f32) {
@@ -4277,17 +4377,21 @@ impl ShipState {
         self.life = 0.0;
         self.velocity += self.death_impulse;
         self.death_impulse = Vec2::ZERO;
-        self.laser_firing = false;
-        self.cannon_firing = false;
         self.laser_beam = None;
         self.queued_laser_fire = false;
         self.queued_cannon_fire = false;
         self.cannon_cooldown_remaining = 0.0;
-        self.wing_theta = 0.0;
-        self.wing_state = WingState::Opened;
+        self.wing_theta = if self.wings_closed {
+            MAX_WING_THETA
+        } else {
+            0.0
+        };
+        self.wing_state = if self.wings_closed {
+            WingState::Closed
+        } else {
+            WingState::Opened
+        };
         self.wing_behavior = WingBehavior::None;
-        self.thrust_behavior = ThrustBehavior::None;
-        self.turn_behavior = TurnBehavior::None;
         self.turn_power = POD_TURN_FORCE / POD_MASS * self.delta_time;
         self.thrust_power = POD_THRUST_FORCE / POD_MASS * self.delta_time;
         self.current_max_omega = BASE_MAX_OMEGA;
@@ -4302,17 +4406,17 @@ impl ShipState {
         self.dead = false;
         self.fragmented = false;
         self.life = self.life_max;
-        self.laser_firing = false;
-        self.cannon_firing = false;
         self.laser_beam = None;
         self.queued_laser_fire = false;
         self.queued_cannon_fire = false;
         self.cannon_cooldown_remaining = 0.0;
         self.wing_theta = 0.0;
         self.wing_state = WingState::Opened;
-        self.wing_behavior = WingBehavior::None;
-        self.thrust_behavior = ThrustBehavior::None;
-        self.turn_behavior = TurnBehavior::None;
+        self.wing_behavior = if self.wings_closed {
+            WingBehavior::Close
+        } else {
+            WingBehavior::None
+        };
         self.turn_power = SHIP_TURN_FORCE / SHIP_MASS * self.delta_time;
         self.thrust_power = SHIP_THRUST_FORCE / SHIP_MASS * self.delta_time;
         self.current_max_omega = BASE_MAX_OMEGA;
@@ -6259,7 +6363,7 @@ mod tests {
         let start_position = state.ships[0].position;
 
         for _ in 0..4 {
-            step(&mut state, &[SpacewarsAction::thrust(0)]);
+            step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
         }
 
         assert!((state.ships[0].position - start_position).dot(normal) > 0.0);
@@ -6664,11 +6768,11 @@ mod tests {
         state.ships[1].position = Vec2::new(900.0, 900.0);
         land_ship_on_planet(&mut state, 0, 0);
 
-        step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, true)]);
 
         assert!(state.ships[0].spaceport_ejection.is_some());
         assert_eq!(state.ships[0].laser_beam, None);
-        step(&mut state, &[SpacewarsAction::fire_laser_halt(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, false)]);
         step_until_spaceport_ejection_finishes(&mut state, 0);
 
         let beam = state.ships[0]
@@ -6699,7 +6803,7 @@ mod tests {
         state.ships[1].position = Vec2::new(900.0, 900.0);
         land_ship_on_planet(&mut state, 0, 0);
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
 
         assert!(state.ships[0].spaceport_ejection.is_some());
         assert!(
@@ -6708,7 +6812,7 @@ mod tests {
                 .iter()
                 .all(|debris| debris.kind != DebrisKind::Shell)
         );
-        step(&mut state, &[SpacewarsAction::fire_cannon_halt(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, false)]);
         step_until_spaceport_ejection_finishes(&mut state, 0);
 
         let shell = state
@@ -7103,7 +7207,7 @@ mod tests {
         let position = state.ships[0].position;
         let velocity = state.ships[0].velocity;
 
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
 
         assert_eq!(state.tick, tick);
         assert_eq!(state.ships[0].position, position);
@@ -7173,16 +7277,93 @@ mod tests {
         let mut state = init_deathmatch();
         let speed_delta = SHIP_THRUST_FORCE / SHIP_MASS / 60.0;
 
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
         assert_vec_close(
             state.ships[0].velocity,
             direction_from_rotation(0.0) * speed_delta,
         );
         assert!((state.ships[0].position.y - (450.0 + speed_delta / 60.0)).abs() < 0.001);
 
-        step(&mut state, &[SpacewarsAction::reverse(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, -1.0)]);
         assert_vec_close(state.ships[0].velocity, Vec2::ZERO);
         assert!((state.ships[0].position.y - (450.0 + speed_delta / 60.0)).abs() < 0.001);
+    }
+
+    #[test]
+    fn analog_thrust_scales_acceleration_and_exhaust_length() {
+        let mut full = init_deathmatch_no_asteroids();
+        let mut half = full.clone();
+        full.sun = None;
+        half.sun = None;
+
+        step(&mut full, &[SpacewarsAction::set_thrust(0, 1.0)]);
+        step(&mut half, &[SpacewarsAction::set_thrust(0, 0.5)]);
+
+        assert_close(
+            half.ships[0].velocity.length(),
+            full.ships[0].velocity.length() * 0.5,
+        );
+        let full_exhaust = full.ships[0].exhaust_trails[0]
+            .start
+            .distance_to(full.ships[0].exhaust_trails[0].end);
+        let half_exhaust = half.ships[0].exhaust_trails[0]
+            .start
+            .distance_to(half.ships[0].exhaust_trails[0].end);
+        assert_close(half_exhaust, full_exhaust * 0.5);
+    }
+
+    #[test]
+    fn analog_turn_and_brake_scale_existing_power() {
+        let mut state = init_deathmatch_no_asteroids();
+        state.sun = None;
+        state.planets.clear();
+        let turn_power = SHIP_TURN_FORCE / SHIP_MASS / 60.0;
+
+        step(&mut state, &[SpacewarsAction::set_turn(0, 0.5)]);
+        assert_close(state.ships[0].omega, turn_power * 0.5);
+
+        state.ships[0].velocity = Vec2::new(100.0, 0.0);
+        step(
+            &mut state,
+            &[
+                SpacewarsAction::set_turn(0, 0.0),
+                SpacewarsAction::set_brake(0, 0.5),
+            ],
+        );
+        let full_speed_delta = SHIP_THRUST_FORCE / SHIP_MASS / 60.0;
+        assert_close(state.ships[0].velocity.x, 100.0 - full_speed_delta * 0.5);
+    }
+
+    #[test]
+    fn held_setpoints_survive_escape_pod_and_ship_rebuild_transitions() {
+        let mut ship = ShipState::new_with_default_life(0, Vec2::ZERO, Color::WHITE, 1.0 / 60.0);
+        ship.set_wings(true);
+        ship.set_thrust(0.5);
+        ship.set_brake(0.25);
+        ship.set_turn(-0.75);
+        ship.set_laser(true);
+        ship.set_cannon(true);
+
+        ship.change_to_escape_pod();
+        ship.update_laser();
+        assert_eq!(ship.form, ShipForm::EscapePod);
+        assert!(ship.wings_closed);
+        assert_eq!(ship.wing_state, WingState::Closed);
+        assert_eq!(ship.thrust, 0.5);
+        assert_eq!(ship.brake, 0.25);
+        assert_eq!(ship.turn, -0.75);
+        assert!(ship.laser_firing);
+        assert!(ship.cannon_firing);
+        assert!(ship.laser_beam.is_none());
+
+        ship.restore_from_escape_pod();
+        assert_eq!(ship.form, ShipForm::Ship);
+        assert_eq!(ship.wing_behavior, WingBehavior::Close);
+        assert_eq!(ship.thrust, 0.5);
+        assert_eq!(ship.brake, 0.25);
+        assert_eq!(ship.turn, -0.75);
+        assert!(ship.laser_firing);
+        assert!(ship.cannon_firing);
     }
 
     #[test]
@@ -7194,11 +7375,11 @@ mod tests {
         state.ships[0].direction = Vec2::Y;
         let speed_delta = SHIP_THRUST_FORCE / SHIP_MASS / 60.0;
 
-        step(&mut state, &[SpacewarsAction::brake(0)]);
+        step(&mut state, &[SpacewarsAction::set_brake(0, 1.0)]);
 
         assert_vec_close(state.ships[0].velocity, Vec2::new(100.0 - speed_delta, 0.0));
         for _ in 0..180 {
-            step(&mut state, &[SpacewarsAction::brake(0)]);
+            step(&mut state, &[SpacewarsAction::set_brake(0, 1.0)]);
         }
         assert!(state.ships[0].velocity.x >= 0.0);
         assert_close(state.ships[0].velocity.y, 0.0);
@@ -7218,14 +7399,17 @@ mod tests {
 
         step(
             &mut state,
-            &[SpacewarsAction::close_wings(0), SpacewarsAction::brake(0)],
+            &[
+                SpacewarsAction::set_wings(0, true),
+                SpacewarsAction::set_brake(0, 1.0),
+            ],
         );
 
         assert_close(
             state.ships[0].velocity.length(),
             WING_CLOSED_SPEED - speed_delta,
         );
-        assert_eq!(state.ships[0].thrust_behavior, ThrustBehavior::Brake);
+        assert_eq!(state.ships[0].brake, 1.0);
     }
 
     #[test]
@@ -7234,8 +7418,8 @@ mod tests {
         let mut replay = init_deathmatch_no_asteroids();
         let start_thruster = ship_thruster_center(&first.ships[0]);
 
-        step(&mut first, &[SpacewarsAction::thrust(0)]);
-        step(&mut replay, &[SpacewarsAction::thrust(0)]);
+        step(&mut first, &[SpacewarsAction::set_thrust(0, 1.0)]);
+        step(&mut replay, &[SpacewarsAction::set_thrust(0, 1.0)]);
 
         assert_eq!(
             first.ships[0].exhaust_trails,
@@ -7253,10 +7437,10 @@ mod tests {
     fn turn_emits_exhaust_after_rotation_begins() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::turn_right(0)]);
+        step(&mut state, &[SpacewarsAction::set_turn(0, 1.0)]);
         assert!(state.ships[0].exhaust_trails.is_empty());
 
-        step(&mut state, &[SpacewarsAction::turn_right(0)]);
+        step(&mut state, &[SpacewarsAction::set_turn(0, 1.0)]);
 
         assert_eq!(state.ships[0].exhaust_trails.len(), 2);
     }
@@ -7265,11 +7449,11 @@ mod tests {
     fn exhaust_trails_fade_and_are_removed() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
         assert_eq!(state.ships[0].exhaust_trails.len(), 2);
 
         for _ in 0..12 {
-            step(&mut state, &[SpacewarsAction::thrust_halt(0)]);
+            step(&mut state, &[SpacewarsAction::set_thrust(0, 0.0)]);
         }
 
         assert!(state.ships[0].exhaust_trails.is_empty());
@@ -7280,32 +7464,35 @@ mod tests {
         let mut state = init_deathmatch();
         let turn_power = SHIP_TURN_FORCE / SHIP_MASS / 60.0;
 
-        step(&mut state, &[SpacewarsAction::turn_right(0)]);
+        step(&mut state, &[SpacewarsAction::set_turn(0, 1.0)]);
         assert_close(state.ships[0].omega, turn_power);
         assert_close(state.ships[0].rotation_radians, -0.0096);
 
         step(&mut state, &[]);
+        assert_close(state.ships[0].omega, turn_power * 2.0);
+        assert_close(state.ships[0].rotation_radians, -0.0288);
+
+        step(&mut state, &[SpacewarsAction::set_turn(0, 0.0)]);
         assert_close(state.ships[0].omega, 0.0);
-        assert_close(state.ships[0].rotation_radians, -0.0096);
     }
 
     #[test]
     fn wings_close_then_open_with_original_hold_release_semantics() {
         let mut state = init_deathmatch();
 
-        step(&mut state, &[SpacewarsAction::close_wings(0)]);
+        step(&mut state, &[SpacewarsAction::set_wings(0, true)]);
         assert_close(state.ships[0].wing_theta, WING_DELTA_SPEED / 60.0);
         assert_eq!(state.ships[0].wing_behavior, WingBehavior::Close);
-        assert_eq!(state.ships[0].thrust_behavior, ThrustBehavior::Full);
+        assert_eq!(state.ships[0].thrust, 0.0);
 
         for _ in 0..9 {
-            step(&mut state, &[SpacewarsAction::close_wings(0)]);
+            step(&mut state, &[SpacewarsAction::set_wings(0, true)]);
         }
         assert_close(state.ships[0].wing_theta, MAX_WING_THETA);
         assert_eq!(state.ships[0].wing_state, WingState::Closed);
         assert_close(state.ships[0].current_max_omega, WING_CLOSED_MAX_OMEGA);
 
-        step(&mut state, &[SpacewarsAction::open_wings(0)]);
+        step(&mut state, &[SpacewarsAction::set_wings(0, false)]);
         assert_eq!(state.ships[0].wing_behavior, WingBehavior::Open);
         assert!(state.ships[0].wing_theta < MAX_WING_THETA);
     }
@@ -7315,13 +7502,13 @@ mod tests {
         let mut state = init_deathmatch();
         state.ships[0].velocity = Vec2::new(0.0, MAX_SPEED * 2.0);
 
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
         assert_close(state.ships[0].velocity.length(), MAX_SPEED);
 
         state.ships[0].wing_state = WingState::Closed;
         state.ships[0].wing_theta = MAX_WING_THETA;
         state.ships[0].velocity = Vec2::new(0.0, WING_CLOSED_SPEED * 2.0);
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
         assert_close(state.ships[0].velocity.length(), WING_CLOSED_SPEED);
     }
 
@@ -7332,10 +7519,10 @@ mod tests {
         state.ships[0].wing_theta = MAX_WING_THETA;
         state.ships[0].velocity = Vec2::new(0.0, WING_CLOSED_SPEED);
 
-        step(&mut state, &[SpacewarsAction::open_wings(0)]);
+        step(&mut state, &[SpacewarsAction::set_wings(0, false)]);
 
         assert_eq!(state.ships[0].wing_behavior, WingBehavior::Open);
-        assert_eq!(state.ships[0].thrust_behavior, ThrustBehavior::None);
+        assert_eq!(state.ships[0].thrust, 0.0);
         assert_close(state.ships[0].velocity.length(), MAX_SPEED);
 
         while state.ships[0].wing_behavior == WingBehavior::Open {
@@ -7355,11 +7542,11 @@ mod tests {
         state.ships[0].wing_theta = MAX_WING_THETA;
         state.ships[0].velocity = Vec2::new(0.0, WING_CLOSED_SPEED);
 
-        step(&mut state, &[SpacewarsAction::open_wings(0)]);
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_wings(0, false)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
 
         assert_eq!(state.ships[0].wing_behavior, WingBehavior::Open);
-        assert_eq!(state.ships[0].thrust_behavior, ThrustBehavior::Full);
+        assert_eq!(state.ships[0].thrust, 1.0);
         assert_close(state.ships[0].velocity.length(), MAX_SPEED);
     }
 
@@ -7389,12 +7576,171 @@ mod tests {
     }
 
     #[test]
+    fn action_payloads_round_trip_and_clamp_untrusted_scalars() {
+        let encoded = SpacewarsAction::SetThrust {
+            player: 1,
+            amount: 0.42,
+        }
+        .encode();
+        assert_eq!(
+            SpacewarsAction::decode(&encoded),
+            Some(SpacewarsAction::SetThrust {
+                player: 1,
+                amount: 0.42,
+            })
+        );
+
+        let mut high = vec![0];
+        high.extend_from_slice(&f32::INFINITY.to_le_bytes());
+        assert_eq!(
+            SpacewarsAction::decode(&Action::scenario(SpacewarsActionKind::SetTurn as u32, high,)),
+            Some(SpacewarsAction::SetTurn {
+                player: 0,
+                rate: 1.0,
+            })
+        );
+
+        let mut nan = vec![0];
+        nan.extend_from_slice(&f32::NAN.to_le_bytes());
+        assert_eq!(
+            SpacewarsAction::decode(&Action::scenario(SpacewarsActionKind::SetBrake as u32, nan,)),
+            Some(SpacewarsAction::SetBrake {
+                player: 0,
+                amount: 0.0,
+            })
+        );
+    }
+
+    #[test]
+    fn action_decoder_rejects_malformed_players_booleans_and_lengths() {
+        assert!(SpacewarsAction::decode(&SpacewarsAction::set_thrust(usize::MAX, 1.0)).is_none());
+        assert!(
+            SpacewarsAction::decode(&Action::scenario(
+                SpacewarsActionKind::SetWings as u32,
+                vec![2, 1],
+            ))
+            .is_none()
+        );
+        assert!(
+            SpacewarsAction::decode(&Action::scenario(
+                SpacewarsActionKind::SetLaser as u32,
+                vec![0, 2],
+            ))
+            .is_none()
+        );
+        assert!(
+            SpacewarsAction::decode(&Action::scenario(
+                SpacewarsActionKind::SetTurn as u32,
+                vec![0, 1, 2],
+            ))
+            .is_none()
+        );
+        assert!(
+            SpacewarsAction::decode(&Action::scenario(
+                SpacewarsActionKind::ZoomIn as u32,
+                vec![0, 1],
+            ))
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn intent_encoder_emits_only_changed_normalized_setpoints() {
+        let mut encoder = ShipIntentEncoder::default();
+        assert!(encoder.encode(0, ShipIntent::default()).is_empty());
+
+        let actions = encoder.encode(
+            0,
+            ShipIntent {
+                turn: 0.456,
+                laser: true,
+                ..ShipIntent::default()
+            },
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter_map(SpacewarsAction::decode)
+                .collect::<Vec<_>>(),
+            vec![
+                SpacewarsAction::SetTurn {
+                    player: 0,
+                    rate: 0.46,
+                },
+                SpacewarsAction::SetLaser {
+                    player: 0,
+                    on: true,
+                },
+            ]
+        );
+        assert!(
+            encoder
+                .encode(
+                    0,
+                    ShipIntent {
+                        turn: 0.459,
+                        laser: true,
+                        ..ShipIntent::default()
+                    }
+                )
+                .is_empty()
+        );
+
+        let released = encoder.encode(0, ShipIntent::default());
+        assert_eq!(
+            released
+                .iter()
+                .filter_map(SpacewarsAction::decode)
+                .collect::<Vec<_>>(),
+            vec![
+                SpacewarsAction::SetTurn {
+                    player: 0,
+                    rate: 0.0,
+                },
+                SpacewarsAction::SetLaser {
+                    player: 0,
+                    on: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn intents_merge_component_wise_by_magnitude_and_boolean_union() {
+        let keyboard = ShipIntent {
+            turn: -1.0,
+            thrust: 1.0,
+            wings_closed: true,
+            ..ShipIntent::default()
+        };
+        let gamepad = ShipIntent {
+            turn: 0.4,
+            thrust: -0.6,
+            brake: 0.75,
+            laser: true,
+            ..ShipIntent::default()
+        };
+
+        assert_eq!(
+            keyboard.merged_with(gamepad),
+            ShipIntent {
+                turn: -1.0,
+                thrust: 1.0,
+                brake: 0.75,
+                wings_closed: true,
+                laser: true,
+                cannon: false,
+            }
+        );
+    }
+
+    #[test]
     fn fire_cannon_spawns_original_shell_and_recoil() {
         let mut state = init_deathmatch_no_asteroids();
         let start_ship = state.ships[0].clone();
         let mount_center = ship_mount_center(&start_ship);
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
 
         assert_eq!(state.debris.len(), 1);
         let shell = state.debris[0];
@@ -7425,9 +7771,9 @@ mod tests {
     fn held_cannon_respects_original_cooldown() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
         for _ in 0..29 {
-            step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+            step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
         }
 
         assert_eq!(
@@ -7439,7 +7785,7 @@ mod tests {
             1
         );
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
 
         assert_eq!(
             state
@@ -7461,7 +7807,7 @@ mod tests {
         state.ships[1].position = shell_spawn_position - target_low_offset;
         let start_life = state.ships[1].life;
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
 
         assert_eq!(
             state.ship_debris_collisions,
@@ -7491,7 +7837,7 @@ mod tests {
         ));
         let start_life = state.debris[0].life;
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
 
         assert_eq!(
             state.debris_collisions,
@@ -7511,7 +7857,7 @@ mod tests {
     fn cannon_shell_hits_body_and_leaves_breakup_fragment() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
         let shell_position = state.debris[0].position;
         state.sun = Some(SunState {
             position: shell_position,
@@ -7537,7 +7883,7 @@ mod tests {
     fn fire_laser_starts_beam_and_hold_extends_it() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, true)]);
         let first = state.ships[0].laser_beam.expect("laser should start");
         assert_close(first.length(), LASER_GROWTH_PER_TICK);
         assert_close(
@@ -7545,7 +7891,7 @@ mod tests {
             LASER_BASE_DAMAGE / LASER_GROWTH_PER_TICK,
         );
 
-        step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, true)]);
         let second = state.ships[0].laser_beam.expect("laser should continue");
         assert_close(second.length(), LASER_GROWTH_PER_TICK * 2.0);
         assert_close(
@@ -7558,10 +7904,10 @@ mod tests {
     fn fire_laser_halt_clears_beam() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, true)]);
         assert!(state.ships[0].laser_beam.is_some());
 
-        step(&mut state, &[SpacewarsAction::fire_laser_halt(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, false)]);
 
         assert!(state.ships[0].laser_beam.is_none());
         assert!(state.laser_hits.is_empty());
@@ -7584,7 +7930,7 @@ mod tests {
             ship_low_bounds(&ship_triangles(&state.ships[1])).center - state.ships[1].position;
         state.ships[1].position = head + state.ships[0].direction * 90.0 - target_low_offset;
 
-        step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, true)]);
 
         let beam = state.ships[0]
             .laser_beam
@@ -7620,9 +7966,9 @@ mod tests {
         reconcile_physics(&mut state);
         state.physics.step(1.0 / 60.0);
 
-        state.apply_action(SpacewarsAction {
+        state.apply_action(SpacewarsAction::SetLaser {
             player: 0,
-            kind: SpacewarsActionKind::FireLaser,
+            on: true,
         });
         update_ship_lasers(&mut state);
         state.laser_hits = resolve_laser_hits(&mut state);
@@ -7651,8 +7997,8 @@ mod tests {
         step(
             &mut state,
             &[
-                SpacewarsAction::fire_laser(0),
-                SpacewarsAction::fire_cannon(0),
+                SpacewarsAction::set_laser(0, true),
+                SpacewarsAction::set_cannon(0, true),
             ],
         );
 
@@ -7671,7 +8017,7 @@ mod tests {
     fn render_frame_includes_active_laser_lines() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::fire_laser(0)]);
+        step(&mut state, &[SpacewarsAction::set_laser(0, true)]);
         let frame = SpacewarsScenario::render_frame(&state);
         let lines = frame
             .layers
@@ -7687,7 +8033,7 @@ mod tests {
     fn render_frame_includes_exhaust_lines_behind_ships() {
         let mut state = init_deathmatch_no_asteroids();
 
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
         let frame = SpacewarsScenario::render_frame(&state);
         let exhaust_layer = frame
             .layers
@@ -7724,7 +8070,7 @@ mod tests {
                 ASTEROID_DAMAGE_SCALAR,
                 Color::DIM_GREY,
             ));
-            step(state, &[SpacewarsAction::fire_laser(0)]);
+            step(state, &[SpacewarsAction::set_laser(0, true)]);
         }
 
         assert_eq!(first.particles, replay.particles);
@@ -7812,7 +8158,7 @@ mod tests {
         let mut state = init_deathmatch_no_asteroids();
         let start_life = state.ships[0].life;
 
-        step(&mut state, &[SpacewarsAction::fire_cannon(0)]);
+        step(&mut state, &[SpacewarsAction::set_cannon(0, true)]);
 
         assert_eq!(state.ships[0].life, start_life);
         assert!(
@@ -8074,8 +8420,8 @@ mod tests {
         step(
             &mut state,
             &[
-                SpacewarsAction::fire_laser(0),
-                SpacewarsAction::fire_cannon(0),
+                SpacewarsAction::set_laser(0, true),
+                SpacewarsAction::set_cannon(0, true),
             ],
         );
 
@@ -8091,7 +8437,7 @@ mod tests {
         let mut state = init_deathmatch_no_asteroids();
         state.ships[0].change_to_escape_pod();
 
-        step(&mut state, &[SpacewarsAction::thrust(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, 1.0)]);
 
         assert_eq!(state.ships[0].form, ShipForm::EscapePod);
         assert!(state.ships[0].velocity.length() > 0.0);
@@ -8118,14 +8464,14 @@ mod tests {
         state.ships[0].change_to_escape_pod();
         state.ships[0].velocity = state.ships[0].direction * POD_CRUISE_SPEED;
 
-        step(&mut state, &[SpacewarsAction::reverse(0)]);
+        step(&mut state, &[SpacewarsAction::set_thrust(0, -1.0)]);
 
         assert_eq!(state.ships[0].form, ShipForm::EscapePod);
         assert!(state.ships[0].velocity.length() < POD_CRUISE_SPEED);
         assert!(state.ships[0].velocity.dot(state.ships[0].direction) > 0.0);
 
         for _ in 0..30 {
-            step(&mut state, &[SpacewarsAction::reverse(0)]);
+            step(&mut state, &[SpacewarsAction::set_thrust(0, -1.0)]);
         }
 
         assert!(state.ships[0].velocity.length() < 0.25);
@@ -8137,13 +8483,13 @@ mod tests {
         state.players[0].planet_count = 1;
         state.ships[0].change_to_escape_pod();
 
-        step(&mut state, &[SpacewarsAction::close_wings(0)]);
+        step(&mut state, &[SpacewarsAction::set_wings(0, true)]);
 
         assert_eq!(state.ships[0].form, ShipForm::EscapePod);
         assert_eq!(state.ships[0].wing_state, WingState::Closed);
         assert_close(state.ships[0].velocity.length(), POD_MAX_SPEED);
 
-        step(&mut state, &[SpacewarsAction::open_wings(0)]);
+        step(&mut state, &[SpacewarsAction::set_wings(0, false)]);
 
         assert_eq!(state.ships[0].wing_state, WingState::Opened);
         assert_close(state.ships[0].velocity.length(), POD_CRUISE_SPEED);
@@ -8556,14 +8902,8 @@ mod tests {
         let initial = state.player_view_heights;
         let step = player_zoom_step(&state.config);
 
-        state.apply_action(SpacewarsAction {
-            player: 0,
-            kind: SpacewarsActionKind::ZoomIn,
-        });
-        state.apply_action(SpacewarsAction {
-            player: 1,
-            kind: SpacewarsActionKind::ZoomOut,
-        });
+        state.apply_action(SpacewarsAction::ZoomIn { player: 0 });
+        state.apply_action(SpacewarsAction::ZoomOut { player: 1 });
 
         assert_eq!(state.player_view_heights[0], initial[0] - step);
         assert_eq!(state.player_view_heights[1], initial[1] + step);
@@ -8737,17 +9077,20 @@ mod tests {
         let mut replay = init_deathmatch_no_asteroids();
 
         for tick in 0..120 {
-            let mut actions = vec![SpacewarsAction::thrust(0), SpacewarsAction::thrust(1)];
+            let mut actions = vec![
+                SpacewarsAction::set_thrust(0, 1.0),
+                SpacewarsAction::set_thrust(1, 1.0),
+            ];
             if tick % 4 < 2 {
-                actions.push(SpacewarsAction::turn_right(0));
-                actions.push(SpacewarsAction::turn_left(1));
+                actions.push(SpacewarsAction::set_turn(0, 1.0));
+                actions.push(SpacewarsAction::set_turn(1, -1.0));
             } else {
-                actions.push(SpacewarsAction::turn_left(0));
-                actions.push(SpacewarsAction::turn_right(1));
+                actions.push(SpacewarsAction::set_turn(0, -1.0));
+                actions.push(SpacewarsAction::set_turn(1, 1.0));
             }
             if tick % 30 == 0 {
-                actions.push(SpacewarsAction::fire_cannon(0));
-                actions.push(SpacewarsAction::fire_cannon(1));
+                actions.push(SpacewarsAction::set_cannon(0, true));
+                actions.push(SpacewarsAction::set_cannon(1, true));
             }
 
             step(&mut first, &actions);

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Build and deploy Space-Wars to the Raspberry Pi over SSH.
+#
+# Usage:
+#   ./update.sh                         # Build + OTA flash + reboot + verify
+#   ./update.sh --skip-build            # Deploy the existing image
+#   ./update.sh --target 192.168.1.108   # Override the target host
+#   ./update.sh --user spacewars        # Override the SSH user
+#   ./update.sh --dry-run               # Show actions without changing the Pi
+#   ./update.sh --prompt                # Require final confirmation
+#   ./update.sh --help                  # Show all updater options
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YOCTO_DIR="$SCRIPT_DIR/yocto"
+TARGET_HOST="spacewars.local"
+REMOTE_USER="spacewars"
+DRY_RUN=false
+SHOW_HELP=false
+UPDATE_ARGS=("$@")
+
+usage() {
+    cat <<'EOF'
+Space-Wars update
+
+Usage:
+  ./update.sh [options]
+
+Options:
+  --target <host>       Target host [default: spacewars.local]
+  --host <host>         Alias for --target
+  --user <user>         SSH user [default: spacewars]
+  --remote-tmp <path>   Remote staging directory [default: /tmp]
+  --image <path>        Use a specific rootfs .ext4.gz image
+  --ssh-key <path>      Public SSH key to inject into the updated slot
+  --skip-build          Deploy the existing image without rebuilding
+  --dry-run             Print update actions without changing the Pi
+  --prompt              Ask for final confirmation before flashing
+  -h, --help            Show this help
+
+Examples:
+  ./update.sh
+  ./update.sh --skip-build
+  ./update.sh --target 192.168.1.108 --dry-run
+EOF
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+while (( $# > 0 )); do
+    case "$1" in
+        --target|--host)
+            (( $# >= 2 )) || fail "Missing value for $1"
+            TARGET_HOST="$2"
+            shift 2
+            ;;
+        --user)
+            (( $# >= 2 )) || fail "Missing value for --user"
+            REMOTE_USER="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            SHOW_HELP=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [ "$SHOW_HELP" = true ]; then
+    usage
+    exit 0
+fi
+
+[ -d "$YOCTO_DIR" ] || fail "Yocto directory not found at $YOCTO_DIR"
+command -v npm >/dev/null 2>&1 || fail "npm is required to run the updater"
+
+(cd "$YOCTO_DIR" && npm run update -- "${UPDATE_ARGS[@]}")
+
+if [ "$DRY_RUN" = true ]; then
+    exit 0
+fi
+
+REMOTE_TARGET="${REMOTE_USER}@${TARGET_HOST}"
+SSH_OPTIONS=(
+    -o BatchMode=yes
+    -o ConnectTimeout=3
+    -o ConnectionAttempts=1
+    -o LogLevel=ERROR
+)
+
+echo "Verifying spacewars-kiosk.service on ${REMOTE_TARGET}..."
+
+deadline=$((SECONDS + 30))
+while (( SECONDS < deadline )); do
+    if ssh "${SSH_OPTIONS[@]}" "$REMOTE_TARGET" \
+        "systemctl is-active --quiet spacewars-kiosk.service"; then
+        ssh "${SSH_OPTIONS[@]}" "$REMOTE_TARGET" \
+            'printf "Boot root: "; sed -n "s/.* root=\([^ ]*\).*/\1/p" /proc/cmdline; systemctl show spacewars-kiosk.service --property=ActiveState --property=MainPID --property=NRestarts'
+        echo "Space-Wars update verified."
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "Error: spacewars-kiosk.service did not become active on ${REMOTE_TARGET}" >&2
+ssh "${SSH_OPTIONS[@]}" "$REMOTE_TARGET" \
+    "systemctl --no-pager --full status spacewars-kiosk.service" || true
+exit 1

--- a/yocto/README.md
+++ b/yocto/README.md
@@ -85,20 +85,21 @@ lsblk -f /dev/sdb
 ## OTA Update
 
 After an OTA-capable image has been flashed once, later root filesystem updates
-can be pushed over SSH to the inactive A/B slot:
+can be pushed from the repository root over SSH to the inactive A/B slot:
 
 ```sh
-cd yocto
-npm run update
-npm run update -- --skip-build
+./update.sh
+./update.sh --skip-build
 ```
 
-`npm run update` follows the DirtSim model: it builds unless `--skip-build` is
+`./update.sh` follows the DirtSim model: it builds unless `--skip-build` is
 passed, transfers the latest
 `spacewars-image-raspberrypi5.rootfs.ext4.gz`, verifies the checksum on the Pi,
 injects the configured SSH public key into the inactive slot, switches the boot
-slot, and reboots. The image grants the `spacewars` user passwordless sudo only
-for the A/B update helper and `systemctl reboot`.
+slot, reboots, and verifies that `spacewars-kiosk.service` is active. The image
+grants the `spacewars` user passwordless sudo only for the A/B update helper and
+`systemctl reboot`. The lower-level command remains available as
+`npm run update` from this directory.
 
 SSH host keys live under `/data/ssh` so reflashes and A/B updates keep a stable
 device identity.

--- a/yocto/meta-spacewars/recipes-devtools/pseudo/pseudo_git.bbappend
+++ b/yocto/meta-spacewars/recipes-devtools/pseudo/pseudo_git.bbappend
@@ -1,0 +1,9 @@
+# GNU tar's jailified extraction path uses openat2. The pseudo revision in
+# Scarthgap only provides an ENOSYS stub, which makes packaging fail on newer
+# hosts with "Cannot mkdir: Function not implemented".
+#
+# Pin the upstream openat2 implementation based on Scarthgap's existing pseudo
+# revision so builds remain reproducible on those hosts.
+SRC_URI:remove = "git://git.yoctoproject.org/pseudo;branch=master;protocol=https"
+SRC_URI:prepend = "git://git.yoctoproject.org/pseudo;protocol=https;nobranch=1 "
+SRCREV = "54f3d1b4dd3eaed2c57b43c3a4d62cdf99239ed2"

--- a/yocto/meta-spacewars/recipes-spacewars/spacewars/files/spacewars-kiosk.service
+++ b/yocto/meta-spacewars/recipes-spacewars/spacewars/files/spacewars-kiosk.service
@@ -14,7 +14,7 @@ Environment=SLINT_BACKEND=linuxkms-software
 Environment=SLINT_DRM_OUTPUT=DPI-1
 Environment=SLINT_KMS_ROTATION=90
 WorkingDirectory=/data/spacewars
-ExecStart=/usr/bin/engine-client --kiosk --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
+ExecStart=/usr/bin/engine-client --fullscreen --config-dir /var/lib/spacewars --renderer raster --raster-scale 2.0
 Restart=on-failure
 RestartSec=2
 NoNewPrivileges=true

--- a/yocto/meta-spacewars/recipes-spacewars/spacewars/spacewars_git.bb
+++ b/yocto/meta-spacewars/recipes-spacewars/spacewars/spacewars_git.bb
@@ -19,6 +19,7 @@ DEPENDS += " \
     libinput \
     libxkbcommon \
     seatd \
+    udev \
 "
 
 RDEPENDS:${PN} += " \
@@ -27,6 +28,7 @@ RDEPENDS:${PN} += " \
     libinput \
     libxkbcommon \
     seatd \
+    libudev \
     xkeyboard-config \
 "
 


### PR DESCRIPTION
## Summary

- Add backend-neutral gilrs controller discovery, stable two-player seat assignment, reconnect behavior, and automatic pause on disconnect.
- Route keyboard, gamepad, and benchmark control sources through normalized analog ShipIntent set points, preserving keyboard behavior while enabling analog Spacewars flight.
- Make the fullscreen launcher, controls, pause, and game-over flows usable at 800x480 with D-pad/stick navigation and controller actions.
- Add basic Rover Lab controls: D-pad left/right drives, and A brakes.
- Boot the Pi kiosk into the launcher and provide the documented A/B update flow and required Yocto gamepad dependencies.

## Design note

Issue #8 proposed a virtual cursor. This implementation uses semantic selection and navigation for the known launcher and overlay controls, giving deterministic movement and visible focus on a low-resolution kiosk while retaining touch and mouse support.

## Validation

- cargo test --workspace: 322 passed
- git diff --check
- Manual playtesting using touch and an NES-style gamepad
- A/B OTA deployed to spacewars.local and booted from /dev/sda3
- Kiosk service active with zero restarts; engine-client reopened the gamepad evdev device

Closes #8