### PR TITLE
Add charged Rover Lab jumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ cargo run -p engine-client -- --scenario rover-lab
 cargo run -p engine-client -- --scenario spacewars
 ```
 
-Rover Lab uses `W` to drive forward, `S` to brake, `X` to reverse, and `R` to
-reset.
+Rover Lab uses d-pad left/right to drive, `B` or d-pad down to brake, and a
+hold/release of `A` to charge and jump. Keyboard equivalents are `W` forward,
+`S` brake, `X` reverse, `Space` jump, and `R` reset.
 
 ## Raspberry Pi / kiosk launch
 

--- a/crates/engine-client/src/client_scenarios/rover_lab.rs
+++ b/crates/engine-client/src/client_scenarios/rover_lab.rs
@@ -18,7 +18,7 @@ pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
         player_zoom: false,
         game_over: false,
     },
-    controls_help: "Rover Lab: d-pad right drives forward, d-pad left drives in reverse, A brakes, and the pause menu can restart the lab. Keyboard: W forward, S brake, X reverse, R reset.",
+    controls_help: "Rover Lab: d-pad right drives forward, d-pad left drives in reverse, B or d-pad down brakes, and holding then releasing A jumps. The pause menu can restart the lab. Keyboard: W forward, S brake, X reverse, hold/release Space to jump, R reset.",
     create,
 };
 
@@ -51,8 +51,8 @@ impl ClientScenario for RoverLabClientScenario {
     }
 
     fn map_input(&self, input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
-        let (throttle, brake) = rover_controls(input);
-        vec![RoverLabAction::drive(throttle, brake)]
+        let (throttle, brake, jump_held) = rover_controls(input);
+        vec![RoverLabAction::drive(throttle, brake, jump_held)]
     }
 
     fn render_frames(&self, _renderer: RenderBackend, _viewport: Viewport) -> Vec<RenderFrame> {
@@ -74,8 +74,8 @@ impl ClientScenario for RoverLabClientScenario {
     }
 }
 
-fn rover_controls(input: &ClientInput) -> (f32, bool) {
-    let (gamepad_throttle, gamepad_brake) = input.rover_drive_input();
+fn rover_controls(input: &ClientInput) -> (f32, bool, bool) {
+    let (gamepad_throttle, gamepad_brake, gamepad_jump) = input.rover_gamepad_input();
     let brake = input.is_pressed(GameKey::P1Brake) || gamepad_brake;
     let throttle = if brake {
         0.0
@@ -86,7 +86,8 @@ fn rover_controls(input: &ClientInput) -> (f32, bool) {
     } else {
         gamepad_throttle
     };
-    (throttle, brake)
+    let jump_held = input.is_pressed(GameKey::P1Laser) || gamepad_jump;
+    (throttle, brake, jump_held)
 }
 
 #[cfg(test)]
@@ -112,14 +113,14 @@ mod tests {
             dpad_right: true,
             ..GamepadSeatInput::default()
         });
-        assert_eq!(rover_controls(&forward), (1.0, false));
+        assert_eq!(rover_controls(&forward), (1.0, false, false));
 
         let (reverse, _) = client_input_with_gamepad(GamepadSeatInput {
             connected: true,
             dpad_left: true,
             ..GamepadSeatInput::default()
         });
-        assert_eq!(rover_controls(&reverse), (-1.0, false));
+        assert_eq!(rover_controls(&reverse), (-1.0, false, false));
     }
 
     #[test]
@@ -129,7 +130,7 @@ mod tests {
             dpad_right: true,
             ..GamepadSeatInput::default()
         });
-        assert_eq!(rover_controls(&input), (1.0, false));
+        assert_eq!(rover_controls(&input), (1.0, false, false));
 
         gamepads.borrow_mut().set_seat(
             0,
@@ -138,19 +139,41 @@ mod tests {
                 ..GamepadSeatInput::default()
             },
         );
-        assert_eq!(rover_controls(&input), (0.0, false));
+        assert_eq!(rover_controls(&input), (0.0, false, false));
     }
 
     #[test]
-    fn nes_a_brake_overrides_gamepad_and_keyboard_throttle() {
+    fn nes_brake_controls_override_gamepad_and_keyboard_throttle() {
         let (mut input, _) = client_input_with_gamepad(GamepadSeatInput {
             connected: true,
             dpad_right: true,
-            south: true,
+            east: true,
             ..GamepadSeatInput::default()
         });
         input.press(GameKey::P1Thrust);
 
-        assert_eq!(rover_controls(&input), (0.0, true));
+        assert_eq!(rover_controls(&input), (0.0, true, false));
+
+        let (input, _) = client_input_with_gamepad(GamepadSeatInput {
+            connected: true,
+            dpad_left: true,
+            dpad_down: true,
+            ..GamepadSeatInput::default()
+        });
+        assert_eq!(rover_controls(&input), (0.0, true, false));
+    }
+
+    #[test]
+    fn nes_a_and_keyboard_space_hold_jump() {
+        let (input, _) = client_input_with_gamepad(GamepadSeatInput {
+            connected: true,
+            south: true,
+            ..GamepadSeatInput::default()
+        });
+        assert_eq!(rover_controls(&input), (0.0, false, true));
+
+        let (mut keyboard, _) = client_input_with_gamepad(GamepadSeatInput::default());
+        keyboard.press(GameKey::P1Laser);
+        assert_eq!(rover_controls(&keyboard), (0.0, false, true));
     }
 }

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -228,18 +228,18 @@ impl ClientInput {
         actions
     }
 
-    pub(crate) fn rover_drive_input(&self) -> (f32, bool) {
+    pub(crate) fn rover_gamepad_input(&self) -> (f32, bool, bool) {
         let gamepads = self.gamepads.borrow();
         let Some(gamepad) = gamepads.seat(0).filter(|gamepad| gamepad.connected) else {
-            return (0.0, false);
+            return (0.0, false, false);
         };
-        let brake = gamepad.south;
+        let brake = gamepad.east || gamepad.dpad_down;
         let throttle = match (gamepad.dpad_left, gamepad.dpad_right) {
             (false, true) if !brake => 1.0,
             (true, false) if !brake => -1.0,
             _ => 0.0,
         };
-        (throttle, brake)
+        (throttle, brake, gamepad.south)
     }
 
     pub(crate) fn reset_spacewars_controls(&mut self) {

--- a/crates/engine-rapier/src/rover.rs
+++ b/crates/engine-rapier/src/rover.rs
@@ -18,6 +18,7 @@ const ROVER_CHASSIS_COLLIDER_ROLE: ColliderRole = ColliderRole::new(20);
 const ROVER_WHEEL_COLLIDER_ROLE: ColliderRole = ColliderRole::new(21);
 const ROVER_LEFT_SUSPENSION_ROLE: JointRole = JointRole::new(20);
 const ROVER_RIGHT_SUSPENSION_ROLE: JointRole = JointRole::new(21);
+const MIN_SUPPORT_ALIGNMENT: f32 = 0.25;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PlanetSpec {
@@ -115,7 +116,31 @@ pub struct RoverSnapshot {
     pub chassis: BodyMotion,
     pub wheels: [BodyMotion; 2],
     pub suspension_anchors: [Vec2; 2],
+    pub suspension_lengths: [f32; 2],
+    pub grounded_wheels: [bool; 2],
+    pub support_normal: Option<Vec2>,
+    pub max_support_impulse: f32,
     pub contacts: Vec<ContactPoint>,
+}
+
+impl RoverSnapshot {
+    pub fn grounded_wheel_count(&self) -> usize {
+        self.grounded_wheels
+            .into_iter()
+            .filter(|grounded| *grounded)
+            .count()
+    }
+
+    pub fn is_grounded(&self) -> bool {
+        self.grounded_wheels.into_iter().any(|grounded| grounded)
+    }
+}
+
+struct RoverSupportState {
+    grounded_wheels: [bool; 2],
+    normal: Option<Vec2>,
+    max_impulse: f32,
+    wheel_contacts: Vec<ContactPoint>,
 }
 
 /// Stable description of one kinematic circular planet assembly.
@@ -427,6 +452,34 @@ impl RoverAssembly {
         true
     }
 
+    /// Apply one mass-independent takeoff velocity to the complete assembly.
+    ///
+    /// The direction is the average supporting wheel-contact normal aligned
+    /// with the chassis' local up axis. Applying the same velocity change to
+    /// all three bodies preserves their relative motion and leaves Rapier's
+    /// suspension joints authoritative.
+    pub fn apply_jump_velocity(&self, physics: &mut PhysicsWorld, speed: f32) -> Option<Vec2> {
+        if !speed.is_finite()
+            || speed <= 0.0
+            || self
+                .bodies()
+                .into_iter()
+                .any(|body| !physics.contains_body(body))
+        {
+            return None;
+        }
+
+        let chassis = physics.motion(self.chassis)?;
+        let direction = self.support_state(physics, chassis).normal?;
+        let delta_velocity = direction * speed;
+        for body in self.bodies() {
+            if !physics.apply_velocity_delta(body, delta_velocity, true) {
+                return None;
+            }
+        }
+        Some(direction)
+    }
+
     pub fn snapshot(&self, physics: &PhysicsWorld) -> Option<RoverSnapshot> {
         let chassis = physics.motion(self.chassis)?;
         let wheels = [
@@ -436,24 +489,67 @@ impl RoverAssembly {
         let suspension_anchors = self
             .suspension_anchors
             .map(|anchor| chassis.position + anchor.rotate_radians(chassis.angle));
-        let mut contacts = Vec::new();
-        for collider in self
-            .wheel_colliders
-            .into_iter()
-            .chain(std::iter::once(self.chassis_collider))
-        {
-            contacts.extend(physics.contact_points(collider));
-        }
+        let suspension_lengths =
+            [0, 1].map(|index| suspension_anchors[index].distance_to(wheels[index].position));
+        let support = self.support_state(physics, chassis);
+        let mut contacts = support.wheel_contacts;
+        contacts.extend(physics.contact_points(self.chassis_collider));
         Some(RoverSnapshot {
             chassis,
             wheels,
             suspension_anchors,
+            suspension_lengths,
+            grounded_wheels: support.grounded_wheels,
+            support_normal: support.normal,
+            max_support_impulse: support.max_impulse,
             contacts,
         })
     }
 
     pub fn remove(self, physics: &mut PhysicsWorld) -> bool {
         physics.remove_entity(self.entity)
+    }
+
+    fn support_state(&self, physics: &PhysicsWorld, chassis: BodyMotion) -> RoverSupportState {
+        let chassis_up = Vec2::Y.rotate_radians(chassis.angle);
+        let mut grounded_wheels = [false; 2];
+        let mut normal_sum = Vec2::ZERO;
+        let mut wheel_contacts = Vec::new();
+
+        for (index, collider) in self.wheel_colliders.into_iter().enumerate() {
+            for contact in physics.contact_points(collider) {
+                let support_normal = -contact.normal.normalized();
+                if support_normal.dot(chassis_up) >= MIN_SUPPORT_ALIGNMENT {
+                    grounded_wheels[index] = true;
+                    normal_sum += support_normal;
+                }
+                wheel_contacts.push(contact);
+            }
+        }
+
+        let normal = (normal_sum.length_squared() > f32::EPSILON).then(|| normal_sum.normalized());
+        let mut max_impulse = 0.0_f32;
+        for event in physics.contact_events() {
+            for collider in self.wheel_colliders {
+                let support_normal = if event.collider_a == collider {
+                    -event.normal
+                } else if event.collider_b == collider {
+                    event.normal
+                } else {
+                    continue;
+                };
+                if support_normal.normalized().dot(chassis_up) >= MIN_SUPPORT_ALIGNMENT {
+                    max_impulse = max_impulse.max(event.impulse_magnitude);
+                }
+            }
+        }
+
+        RoverSupportState {
+            grounded_wheels,
+            normal,
+            max_impulse,
+            wheel_contacts,
+        }
     }
 }
 
@@ -513,10 +609,17 @@ mod tests {
     }
 
     fn test_world() -> (PhysicsWorld, PlanetSpec, PlanetAssembly, RoverAssembly) {
+        test_world_with_bumps(&[])
+    }
+
+    fn test_world_with_bumps(
+        bumps: &[BumpSpec],
+    ) -> (PhysicsWorld, PlanetSpec, PlanetAssembly, RoverAssembly) {
         let mut physics = PhysicsWorld::new(PhysicsWorldConfig {
             solver_iterations: 8,
             internal_stabilization_iterations: 2,
             max_ccd_substeps: 2,
+            collect_events: true,
             ..PhysicsWorldConfig::default()
         });
         let planet_spec = PlanetSpec {
@@ -524,7 +627,7 @@ mod tests {
             radius: 20.0,
             angle: 0.0,
         };
-        let planet = PlanetAssembly::insert(&mut physics, PLANET, planet_spec, &[]).unwrap();
+        let planet = PlanetAssembly::insert(&mut physics, PLANET, planet_spec, bumps).unwrap();
         let rover = RoverAssembly::insert(
             &mut physics,
             ROVER,
@@ -536,17 +639,173 @@ mod tests {
         (physics, planet_spec, planet, rover)
     }
 
+    fn step_rover(physics: &mut PhysicsWorld, rover: &RoverAssembly, control: RoverControl) {
+        physics.clear_forces();
+        assert!(rover.set_control(physics, control));
+        assert!(rover.apply_acceleration_field(physics, gravity));
+        physics.step(1.0 / 60.0);
+    }
+
+    fn settle_rover(physics: &mut PhysicsWorld, rover: &RoverAssembly) {
+        for _ in 0..240 {
+            step_rover(physics, rover, RoverControl::default());
+        }
+    }
+
+    fn driven_suspension_excursion(
+        mut physics: PhysicsWorld,
+        rover: &RoverAssembly,
+    ) -> (f32, RoverSnapshot) {
+        settle_rover(&mut physics, rover);
+        let mut minimum_length = f32::INFINITY;
+        let mut maximum_length = 0.0_f32;
+        for _ in 0..900 {
+            step_rover(
+                &mut physics,
+                rover,
+                RoverControl {
+                    throttle: 0.7,
+                    brake: false,
+                },
+            );
+            let snapshot = rover.snapshot(&physics).unwrap();
+            for length in snapshot.suspension_lengths {
+                minimum_length = minimum_length.min(length);
+                maximum_length = maximum_length.max(length);
+            }
+        }
+        (
+            maximum_length - minimum_length,
+            rover.snapshot(&physics).unwrap(),
+        )
+    }
+
     #[test]
     fn assembly_uses_the_canonical_world_and_settles() {
         let (mut physics, _, _, rover) = test_world();
-        for _ in 0..240 {
-            physics.clear_forces();
-            assert!(rover.apply_acceleration_field(&mut physics, gravity));
-            physics.step(1.0 / 60.0);
-        }
+        settle_rover(&mut physics, &rover);
         let snapshot = rover.snapshot(&physics).unwrap();
         assert!(!snapshot.contacts.is_empty());
+        assert!(snapshot.is_grounded());
+        assert!(snapshot.support_normal.is_some());
         assert!(snapshot.chassis.position.length() > 20.0);
+    }
+
+    #[test]
+    fn jump_uses_surface_support_and_preserves_articulated_motion() {
+        let (mut physics, planet_spec, _, rover) = test_world();
+        settle_rover(&mut physics, &rover);
+        let before = rover
+            .bodies()
+            .map(|body| physics.motion(body).unwrap().linear_velocity);
+
+        let jump_speed = 8.0;
+        let direction = rover
+            .apply_jump_velocity(&mut physics, jump_speed)
+            .expect("a settled rover must have a supporting contact");
+        let after = rover
+            .bodies()
+            .map(|body| physics.motion(body).unwrap().linear_velocity);
+        let radial_up =
+            (rover.snapshot(&physics).unwrap().chassis.position - planet_spec.center).normalized();
+
+        assert!(direction.dot(radial_up) > 0.95);
+        for index in 0..3 {
+            let applied = after[index] - before[index];
+            assert!((applied - direction * jump_speed).length() < 1.0e-4);
+        }
+    }
+
+    #[test]
+    fn wheel_motors_drive_around_the_curved_surface() {
+        let (mut physics, _, _, rover) = test_world();
+        settle_rover(&mut physics, &rover);
+        let start = rover.snapshot(&physics).unwrap().chassis.position;
+        let start_angle = start.y.atan2(start.x);
+
+        for _ in 0..600 {
+            step_rover(
+                &mut physics,
+                &rover,
+                RoverControl {
+                    throttle: 0.7,
+                    brake: false,
+                },
+            );
+        }
+
+        let end = rover.snapshot(&physics).unwrap().chassis.position;
+        let angular_travel = (end.y.atan2(end.x) - start_angle).abs();
+        assert!(
+            angular_travel > 0.35,
+            "rover only traveled {angular_travel} radians"
+        );
+        assert!(
+            (20.0..25.0).contains(&end.length()),
+            "rover radius was {}",
+            end.length()
+        );
+    }
+
+    #[test]
+    fn suspension_compresses_and_recovers_over_a_surface_bump() {
+        let bump = BumpSpec {
+            surface_angle: 1.08,
+            half_width: 1.25,
+            half_height: 0.32,
+        };
+        let (flat_physics, _, _, flat_rover) = test_world();
+        let (bump_physics, _, _, bump_rover) = test_world_with_bumps(&[bump]);
+        let (flat_excursion, _) = driven_suspension_excursion(flat_physics, &flat_rover);
+        let (bump_excursion, snapshot) = driven_suspension_excursion(bump_physics, &bump_rover);
+
+        assert!(
+            bump_excursion > flat_excursion + 0.04,
+            "bump excursion {bump_excursion} was too close to flat excursion {flat_excursion}"
+        );
+        assert!((20.0..25.0).contains(&snapshot.chassis.position.length()));
+    }
+
+    #[test]
+    fn rover_completes_a_bumped_circumference_without_escaping() {
+        let bump = BumpSpec {
+            surface_angle: 1.08,
+            half_width: 1.25,
+            half_height: 0.32,
+        };
+        let (mut physics, _, _, rover) = test_world_with_bumps(&[bump]);
+        settle_rover(&mut physics, &rover);
+
+        let start = rover.snapshot(&physics).unwrap().chassis.position;
+        let mut previous_angle = start.y.atan2(start.x);
+        let mut accumulated_angle = 0.0_f32;
+        for _ in 0..3600 {
+            step_rover(
+                &mut physics,
+                &rover,
+                RoverControl {
+                    throttle: 0.7,
+                    brake: false,
+                },
+            );
+            let position = rover.snapshot(&physics).unwrap().chassis.position;
+            assert!(
+                (20.0..25.0).contains(&position.length()),
+                "rover radius was {}",
+                position.length()
+            );
+            let angle = position.y.atan2(position.x);
+            let delta = (angle - previous_angle + std::f32::consts::PI)
+                .rem_euclid(std::f32::consts::TAU)
+                - std::f32::consts::PI;
+            accumulated_angle += delta;
+            previous_angle = angle;
+        }
+
+        assert!(
+            accumulated_angle.abs() > std::f32::consts::TAU,
+            "rover only traveled {accumulated_angle} radians"
+        );
     }
 
     #[test]

--- a/scenarios/rover-lab/src/lib.rs
+++ b/scenarios/rover-lab/src/lib.rs
@@ -31,6 +31,13 @@ const PLANET_RADIUS: f32 = 20.0;
 const CAMERA_HEIGHT: f32 = 54.0;
 const GRAVITY_ACCELERATION: f32 = 18.0;
 const DEFAULT_PLANET_ANGULAR_VELOCITY: f32 = 0.015;
+const LAB_WHEEL_TARGET_SPEED: f32 = 12.0;
+const LAB_WHEEL_MOTOR_TORQUE: f32 = 100.0;
+const JUMP_MAX_CHARGE_TICKS: u16 = 48;
+const JUMP_MIN_HEIGHT: f32 = 0.6;
+const JUMP_MAX_HEIGHT: f32 = 4.0;
+const MIN_LANDING_AIRTIME_TICKS: u32 = 3;
+const MAX_LANDING_OUTWARD_SPEED: f32 = 0.5;
 const LAB_BUMP: BumpSpec = BumpSpec {
     surface_angle: 1.08,
     half_width: 1.25,
@@ -46,6 +53,8 @@ const WHEEL_COLOR: RenderColor = RenderColor::rgb(0.13, 0.15, 0.19);
 const WHEEL_STROKE: RenderColor = RenderColor::rgb(0.75, 0.82, 0.9);
 const SUSPENSION_COLOR: RenderColor = RenderColor::rgb(0.38, 0.95, 0.84);
 const CONTACT_COLOR: RenderColor = RenderColor::rgb(1.0, 0.2, 0.85);
+const CHARGE_BACKGROUND: RenderColor = RenderColor::rgb(0.08, 0.1, 0.16);
+const CHARGE_FILL: RenderColor = RenderColor::rgb(0.96, 0.74, 0.16);
 
 pub struct RoverLabScenario;
 
@@ -81,6 +90,14 @@ pub struct RoverLabState {
     pub control: RoverControl,
     pub gravity_sources: Vec<RoverGravitySource>,
     pub last_gravity_metrics: GravityStepMetrics,
+    pub jump_held: bool,
+    pub jump_charge_ticks: u16,
+    pub last_jump_speed: f32,
+    pub airborne_ticks: u32,
+    pub last_airtime_ticks: u32,
+    pub last_landing_impulse: f32,
+    jump_was_held: bool,
+    jump_in_flight: bool,
     planet_assembly: PlanetAssembly,
     rover: RoverAssembly,
     physics: PhysicsWorld,
@@ -94,18 +111,24 @@ impl RoverLabState {
             .snapshot(&self.physics)
             .expect("rover lab must retain its rover")
     }
+
+    pub fn jump_charge_fraction(&self) -> f32 {
+        f32::from(self.jump_charge_ticks) / f32::from(JUMP_MAX_CHARGE_TICKS)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RoverLabAction {
     pub throttle: f32,
     pub brake: bool,
+    pub jump_held: bool,
 }
 
 impl RoverLabAction {
-    pub fn drive(throttle: f32, brake: bool) -> Action {
+    pub fn drive(throttle: f32, brake: bool, jump_held: bool) -> Action {
         let mut payload = throttle.to_le_bytes().to_vec();
         payload.push(u8::from(brake));
+        payload.push(u8::from(jump_held));
         Action::scenario(DRIVE_ACTION_KIND, payload)
     }
 
@@ -113,12 +136,13 @@ impl RoverLabAction {
         let Action::Scenario { kind, payload } = action else {
             return None;
         };
-        if *kind != DRIVE_ACTION_KIND || payload.len() != 5 {
+        if *kind != DRIVE_ACTION_KIND || payload.len() != 6 {
             return None;
         }
         Some(Self {
             throttle: f32::from_le_bytes(payload[0..4].try_into().ok()?),
             brake: payload[4] != 0,
+            jump_held: payload[5] != 0,
         })
     }
 }
@@ -134,7 +158,11 @@ impl Scenario for RoverLabScenario {
             radius: PLANET_RADIUS,
             angle: 0.0,
         };
-        let rover_spec = RoverSpec::default();
+        let rover_spec = RoverSpec {
+            wheel_target_speed: LAB_WHEEL_TARGET_SPEED,
+            wheel_motor_torque: LAB_WHEEL_MOTOR_TORQUE,
+            ..RoverSpec::default()
+        };
         let mut physics = PhysicsWorld::new(PhysicsWorldConfig {
             length_unit: 1.0,
             solver_iterations: 8,
@@ -166,6 +194,14 @@ impl Scenario for RoverLabScenario {
             control: RoverControl::default(),
             gravity_sources,
             last_gravity_metrics: GravityStepMetrics::default(),
+            jump_held: false,
+            jump_charge_ticks: 0,
+            last_jump_speed: 0.0,
+            airborne_ticks: 0,
+            last_airtime_ticks: 0,
+            last_landing_impulse: 0.0,
+            jump_was_held: false,
+            jump_in_flight: false,
             planet_assembly,
             rover,
             physics,
@@ -184,12 +220,15 @@ impl Scenario for RoverLabScenario {
                 throttle: action.throttle.clamp(-1.0, 1.0),
                 brake: action.brake,
             };
+            state.jump_held = action.jump_held;
         }
 
         let dt_seconds = dt.as_secs_f32();
         if !dt_seconds.is_finite() || dt_seconds <= 0.0 {
             return StepResult::default();
         }
+
+        update_jump(state);
 
         state.planet.angle = (state.planet.angle
             + state.config.planet_angular_velocity * dt_seconds)
@@ -226,9 +265,14 @@ impl Scenario for RoverLabScenario {
             rover.chassis.linear_velocity.y,
             rover.wheels[0].angle,
             rover.wheels[1].angle,
+            state.jump_charge_fraction(),
+            state.last_jump_speed,
+            state.last_landing_impulse,
         ] {
             payload.extend_from_slice(&value.to_le_bytes());
         }
+        payload.push(u8::try_from(rover.grounded_wheel_count()).unwrap_or(u8::MAX));
+        payload.extend_from_slice(&state.airborne_ticks.to_le_bytes());
         Observation { payload }
     }
 
@@ -239,6 +283,70 @@ impl Scenario for RoverLabScenario {
     fn tick_model() -> TickModel {
         TickModel::FixedTimestep { hz: FIXED_HZ }
     }
+}
+
+fn update_jump(state: &mut RoverLabState) {
+    let snapshot = state.rover_snapshot();
+    let grounded = snapshot.is_grounded();
+
+    if state.jump_in_flight {
+        state.airborne_ticks = state.airborne_ticks.saturating_add(1);
+        let outward_speed = snapshot
+            .support_normal
+            .map(|normal| snapshot.chassis.linear_velocity.dot(normal))
+            .unwrap_or(f32::INFINITY);
+        if grounded
+            && state.airborne_ticks >= MIN_LANDING_AIRTIME_TICKS
+            && outward_speed <= MAX_LANDING_OUTWARD_SPEED
+        {
+            state.last_airtime_ticks = state.airborne_ticks;
+            state.last_landing_impulse = snapshot.max_support_impulse;
+            state.airborne_ticks = 0;
+            state.jump_in_flight = false;
+        }
+    } else if grounded {
+        state.airborne_ticks = 0;
+    } else {
+        state.airborne_ticks = state.airborne_ticks.saturating_add(1);
+    }
+
+    let released = state.jump_was_held && !state.jump_held;
+    if state.jump_held {
+        if grounded && !state.jump_in_flight {
+            state.jump_charge_ticks = state
+                .jump_charge_ticks
+                .saturating_add(1)
+                .min(JUMP_MAX_CHARGE_TICKS);
+        } else {
+            state.jump_charge_ticks = 0;
+        }
+    } else if released {
+        if grounded && !state.jump_in_flight && state.jump_charge_ticks > 0 {
+            let jump_speed = jump_speed(state.jump_charge_ticks, state.config.gravity_acceleration);
+            if state
+                .rover
+                .apply_jump_velocity(&mut state.physics, jump_speed)
+                .is_some()
+            {
+                state.last_jump_speed = jump_speed;
+                state.airborne_ticks = 0;
+                state.jump_in_flight = true;
+            }
+        }
+        state.jump_charge_ticks = 0;
+    } else if !grounded {
+        state.jump_charge_ticks = 0;
+    }
+
+    state.jump_was_held = state.jump_held;
+}
+
+fn jump_speed(charge_ticks: u16, gravity_acceleration: f32) -> f32 {
+    let charge = f32::from(charge_ticks.saturating_sub(1))
+        / f32::from(JUMP_MAX_CHARGE_TICKS.saturating_sub(1));
+    let charge = charge.clamp(0.0, 1.0);
+    let height = JUMP_MIN_HEIGHT + (JUMP_MAX_HEIGHT - JUMP_MIN_HEIGHT) * charge;
+    (2.0 * gravity_acceleration * height).sqrt()
 }
 
 fn apply_rover_gravity(state: &mut RoverLabState, dt_seconds: f32) -> GravityStepMetrics {
@@ -377,7 +485,7 @@ fn render_lab(state: &RoverLabState) -> RenderFrame {
         }),
     );
 
-    for contact in rover.contacts {
+    for contact in &rover.contacts {
         frame.push_primitive(
             5,
             RenderPrimitive::Circle(RenderCircle::filled(
@@ -407,14 +515,92 @@ fn render_lab(state: &RoverLabState) -> RenderFrame {
     };
     let mut text = RenderText::new(
         RenderPoint::new(0.0, 25.3),
-        format!("Rover lab | W forward  S brake  X reverse  R reset | {control_label}"),
+        format!(
+            "Rover lab | D-pad left/right drive  B/down brake  hold/release A jump | {control_label}"
+        ),
     );
     text.color = RenderColor::rgb(0.88, 0.94, 1.0);
     text.size = 16.0;
     text.anchor = TextAnchor::Center;
     frame.push_primitive(10, RenderPrimitive::Text(text));
 
+    let relative_speed = surface_relative_speed(state, rover.chassis);
+    let airtime = if state.jump_in_flight || !rover.is_grounded() {
+        state.airborne_ticks
+    } else {
+        state.last_airtime_ticks
+    } as f32
+        / FIXED_HZ as f32;
+    let mut telemetry = RenderText::new(
+        RenderPoint::new(0.0, -25.2),
+        format!(
+            "speed {relative_speed:+.1} | wheels {}/2 | suspension {:.2}/{:.2} | jump {:>3.0}% | air {airtime:.2}s | landing {:.1}",
+            rover.grounded_wheel_count(),
+            rover.suspension_lengths[0],
+            rover.suspension_lengths[1],
+            state.jump_charge_fraction() * 100.0,
+            state.last_landing_impulse,
+        ),
+    );
+    telemetry.color = RenderColor::rgb(0.78, 0.88, 1.0);
+    telemetry.size = 14.0;
+    telemetry.anchor = TextAnchor::Center;
+    frame.push_primitive(10, RenderPrimitive::Text(telemetry));
+
+    render_jump_charge(&mut frame, state.jump_charge_fraction());
+
     frame
+}
+
+fn surface_relative_speed(state: &RoverLabState, chassis: BodyMotion) -> f32 {
+    let offset = chassis.position - state.planet.center;
+    let normal = offset.normalized();
+    if normal.length_squared() <= f32::EPSILON {
+        return 0.0;
+    }
+    let tangent = Vec2::new(-normal.y, normal.x);
+    let surface_velocity = tangent * (state.config.planet_angular_velocity * offset.length());
+    (chassis.linear_velocity - surface_velocity).dot(tangent)
+}
+
+fn render_jump_charge(frame: &mut RenderFrame, charge: f32) {
+    const LEFT: f32 = -5.0;
+    const RIGHT: f32 = 5.0;
+    const BOTTOM: f32 = -23.9;
+    const TOP: f32 = -23.35;
+
+    let outline = [
+        Vec2::new(LEFT, BOTTOM),
+        Vec2::new(RIGHT, BOTTOM),
+        Vec2::new(RIGHT, TOP),
+        Vec2::new(LEFT, TOP),
+    ];
+    frame.push_primitive(
+        10,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: outline.map(render_point).to_vec(),
+            fill: Some(Fill::new(CHARGE_BACKGROUND)),
+            stroke: Some(Stroke::new(WHEEL_STROKE, 0.08)),
+        }),
+    );
+
+    let fill_right = LEFT + (RIGHT - LEFT) * charge.clamp(0.0, 1.0);
+    if fill_right > LEFT {
+        let fill = [
+            Vec2::new(LEFT, BOTTOM),
+            Vec2::new(fill_right, BOTTOM),
+            Vec2::new(fill_right, TOP),
+            Vec2::new(LEFT, TOP),
+        ];
+        frame.push_primitive(
+            11,
+            RenderPrimitive::Polygon(RenderPolygon {
+                points: fill.map(render_point).to_vec(),
+                fill: Some(Fill::new(CHARGE_FILL)),
+                stroke: None,
+            }),
+        );
+    }
 }
 
 fn render_wheel(frame: &mut RenderFrame, wheel: BodyMotion, radius: f32) {
@@ -466,14 +652,70 @@ fn render_point(point: Vec2) -> RenderPoint {
 mod tests {
     use super::*;
 
+    const STEP: Duration = Duration::from_nanos(1_000_000_000 / FIXED_HZ as u64);
+
+    fn step_with(state: &mut RoverLabState, throttle: f32, brake: bool, jump_held: bool) {
+        let action = RoverLabAction::drive(throttle, brake, jump_held);
+        RoverLabScenario::step(state, std::slice::from_ref(&action), STEP);
+    }
+
+    fn settle(state: &mut RoverLabState) {
+        for _ in 0..240 {
+            step_with(state, 0.0, false, false);
+        }
+        assert!(state.rover_snapshot().is_grounded());
+    }
+
+    fn jump_apex(charge_ticks: u16) -> (f32, f32, u32, f32) {
+        let mut state = RoverLabScenario::init(RoverLabConfig::default(), 12);
+        settle(&mut state);
+        let start_radius = state.rover_snapshot().chassis.position.length();
+
+        for _ in 0..charge_ticks {
+            step_with(&mut state, 0.0, false, true);
+        }
+        assert_eq!(
+            state.jump_charge_ticks,
+            charge_ticks.min(JUMP_MAX_CHARGE_TICKS)
+        );
+        step_with(&mut state, 0.0, false, false);
+        let jump_speed = state.last_jump_speed;
+        assert!(jump_speed > 0.0);
+
+        let mut apex = state.rover_snapshot().chassis.position.length();
+        let mut became_airborne = !state.rover_snapshot().is_grounded();
+        for _ in 0..360 {
+            step_with(&mut state, 0.0, false, false);
+            let snapshot = state.rover_snapshot();
+            apex = apex.max(snapshot.chassis.position.length());
+            became_airborne |= !snapshot.is_grounded();
+            if became_airborne && snapshot.is_grounded() && state.last_airtime_ticks > 0 {
+                break;
+            }
+        }
+
+        assert!(became_airborne);
+        assert!(state.rover_snapshot().is_grounded());
+        assert!(state.last_airtime_ticks > 0);
+        assert!(state.last_landing_impulse.is_finite());
+        assert!(state.last_landing_impulse > 0.0);
+        (
+            jump_speed,
+            apex - start_radius,
+            state.last_airtime_ticks,
+            state.last_landing_impulse,
+        )
+    }
+
     #[test]
     fn drive_action_round_trips() {
-        let action = RoverLabAction::drive(-0.75, true);
+        let action = RoverLabAction::drive(-0.75, true, true);
         assert_eq!(
             RoverLabAction::decode(&action),
             Some(RoverLabAction {
                 throttle: -0.75,
                 brake: true,
+                jump_held: true,
             })
         );
     }
@@ -482,7 +724,7 @@ mod tests {
     fn scenario_steps_and_renders_authoritative_rapier_state() {
         let mut state = RoverLabScenario::init(RoverLabConfig::default(), 4);
         let initial = state.rover_snapshot().chassis.position;
-        let action = RoverLabAction::drive(0.7, false);
+        let action = RoverLabAction::drive(0.7, false, false);
         for _ in 0..600 {
             RoverLabScenario::step(
                 &mut state,
@@ -501,6 +743,49 @@ mod tests {
                 .any(|layer| !layer.primitives.is_empty())
         );
         assert!(!RoverLabScenario::observe(&state).payload.is_empty());
+    }
+
+    #[test]
+    fn charge_duration_controls_jump_strength_and_airtime() {
+        let (tap_speed, tap_apex, tap_airtime, _) = jump_apex(1);
+        let (full_speed, full_apex, full_airtime, _) = jump_apex(JUMP_MAX_CHARGE_TICKS);
+
+        assert!((tap_speed - (2.0 * GRAVITY_ACCELERATION * JUMP_MIN_HEIGHT).sqrt()).abs() < 1.0e-4);
+        assert!(
+            (full_speed - (2.0 * GRAVITY_ACCELERATION * JUMP_MAX_HEIGHT).sqrt()).abs() < 1.0e-4
+        );
+        assert!(full_speed > tap_speed);
+        assert!(
+            full_apex > tap_apex + 2.0,
+            "full apex {full_apex} was too close to tap apex {tap_apex}"
+        );
+        assert!(
+            full_airtime > tap_airtime,
+            "full airtime {full_airtime} was not longer than tap airtime {tap_airtime}"
+        );
+    }
+
+    #[test]
+    fn jump_cannot_charge_or_retrigger_while_airborne() {
+        let mut state = RoverLabScenario::init(RoverLabConfig::default(), 18);
+        settle(&mut state);
+        for _ in 0..JUMP_MAX_CHARGE_TICKS {
+            step_with(&mut state, 0.0, false, true);
+        }
+        step_with(&mut state, 0.0, false, false);
+        let takeoff_speed = state.last_jump_speed;
+
+        while state.rover_snapshot().is_grounded() {
+            step_with(&mut state, 0.0, false, false);
+        }
+        for _ in 0..12 {
+            step_with(&mut state, 0.0, false, true);
+            assert_eq!(state.jump_charge_ticks, 0);
+        }
+        step_with(&mut state, 0.0, false, false);
+
+        assert_eq!(state.last_jump_speed, takeoff_speed);
+        assert!(!state.rover_snapshot().is_grounded());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add support-contact, grounded-wheel, suspension, and landing telemetry to the reusable rover assembly.
- Add a mass-independent jump API that applies the same support-normal velocity change to the chassis and both wheels.
- Implement deterministic hold/release jump charging in Rover Lab, from a short hop through a 0.8-second full charge.
- Increase Rover Lab wheel target speed and motor torque without changing the shared rover defaults.
- Map NES-style controls to d-pad left/right drive, B or down brake, and A jump; retain keyboard controls with Space for jump.
- Add a visible charge meter, detailed vector telemetry, updated help, and behavior-focused regression coverage.

## Validation

- `cargo test --workspace`
- `cargo +1.89.0 test -p engine-rapier -p scenario-rover-lab -p engine-client`
- `cargo clippy -p engine-rapier -p scenario-rover-lab --all-targets -- -D warnings`
- Local vector and raster rendering smoke checks
- Raspberry Pi/gamepad playtesting

## Rendering note

The raster renderer currently ignores `RenderText` primitives, so kiosk/raster presentation shows the graphical charge meter while detailed numeric telemetry remains available through the vector renderer and scenario observation payload.