### PR TITLE
Integrate autonomous rovers into Spacewars

### DIFF
--- a/crates/engine-rapier/src/rover.rs
+++ b/crates/engine-rapier/src/rover.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::world::{
     BodyId, BodyKind, BodyMotion, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec,
-    ContactPoint, JointId, JointRole, PhysicsId, PhysicsWorld,
+    CollisionGroups, ContactPoint, JointId, JointRole, PhysicsId, PhysicsWorld,
 };
 
 const PLANET_BODY_ROLE: BodyRole = BodyRole::new(10);
@@ -73,6 +73,7 @@ pub struct RoverSpec {
     pub wheel_target_speed: f32,
     pub wheel_motor_torque: f32,
     pub wheel_brake_torque: f32,
+    pub collision_groups: CollisionGroups,
 }
 
 impl Default for RoverSpec {
@@ -92,6 +93,7 @@ impl Default for RoverSpec {
             wheel_target_speed: 7.0,
             wheel_motor_torque: 80.0,
             wheel_brake_torque: 100.0,
+            collision_groups: CollisionGroups::ALL,
         }
     }
 }
@@ -291,6 +293,8 @@ impl RoverAssembly {
         chassis_shape.density = 1.0;
         chassis_shape.friction = 0.7;
         chassis_shape.restitution = 0.0;
+        chassis_shape.collision_groups = spec.collision_groups;
+        chassis_shape.solver_groups = spec.collision_groups;
         if !physics.insert_body(
             chassis,
             BodySpec {
@@ -331,6 +335,8 @@ impl RoverAssembly {
             wheel_shape.density = 0.8;
             wheel_shape.friction = 1.6;
             wheel_shape.restitution = 0.0;
+            wheel_shape.collision_groups = spec.collision_groups;
+            wheel_shape.solver_groups = spec.collision_groups;
             if !physics.insert_body(
                 wheels[index],
                 BodySpec {

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -27,7 +27,10 @@ use engine_core::{
 use engine_gravity::{
     GravityBackend, GravityConfig, GravityId, GravityParticipant, GravitySolver, GravityStepMetrics,
 };
-use engine_rapier::world::PhysicsStepMetrics;
+use engine_rapier::{
+    rover::{RoverControl, RoverSnapshot},
+    world::PhysicsStepMetrics,
+};
 use physics::{MechanicalContact, MechanicalEntity};
 
 #[cfg(test)]
@@ -42,6 +45,7 @@ const PLANET_LAYER: i32 = -10;
 const SPACEPORT_LAYER: i32 = -5;
 const SPACEPORT_FEEDBACK_LAYER: i32 = -4;
 const PLANET_OWNERSHIP_LAYER: i32 = -3;
+const ROVER_LAYER: i32 = -2;
 const EXHAUST_LAYER: i32 = -1;
 const SHIP_LAYER: i32 = 0;
 const DEBRIS_LAYER: i32 = 1;
@@ -75,6 +79,10 @@ const FLAG_WIDTH_FACTOR: f32 = 0.45;
 const FLAG_STEM_FACTOR: f32 = 0.7;
 const FLAG_RADIUS_DIVISOR: f32 = 15.0;
 const OVERVIEW_OWNERSHIP_STROKE_WIDTH: f32 = 2.25;
+const ROVER_MIN_PLANET_RADIUS: f32 = 45.0;
+const ROVER_PATROL_SPEED: f32 = 6.0;
+const ROVER_PATROL_SPEED_ERROR_SCALE: f32 = 3.0;
+const ROVER_OVERVIEW_RADIUS: f32 = 4.0;
 const PLANET_CAPTURE_SECS: f32 = 4.0;
 const PLANET_CAPTURE_DECAY_RATE: f32 = 0.5;
 const POD_REBUILD_SECS: f32 = 8.0;
@@ -157,6 +165,9 @@ const GRAVITY_BODY_TAG: u64 = 1;
 const GRAVITY_SHIP_TAG: u64 = 2;
 const GRAVITY_DEBRIS_TAG: u64 = 3;
 const GRAVITY_PARTICLE_TAG: u64 = 4;
+const GRAVITY_ROVER_TAG: u64 = 5;
+const GRAVITY_ROVER_FRAME_TAG: u64 = 6;
+const ROVER_BODY_COUNT: u64 = 3;
 
 pub const SPACEWARS_PLAYER_COUNT: usize = 2;
 
@@ -251,6 +262,7 @@ pub struct SpacewarsState {
     pub debris: Vec<DebrisState>,
     pub sun: Option<SunState>,
     pub planets: Vec<PlanetState>,
+    pub rovers: Vec<RoverState>,
     pub starfield: Option<StarFieldState>,
     pub particles: Vec<ParticleState>,
     pub laser_hits: Vec<LaserHit>,
@@ -328,6 +340,41 @@ pub struct PlanetState {
     pub orbit_omega: f32,
     pub wrapper_angle: f32,
     pub wrapper_omega: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RoverState {
+    pub id: u64,
+    pub planet: usize,
+    pub owner_id: usize,
+    pub deployed_tick: u64,
+    pub intent: RoverIntent,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct RoverIntent {
+    pub throttle: f32,
+    pub brake: bool,
+}
+
+impl RoverIntent {
+    fn control(self) -> RoverControl {
+        RoverControl {
+            throttle: self.throttle,
+            brake: self.brake,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RoverObservation {
+    pub id: u64,
+    pub planet: usize,
+    pub owner_id: usize,
+    pub chassis_position: Vec2,
+    pub surface_relative_speed: f32,
+    pub grounded_wheels: u8,
+    pub suspension_lengths: [f32; 2],
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -884,6 +931,7 @@ impl Scenario for SpacewarsScenario {
             debris: Vec::new(),
             sun,
             planets,
+            rovers: Vec::new(),
             starfield,
             particles: Vec::new(),
             laser_hits: Vec::new(),
@@ -919,6 +967,8 @@ impl Scenario for SpacewarsScenario {
             }
         }
         update_spaceports(state, dt);
+        reconcile_rover_deployments(state);
+        update_rover_patrol(state);
 
         let universe_radius = state.config.universe_radius as f32;
         for ship in &mut state.ships {
@@ -931,7 +981,7 @@ impl Scenario for SpacewarsScenario {
         handle_ship_deaths(state);
 
         let lifecycle_started = Instant::now();
-        let lifecycle = reconcile_physics(state);
+        let lifecycle = reconcile_physics(state, dt);
         let lifecycle_time = lifecycle_started.elapsed();
 
         let gravity_started = Instant::now();
@@ -1106,6 +1156,25 @@ impl SpacewarsScenario {
                 counts
             },
         )
+    }
+
+    pub fn observe_rover(state: &SpacewarsState, rover_id: u64) -> Option<RoverObservation> {
+        let rover = state.rovers.iter().find(|rover| rover.id == rover_id)?;
+        let planet = state.planets.get(rover.planet)?;
+        let snapshot = state.physics.rover_snapshot(rover)?;
+        let radial = (snapshot.chassis.position - planet.position).normalized();
+        let tangent = radial.rotate_radians(core::f32::consts::FRAC_PI_2);
+        let surface_velocity = planet_surface_velocity(planet, snapshot.chassis.position);
+        Some(RoverObservation {
+            id: rover.id,
+            planet: rover.planet,
+            owner_id: rover.owner_id,
+            chassis_position: snapshot.chassis.position,
+            surface_relative_speed: (snapshot.chassis.linear_velocity - surface_velocity)
+                .dot(tangent),
+            grounded_wheels: u8::try_from(snapshot.grounded_wheel_count()).unwrap_or(u8::MAX),
+            suspension_lengths: snapshot.suspension_lengths,
+        })
     }
 
     pub fn render_player_frames(state: &SpacewarsState) -> Vec<RenderFrame> {
@@ -1768,6 +1837,7 @@ fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
         debris,
         sun,
         planets,
+        rovers,
         particles,
         physics,
         gravity_solver,
@@ -1797,6 +1867,30 @@ fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
             1.0,
         )
     }));
+    for rover in rovers {
+        let Some(motions) = physics.rover_body_motions(rover) else {
+            continue;
+        };
+        for (body_index, motion) in motions.into_iter().enumerate() {
+            gravity_participants.push(GravityParticipant::target(
+                tagged_gravity_id(
+                    GRAVITY_ROVER_TAG,
+                    rover_gravity_payload(rover.id, body_index),
+                ),
+                motion.position,
+                1.0,
+            ));
+        }
+        // The host planet follows a scripted kinematic orbit and therefore
+        // does not receive gravity. Measure its common external acceleration
+        // at the center (the coincident host source is ignored) so rover bodies
+        // retain local/tidal gravity without being pulled out of that frame.
+        gravity_participants.push(GravityParticipant::target(
+            tagged_gravity_id(GRAVITY_ROVER_FRAME_TAG, rover.id),
+            planets[rover.planet].position,
+            1.0,
+        ));
+    }
 
     let debris_responds = tick.is_multiple_of(ASTEROID_GRAVITY_FRAME_MODULUS);
     gravity_participants.extend(debris.iter().filter(|debris| !debris.dead).map(|debris| {
@@ -1831,11 +1925,18 @@ fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
             },
         )
         .expect("Spacewars mechanics produce valid gravity participants");
+    let rover_frame_deltas = outputs
+        .iter()
+        .filter_map(|output| {
+            let (tag, rover_id) = split_gravity_id(output.id);
+            (tag == GRAVITY_ROVER_FRAME_TAG).then_some((rover_id, output.velocity_delta))
+        })
+        .collect::<BTreeMap<_, _>>();
     for output in outputs {
-        if output.velocity_delta == Vec2::ZERO {
+        let (tag, payload) = split_gravity_id(output.id);
+        if output.velocity_delta == Vec2::ZERO && tag != GRAVITY_ROVER_TAG {
             continue;
         }
-        let (tag, payload) = split_gravity_id(output.id);
         match tag {
             GRAVITY_SHIP_TAG => {
                 let index = usize::try_from(payload).expect("ship gravity id fits usize");
@@ -1854,11 +1955,34 @@ fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
                 let index = usize::try_from(payload).expect("particle gravity id fits usize");
                 particles[index].velocity += output.velocity_delta;
             }
-            GRAVITY_BODY_TAG => {}
+            GRAVITY_ROVER_TAG => {
+                let (rover_id, body_index) = split_rover_gravity_payload(payload);
+                let frame_delta = rover_frame_deltas
+                    .get(&rover_id)
+                    .copied()
+                    .unwrap_or(Vec2::ZERO);
+                assert!(physics.apply_rover_velocity_delta(
+                    rover_id,
+                    body_index,
+                    output.velocity_delta - frame_delta,
+                ));
+            }
+            GRAVITY_BODY_TAG | GRAVITY_ROVER_FRAME_TAG => {}
             _ => unreachable!("gravity ids use known Spacewars tags"),
         }
     }
     gravity_solver.metrics()
+}
+
+fn rover_gravity_payload(rover_id: u64, body_index: usize) -> u64 {
+    rover_id * ROVER_BODY_COUNT + body_index as u64
+}
+
+fn split_rover_gravity_payload(payload: u64) -> (u64, usize) {
+    (
+        payload / ROVER_BODY_COUNT,
+        (payload % ROVER_BODY_COUNT) as usize,
+    )
 }
 
 fn tagged_gravity_id(tag: u64, payload: u64) -> GravityId {
@@ -1874,7 +1998,7 @@ fn split_gravity_id(id: GravityId) -> (u64, u64) {
     )
 }
 
-fn reconcile_physics(state: &mut SpacewarsState) -> physics::PhysicsLifecycle {
+fn reconcile_physics(state: &mut SpacewarsState, dt_seconds: f32) -> physics::PhysicsLifecycle {
     let mut docked_ships = [false; 2];
     for contact in &state.spaceport_contacts {
         if let Some(docked) = docked_ships.get_mut(contact.ship) {
@@ -1882,14 +2006,16 @@ fn reconcile_physics(state: &mut SpacewarsState) -> physics::PhysicsLifecycle {
         }
     }
 
-    state.physics.reconcile(
-        state.tick,
-        &mut state.ships,
-        &mut state.debris,
-        state.sun,
-        &state.planets,
-        &docked_ships,
-    )
+    state.physics.reconcile(physics::PhysicsReconcileInput {
+        tick: state.tick,
+        dt_seconds,
+        ships: &mut state.ships,
+        debris: &mut state.debris,
+        sun: state.sun,
+        planets: &state.planets,
+        rovers: &state.rovers,
+        docked_ships: &docked_ships,
+    })
 }
 
 fn resolve_physics_spaceport_contacts(
@@ -3412,6 +3538,80 @@ fn refresh_player_planet_counts(state: &mut SpacewarsState) {
     }
 }
 
+fn reconcile_rover_deployments(state: &mut SpacewarsState) {
+    state.rovers.retain(|rover| {
+        state
+            .planets
+            .get(rover.planet)
+            .map(|planet| {
+                planet.radius >= ROVER_MIN_PLANET_RADIUS && planet.owner_id == Some(rover.owner_id)
+            })
+            .unwrap_or(false)
+    });
+
+    let mut deployed_planets = state
+        .rovers
+        .iter()
+        .map(|rover| rover.planet)
+        .collect::<BTreeSet<_>>();
+    for (planet_index, planet) in state.planets.iter().enumerate() {
+        let Some(owner_id) = planet.owner_id.filter(|owner| *owner < state.players.len()) else {
+            continue;
+        };
+        if planet.radius < ROVER_MIN_PLANET_RADIUS || !deployed_planets.insert(planet_index) {
+            continue;
+        }
+        state.rovers.push(RoverState {
+            id: planet_index as u64,
+            planet: planet_index,
+            owner_id,
+            deployed_tick: state.tick,
+            intent: RoverIntent::default(),
+        });
+    }
+    state.rovers.sort_unstable_by_key(|rover| rover.id);
+}
+
+fn update_rover_patrol(state: &mut SpacewarsState) {
+    let intents = state
+        .rovers
+        .iter()
+        .map(|rover| {
+            SpacewarsScenario::observe_rover(state, rover.id)
+                .map(rover_patrol_intent)
+                .unwrap_or_default()
+        })
+        .collect::<Vec<_>>();
+    for (rover, intent) in state.rovers.iter_mut().zip(intents) {
+        rover.intent = intent;
+    }
+}
+
+fn rover_patrol_intent(observation: RoverObservation) -> RoverIntent {
+    if observation.grounded_wheels == 0 {
+        return RoverIntent::default();
+    }
+
+    let direction = if observation.owner_id.is_multiple_of(2) {
+        1.0
+    } else {
+        -1.0
+    };
+    let directed_speed = observation.surface_relative_speed * direction;
+    if directed_speed > ROVER_PATROL_SPEED + 1.0 {
+        return RoverIntent {
+            throttle: 0.0,
+            brake: true,
+        };
+    }
+    RoverIntent {
+        throttle: direction
+            * ((ROVER_PATROL_SPEED - directed_speed) / ROVER_PATROL_SPEED_ERROR_SCALE)
+                .clamp(0.0, 1.0),
+        brake: false,
+    }
+}
+
 fn collision_normal(ship_position: Vec2, body_position: Vec2) -> Vec2 {
     let offset = ship_position - body_position;
     if offset.length() == 0.0 {
@@ -3648,6 +3848,16 @@ impl PlanetState {
         self.wrapper_angle += self.wrapper_omega * dt;
         self.position = sun_position + Vec2::from_radians(self.orbit_angle) * self.orbit_radius;
     }
+}
+
+fn planet_surface_velocity(planet: &PlanetState, world_position: Vec2) -> Vec2 {
+    let orbit_offset = Vec2::from_radians(planet.orbit_angle) * planet.orbit_radius;
+    let orbit_velocity =
+        orbit_offset.rotate_radians(core::f32::consts::FRAC_PI_2) * planet.orbit_omega;
+    let surface_offset = world_position - planet.position;
+    let spin_velocity =
+        surface_offset.rotate_radians(core::f32::consts::FRAC_PI_2) * planet.wrapper_omega;
+    orbit_velocity + spin_velocity
 }
 
 impl DebrisState {
@@ -4581,6 +4791,23 @@ fn render_state_with_camera(
         render_planet_flags(&mut frame, state, planet);
     }
 
+    for rover in &state.rovers {
+        let Some(snapshot) = state.physics.rover_snapshot(rover) else {
+            continue;
+        };
+        let color = state
+            .players
+            .get(rover.owner_id)
+            .map(|player| render_color(player.color))
+            .unwrap_or(RenderColor::WHITE);
+        match options.rover_style {
+            RoverRenderStyle::Full => render_rover(&mut frame, snapshot, color),
+            RoverRenderStyle::SimpleMark => {
+                render_rover_mark(&mut frame, snapshot.chassis.position, color)
+            }
+        }
+    }
+
     if options.show_exhaust {
         for ship in &state.ships {
             render_exhaust(&mut frame, ship);
@@ -4627,6 +4854,7 @@ struct RenderOptions {
     show_particles: bool,
     show_planet_ownership_halo: bool,
     debris_style: DebrisRenderStyle,
+    rover_style: RoverRenderStyle,
     player_view: Option<(usize, f32)>,
 }
 
@@ -4639,6 +4867,7 @@ impl RenderOptions {
             show_particles: true,
             show_planet_ownership_halo: false,
             debris_style: DebrisRenderStyle::Full,
+            rover_style: RoverRenderStyle::Full,
             player_view: None,
         }
     }
@@ -4651,6 +4880,7 @@ impl RenderOptions {
             show_particles: false,
             show_planet_ownership_halo: true,
             debris_style: DebrisRenderStyle::SimpleMarks,
+            rover_style: RoverRenderStyle::SimpleMark,
             player_view: Some((player, player_view_aspect_ratio)),
         }
     }
@@ -4663,6 +4893,7 @@ impl RenderOptions {
             show_particles: true,
             show_planet_ownership_halo: false,
             debris_style: DebrisRenderStyle::Full,
+            rover_style: RoverRenderStyle::Full,
             player_view: None,
         }
     }
@@ -4675,6 +4906,7 @@ impl RenderOptions {
             show_particles: false,
             show_planet_ownership_halo: true,
             debris_style: DebrisRenderStyle::SimpleMarks,
+            rover_style: RoverRenderStyle::SimpleMark,
             player_view: Some((player, player_view_aspect_ratio)),
         }
     }
@@ -4684,6 +4916,12 @@ impl RenderOptions {
 enum DebrisRenderStyle {
     Full,
     SimpleMarks,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RoverRenderStyle {
+    Full,
+    SimpleMark,
 }
 
 fn render_player_view_rectangle(
@@ -5166,6 +5404,69 @@ fn blend_color(from: RenderColor, to: RenderColor, t: f32) -> RenderColor {
     )
 }
 
+fn render_rover(frame: &mut RenderFrame, rover: RoverSnapshot, owner_color: RenderColor) {
+    let spec = physics::spacewars_rover_spec();
+    let outline = RenderColor::rgba(0.02, 0.02, 0.03, 0.95);
+    let suspension_color = with_alpha(owner_color, 0.9);
+    for index in 0..2 {
+        let wheel = rover.wheels[index];
+        frame.push_primitive(
+            ROVER_LAYER,
+            RenderPrimitive::Line(engine_common::RenderLine::new(
+                render_point(rover.suspension_anchors[index]),
+                render_point(wheel.position),
+                Stroke::new(suspension_color, 0.3),
+            )),
+        );
+        frame.push_primitive(
+            ROVER_LAYER,
+            RenderPrimitive::Circle(RenderCircle {
+                center: render_point(wheel.position),
+                radius: spec.wheel_radius,
+                fill: Some(Fill::new(dim(owner_color, 0.22))),
+                stroke: Some(Stroke::new(owner_color, 0.24)),
+            }),
+        );
+        let spoke = Vec2::from_radians(wheel.angle) * (spec.wheel_radius * 0.75);
+        frame.push_primitive(
+            ROVER_LAYER,
+            RenderPrimitive::Line(engine_common::RenderLine::new(
+                render_point(wheel.position - spoke),
+                render_point(wheel.position + spoke),
+                Stroke::new(owner_color, 0.18),
+            )),
+        );
+    }
+
+    let chassis_points = [
+        Vec2::new(-spec.chassis_half_width, -spec.chassis_half_height),
+        Vec2::new(spec.chassis_half_width, -spec.chassis_half_height),
+        Vec2::new(spec.chassis_half_width, spec.chassis_half_height),
+        Vec2::new(-spec.chassis_half_width, spec.chassis_half_height),
+    ]
+    .map(|point| rover.chassis.position + point.rotate_radians(rover.chassis.angle));
+    frame.push_primitive(
+        ROVER_LAYER,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: chassis_points.map(render_point).to_vec(),
+            fill: Some(Fill::new(owner_color)),
+            stroke: Some(Stroke::new(outline, 0.35)),
+        }),
+    );
+}
+
+fn render_rover_mark(frame: &mut RenderFrame, position: Vec2, owner_color: RenderColor) {
+    frame.push_primitive(
+        ROVER_LAYER,
+        RenderPrimitive::Circle(RenderCircle {
+            center: render_point(position),
+            radius: ROVER_OVERVIEW_RADIUS,
+            fill: Some(Fill::new(owner_color)),
+            stroke: Some(Stroke::new(RenderColor::WHITE, 0.75)),
+        }),
+    );
+}
+
 fn render_ship(frame: &mut RenderFrame, ship: &ShipState) {
     if ship.form == ShipForm::EscapePod {
         render_escape_pod(frame, ship);
@@ -5411,6 +5712,26 @@ mod tests {
 
     fn init_default(seed: u64) -> SpacewarsState {
         SpacewarsScenario::init(SpacewarsConfig::default(), seed)
+    }
+
+    fn init_rover_world(seed: u64) -> SpacewarsState {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            use_starfield: false,
+            ..SpacewarsConfig::default()
+        };
+        SpacewarsScenario::init(config, seed)
+    }
+
+    fn largest_rover_planet(state: &SpacewarsState) -> usize {
+        state
+            .planets
+            .iter()
+            .enumerate()
+            .filter(|(_, planet)| planet.radius >= ROVER_MIN_PLANET_RADIUS)
+            .max_by(|(_, left), (_, right)| left.radius.total_cmp(&right.radius))
+            .map(|(index, _)| index)
+            .expect("default world should contain a rover-sized planet")
     }
 
     fn step(state: &mut SpacewarsState, actions: &[Action]) -> StepResult {
@@ -7963,7 +8284,7 @@ mod tests {
         let head_offset = desired_head - ship_mount_center(&state.ships[0]);
         state.ships[0].position += head_offset;
         let direction = state.ships[0].direction;
-        reconcile_physics(&mut state);
+        reconcile_physics(&mut state, 1.0 / 60.0);
         state.physics.step(1.0 / 60.0);
 
         state.apply_action(SpacewarsAction::SetLaser {
@@ -9168,5 +9489,218 @@ mod tests {
 
         assert_eq!(state.last_step_metrics.added, 1);
         assert_eq!(state.last_step_metrics.removed, 1);
+    }
+
+    #[test]
+    fn owned_planet_deploys_rover_into_canonical_physics_and_gravity() {
+        let mut state = init_rover_world(123);
+        let planet = largest_rover_planet(&state);
+        let baseline_bodies = state.physics.body_count();
+
+        step(&mut state, &[]);
+        let baseline_gravity_targets = state.last_step_metrics.gravity.target_count;
+        assert!(state.rovers.is_empty());
+
+        state.planets[planet].owner_id = Some(0);
+        step(&mut state, &[]);
+
+        assert_eq!(state.rovers.len(), 1);
+        assert_eq!(
+            state.rovers[0],
+            RoverState {
+                id: planet as u64,
+                planet,
+                owner_id: 0,
+                deployed_tick: 1,
+                intent: RoverIntent::default(),
+            }
+        );
+        assert!(SpacewarsScenario::observe_rover(&state, planet as u64).is_some());
+        assert_eq!(state.physics.body_count(), baseline_bodies + 3);
+        assert_eq!(
+            state.last_step_metrics.gravity.target_count,
+            baseline_gravity_targets + 4
+        );
+    }
+
+    #[test]
+    fn planets_below_rover_size_threshold_do_not_deploy_one() {
+        let mut state = init_rover_world(123);
+        let planet = largest_rover_planet(&state);
+        state.planets[planet].radius = ROVER_MIN_PLANET_RADIUS - 0.01;
+        state.planets[planet].mass = body_mass(state.planets[planet].radius);
+        state.planets[planet].owner_id = Some(0);
+
+        step(&mut state, &[]);
+
+        assert!(state.rovers.is_empty());
+    }
+
+    #[test]
+    fn rover_is_replaced_on_capture_and_removed_when_planet_becomes_unowned() {
+        let mut state = init_rover_world(123);
+        let planet = largest_rover_planet(&state);
+        let baseline_bodies = state.physics.body_count();
+        state.planets[planet].owner_id = Some(0);
+        step(&mut state, &[]);
+        assert_eq!(state.physics.body_count(), baseline_bodies + 3);
+
+        state.planets[planet].owner_id = Some(1);
+        step(&mut state, &[]);
+
+        assert_eq!(state.rovers.len(), 1);
+        assert_eq!(state.rovers[0].id, planet as u64);
+        assert_eq!(state.rovers[0].owner_id, 1);
+        assert_eq!(state.rovers[0].deployed_tick, 1);
+        assert_eq!(state.physics.body_count(), baseline_bodies + 3);
+        assert!(SpacewarsScenario::observe_rover(&state, planet as u64).is_some());
+
+        state.planets[planet].owner_id = None;
+        step(&mut state, &[]);
+
+        assert!(state.rovers.is_empty());
+        assert!(SpacewarsScenario::observe_rover(&state, planet as u64).is_none());
+        assert_eq!(state.physics.body_count(), baseline_bodies);
+    }
+
+    #[test]
+    fn rover_patrol_stays_attached_to_moving_spinning_planet() {
+        let mut state = init_rover_world(123);
+        let planet_index = largest_rover_planet(&state);
+        state.planets[planet_index].owner_id = Some(0);
+        step(&mut state, &[]);
+
+        let start_planet = state.planets[planet_index];
+        let start = SpacewarsScenario::observe_rover(&state, planet_index as u64)
+            .expect("deployed rover should be observable");
+        let start_offset = start.chassis_position - start_planet.position;
+        let mut previous_surface_angle =
+            start_offset.y.atan2(start_offset.x) - start_planet.wrapper_angle;
+        let mut accumulated_surface_travel = 0.0_f32;
+        let mut grounded_ticks = 0;
+        let mut controlled_ticks = 0;
+        let mut minimum_radial_distance = f32::INFINITY;
+        let mut maximum_radial_distance = 0.0_f32;
+
+        for _ in 0..600 {
+            step(&mut state, &[]);
+            let planet = state.planets[planet_index];
+            let observation = SpacewarsScenario::observe_rover(&state, planet_index as u64)
+                .expect("active rover should remain observable");
+            let radial_distance = observation.chassis_position.distance_to(planet.position);
+            minimum_radial_distance = minimum_radial_distance.min(radial_distance);
+            maximum_radial_distance = maximum_radial_distance.max(radial_distance);
+            grounded_ticks += usize::from(observation.grounded_wheels > 0);
+            controlled_ticks += usize::from(
+                state.rovers[0].intent.throttle.abs() > 0.01 || state.rovers[0].intent.brake,
+            );
+            let offset = observation.chassis_position - planet.position;
+            let surface_angle = offset.y.atan2(offset.x) - planet.wrapper_angle;
+            let angle_delta = (surface_angle - previous_surface_angle + core::f32::consts::PI)
+                .rem_euclid(core::f32::consts::TAU)
+                - core::f32::consts::PI;
+            accumulated_surface_travel += angle_delta.abs();
+            previous_surface_angle = surface_angle;
+        }
+
+        let end_planet = state.planets[planet_index];
+        let surface_radius = end_planet.radius * BODY_BOUNDS_RADIUS_SCALE;
+
+        assert!(
+            minimum_radial_distance > surface_radius - 3.0,
+            "rover sank below planet surface: minimum {minimum_radial_distance}, surface {surface_radius}"
+        );
+        assert!(
+            maximum_radial_distance < surface_radius + 15.0,
+            "rover drifted away from planet: maximum {maximum_radial_distance}, surface {surface_radius}"
+        );
+        assert!(grounded_ticks > 500, "rover should remain grounded");
+        assert!(
+            controlled_ticks > 500,
+            "patrol should keep driving or braking the rover"
+        );
+        assert!(
+            accumulated_surface_travel > 0.05,
+            "patrol should travel around the planet surface"
+        );
+    }
+
+    #[test]
+    fn rover_deployment_and_patrol_replay_bit_for_bit() {
+        let mut first = init_rover_world(123);
+        let mut replay = init_rover_world(123);
+        let planet = largest_rover_planet(&first);
+        first.planets[planet].owner_id = Some(0);
+        replay.planets[planet].owner_id = Some(0);
+
+        for _ in 0..180 {
+            step(&mut first, &[]);
+            step(&mut replay, &[]);
+
+            assert_eq!(first.rovers, replay.rovers);
+            assert_eq!(
+                SpacewarsScenario::observe_rover(&first, planet as u64),
+                SpacewarsScenario::observe_rover(&replay, planet as u64)
+            );
+            assert_eq!(
+                first.physics.snapshot_bytes(),
+                replay.physics.snapshot_bytes()
+            );
+        }
+    }
+
+    #[test]
+    fn rover_has_detailed_player_rendering_and_simplified_overview_mark() {
+        let mut state = init_rover_world(123);
+        let planet = largest_rover_planet(&state);
+        state.planets[planet].owner_id = Some(0);
+        step(&mut state, &[]);
+        let owner_color = render_color(state.players[0].color);
+
+        let player_frame = SpacewarsScenario::render_frame(&state);
+        let rover_layer = player_frame
+            .layers
+            .iter()
+            .find(|layer| layer.z == ROVER_LAYER)
+            .expect("player view should render the rover");
+        assert_eq!(rover_layer.primitives.len(), 7);
+        assert_eq!(
+            rover_layer
+                .primitives
+                .iter()
+                .filter(|primitive| matches!(primitive, RenderPrimitive::Circle(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            rover_layer
+                .primitives
+                .iter()
+                .filter(|primitive| matches!(primitive, RenderPrimitive::Line(_)))
+                .count(),
+            4
+        );
+        assert_eq!(
+            rover_layer
+                .primitives
+                .iter()
+                .filter(|primitive| matches!(primitive, RenderPrimitive::Polygon(_)))
+                .count(),
+            1
+        );
+
+        let overview = render_overview_state(&state, 0, 0.75);
+        let overview_layer = overview
+            .layers
+            .iter()
+            .find(|layer| layer.z == ROVER_LAYER)
+            .expect("overview should retain a rover mark");
+        assert_eq!(overview_layer.primitives.len(), 1);
+        let RenderPrimitive::Circle(mark) = &overview_layer.primitives[0] else {
+            panic!("overview rover should be a simple circular mark");
+        };
+        assert_eq!(mark.radius, ROVER_OVERVIEW_RADIUS);
+        assert_eq!(mark.fill, Some(Fill::new(owner_color)));
+        assert_eq!(mark.stroke, Some(Stroke::new(RenderColor::WHITE, 0.75)));
     }
 }

--- a/scenarios/spacewars/src/physics.rs
+++ b/scenarios/spacewars/src/physics.rs
@@ -3,24 +3,29 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use engine_core::Vec2;
-use engine_rapier::world::{
-    BodyId as PhysicsBodyId, BodyKind, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec,
-    CollisionGroups, PhysicsId, PhysicsStepMetrics, PhysicsWorld, PhysicsWorldConfig,
-    RayCastOptions,
+use engine_rapier::{
+    rover::{RoverAssembly, RoverSnapshot, RoverSpawnPose, RoverSpec},
+    world::{
+        BodyId as PhysicsBodyId, BodyKind, BodyMotion, BodyRole, BodySpec, ColliderId,
+        ColliderRole, ColliderSpec, CollisionGroups, PhysicsId, PhysicsStepMetrics, PhysicsWorld,
+        PhysicsWorldConfig, RayCastOptions,
+    },
 };
 
 use super::{
     BODY_BOUNDS_RADIUS_SCALE, BodyId, CANNON_SHELL_RADIUS, DEFAULT_ELASTICITY, DebrisKind,
     DebrisState, PLANET_ELASTICITY, POD_BODY, POD_LASER, POD_PIVOT, POD_THRUSTER, PlanetState,
-    SHELL_BODY, SHIP_BODY, SHIP_LASER, SHIP_LEFT_WING, SHIP_PIVOT, SHIP_RIGHT_WING, SHIP_THRUSTER,
-    SHIP_WING_MOUNT, SHIP_WING_PIVOT, SPACEPORT_ARC_LENGTH, SPACEPORT_DEPTH_FACTOR,
-    SPACEPORT_OUTER_POINTS, ShipForm, ShipState, SunState, rotate_points, spaceport_local_points,
+    RoverState, SHELL_BODY, SHIP_BODY, SHIP_LASER, SHIP_LEFT_WING, SHIP_PIVOT, SHIP_RIGHT_WING,
+    SHIP_THRUSTER, SHIP_WING_MOUNT, SHIP_WING_PIVOT, SPACEPORT_ARC_LENGTH, SPACEPORT_DEPTH_FACTOR,
+    SPACEPORT_OUTER_POINTS, ShipForm, ShipState, SunState, planet_surface_velocity, rotate_points,
+    spaceport_local_points,
 };
 
 const WORLD_ENTITY_VALUE: u64 = 1;
 const SUN_ENTITY_VALUE: u64 = 2;
 const PLANET_ENTITY_BASE: u64 = 100;
 const SHIP_ENTITY_BASE: u64 = 10_000;
+const ROVER_ENTITY_BASE: u64 = 50_000;
 const DEBRIS_ENTITY_BASE: u64 = 100_000;
 
 const WORLD_ROLE: ColliderRole = ColliderRole::new(1);
@@ -29,6 +34,7 @@ const SPACEPORT_SENSOR_ROLE: ColliderRole = ColliderRole::new(3);
 const SPACEPORT_GATE_ROLE: ColliderRole = ColliderRole::new(4);
 const SHIP_HULL_ROLE: ColliderRole = ColliderRole::new(5);
 const DEBRIS_ROLE: ColliderRole = ColliderRole::new(6);
+const ROVER_SURFACE_ROLE: ColliderRole = ColliderRole::new(7);
 
 const GROUP_SHIP_0: u32 = 1 << 0;
 const GROUP_SHIP_1: u32 = 1 << 1;
@@ -39,12 +45,30 @@ const GROUP_BODY: u32 = 1 << 5;
 const GROUP_WORLD: u32 = 1 << 6;
 const GROUP_SPACEPORT_GATE: u32 = 1 << 7;
 const GROUP_SPACEPORT_SENSOR: u32 = 1 << 8;
+const GROUP_ROVER: u32 = 1 << 9;
+const GROUP_ROVER_SURFACE: u32 = 1 << 10;
 const GROUP_ALL_SHIPS: u32 = GROUP_SHIP_0 | GROUP_SHIP_1 | GROUP_POD_0 | GROUP_POD_1;
 const GROUP_ALL_SOLIDS: u32 =
-    GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_BODY | GROUP_WORLD | GROUP_SPACEPORT_GATE;
+    GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_BODY | GROUP_WORLD | GROUP_SPACEPORT_GATE | GROUP_ROVER;
 
 const PLANET_SURFACE_SEGMENTS: usize = 24;
 const WORLD_SURFACE_SEGMENTS: usize = 192;
+
+pub(super) fn spacewars_rover_spec() -> RoverSpec {
+    RoverSpec {
+        suspension_stiffness: 10_000.0,
+        suspension_damping: 350.0,
+        suspension_max_force: 10_000.0,
+        wheel_target_speed: 12.0,
+        wheel_motor_torque: 100.0,
+        wheel_brake_torque: 120.0,
+        collision_groups: CollisionGroups::new(
+            GROUP_ROVER,
+            GROUP_BODY | GROUP_WORLD | GROUP_ROVER_SURFACE,
+        ),
+        ..RoverSpec::default()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) enum MechanicalEntity {
@@ -95,13 +119,33 @@ struct DebrisColliderKey {
 }
 
 #[derive(Debug, Clone)]
+struct RoverPhysicsEntry {
+    planet: usize,
+    owner_id: usize,
+    last_planet: PlanetState,
+    assembly: RoverAssembly,
+}
+
+#[derive(Debug, Clone)]
 pub(super) struct SpacewarsPhysics {
     world: PhysicsWorld,
     sun_radius: Option<u32>,
     ship_keys: [Option<ShipColliderKey>; 2],
     planet_keys: Vec<Option<PlanetColliderKey>>,
+    rovers: BTreeMap<u64, RoverPhysicsEntry>,
     debris_keys: BTreeMap<u64, DebrisColliderKey>,
     next_debris_entity: u64,
+}
+
+pub(super) struct PhysicsReconcileInput<'a> {
+    pub tick: u64,
+    pub dt_seconds: f32,
+    pub ships: &'a mut [ShipState; 2],
+    pub debris: &'a mut [DebrisState],
+    pub sun: Option<SunState>,
+    pub planets: &'a [PlanetState],
+    pub rovers: &'a [RoverState],
+    pub docked_ships: &'a [bool; 2],
 }
 
 impl SpacewarsPhysics {
@@ -123,6 +167,7 @@ impl SpacewarsPhysics {
             sun_radius: None,
             ship_keys: [None, None],
             planet_keys: vec![None; planets.len()],
+            rovers: BTreeMap::new(),
             debris_keys: BTreeMap::new(),
             next_debris_entity: DEBRIS_ENTITY_BASE,
         };
@@ -144,15 +189,17 @@ impl SpacewarsPhysics {
         physics
     }
 
-    pub fn reconcile(
-        &mut self,
-        tick: u64,
-        ships: &mut [ShipState; 2],
-        debris: &mut [DebrisState],
-        sun: Option<SunState>,
-        planets: &[PlanetState],
-        docked_ships: &[bool; 2],
-    ) -> PhysicsLifecycle {
+    pub fn reconcile(&mut self, input: PhysicsReconcileInput<'_>) -> PhysicsLifecycle {
+        let PhysicsReconcileInput {
+            tick,
+            dt_seconds,
+            ships,
+            debris,
+            sun,
+            planets,
+            rovers,
+            docked_ships,
+        } = input;
         let mut lifecycle = PhysicsLifecycle::default();
         match sun {
             Some(sun) if self.sun_radius != Some(sun.radius.to_bits()) => {
@@ -209,6 +256,7 @@ impl SpacewarsPhysics {
             }
         }
 
+        self.reconcile_rovers(rovers, planets, dt_seconds, &mut lifecycle);
         self.reconcile_debris(tick, debris, &mut lifecycle);
         lifecycle
     }
@@ -225,6 +273,36 @@ impl SpacewarsPhysics {
         };
         self.world
             .apply_velocity_delta(primary_body(entity), delta_velocity, true)
+    }
+
+    pub fn rover_snapshot(&self, rover: &RoverState) -> Option<RoverSnapshot> {
+        let entry = self.rover_entry(rover)?;
+        entry.assembly.snapshot(&self.world)
+    }
+
+    pub fn rover_body_motions(&self, rover: &RoverState) -> Option<[BodyMotion; 3]> {
+        let bodies = self.rover_entry(rover)?.assembly.bodies();
+        Some([
+            self.world.motion(bodies[0])?,
+            self.world.motion(bodies[1])?,
+            self.world.motion(bodies[2])?,
+        ])
+    }
+
+    pub fn apply_rover_velocity_delta(
+        &mut self,
+        id: u64,
+        body_index: usize,
+        delta_velocity: Vec2,
+    ) -> bool {
+        let Some(body) = self
+            .rovers
+            .get(&id)
+            .and_then(|entry| entry.assembly.bodies().get(body_index).copied())
+        else {
+            return false;
+        };
+        self.world.apply_velocity_delta(body, delta_velocity, true)
     }
 
     #[cfg(test)]
@@ -266,6 +344,108 @@ impl SpacewarsPhysics {
             item.rotation_radians = motion.angle;
             item.omega = motion.angular_velocity;
         }
+    }
+
+    fn rover_entry(&self, rover: &RoverState) -> Option<&RoverPhysicsEntry> {
+        let entry = self.rovers.get(&rover.id)?;
+        (entry.planet == rover.planet && entry.owner_id == rover.owner_id).then_some(entry)
+    }
+
+    fn reconcile_rovers(
+        &mut self,
+        rovers: &[RoverState],
+        planets: &[PlanetState],
+        dt_seconds: f32,
+        lifecycle: &mut PhysicsLifecycle,
+    ) {
+        let mut active = BTreeSet::new();
+        for rover in rovers {
+            if !active.insert(rover.id) {
+                continue;
+            }
+            let key_matches = self
+                .rovers
+                .get(&rover.id)
+                .map(|entry| entry.planet == rover.planet && entry.owner_id == rover.owner_id)
+                .unwrap_or(false);
+            if !key_matches {
+                if let Some(entry) = self.rovers.remove(&rover.id) {
+                    lifecycle.removed += usize::from(entry.assembly.remove(&mut self.world));
+                }
+                let Some(planet) = planets.get(rover.planet) else {
+                    continue;
+                };
+                if let Some(entry) = self.insert_rover(rover, planet) {
+                    self.rovers.insert(rover.id, entry);
+                    lifecycle.added += 1;
+                }
+            }
+
+            if let Some(entry) = self.rovers.get_mut(&rover.id) {
+                if key_matches && let Some(planet) = planets.get(entry.planet) {
+                    transport_rover_with_planet(&mut self.world, entry, planet, dt_seconds);
+                }
+                let _ = entry
+                    .assembly
+                    .set_control(&mut self.world, rover.intent.control());
+            }
+        }
+
+        let stale = self
+            .rovers
+            .keys()
+            .copied()
+            .filter(|id| !active.contains(id))
+            .collect::<Vec<_>>();
+        for id in stale {
+            if let Some(entry) = self.rovers.remove(&id) {
+                lifecycle.removed += usize::from(entry.assembly.remove(&mut self.world));
+            }
+        }
+    }
+
+    fn insert_rover(
+        &mut self,
+        rover: &RoverState,
+        planet: &PlanetState,
+    ) -> Option<RoverPhysicsEntry> {
+        let spec = spacewars_rover_spec();
+        let up_angle = planet.wrapper_angle + core::f32::consts::PI;
+        let up = Vec2::from_radians(up_angle);
+        let wheel_center = planet.position
+            + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + spec.wheel_radius + 0.03);
+        let assembly = RoverAssembly::insert_at(
+            &mut self.world,
+            rover_entity(rover.id),
+            RoverSpawnPose {
+                wheel_center,
+                up_angle,
+            },
+            spec,
+        )?;
+
+        for body in assembly.bodies() {
+            let Some(motion) = self.world.motion(body) else {
+                assembly.remove(&mut self.world);
+                return None;
+            };
+            if !self.world.set_velocity(
+                body,
+                planet_surface_velocity(planet, motion.position),
+                planet.wrapper_omega,
+                true,
+            ) {
+                assembly.remove(&mut self.world);
+                return None;
+            }
+        }
+        let _ = assembly.set_control(&mut self.world, rover.intent.control());
+        Some(RoverPhysicsEntry {
+            planet: rover.planet,
+            owner_id: rover.owner_id,
+            last_planet: *planet,
+            assembly,
+        })
     }
 
     pub fn contacts(&self) -> Vec<MechanicalContact> {
@@ -321,7 +501,8 @@ impl SpacewarsPhysics {
                 max_distance,
                 solid: false,
                 include_sensors: false,
-                collision_groups: CollisionGroups::ALL,
+                // Combat damage is deliberately outside this first rover slice.
+                collision_groups: CollisionGroups::new(u32::MAX, !GROUP_ROVER),
                 exclude_entity: Some(ship_entity(shooter)),
             },
         )?;
@@ -381,7 +562,7 @@ impl SpacewarsPhysics {
         collider.restitution = DEFAULT_ELASTICITY;
         collider.friction = 0.0;
         collider.collision_groups =
-            CollisionGroups::new(GROUP_WORLD, GROUP_ALL_SHIPS | GROUP_DEBRIS);
+            CollisionGroups::new(GROUP_WORLD, GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_ROVER);
         collider.solver_groups = collider.collision_groups;
         let inserted = self.world.insert_body(
             primary_body(entity),
@@ -424,6 +605,19 @@ impl SpacewarsPhysics {
         let entity = planet_entity(index);
         let body_groups = CollisionGroups::new(GROUP_BODY, GROUP_ALL_SHIPS | GROUP_DEBRIS);
         let mut colliders = planet_solid_colliders(entity, planet.radius, body_groups);
+        // Ships retain the legacy segmented, frictionless, elastic surface and
+        // spaceport cavity. Rovers get a smooth traction surface on the same
+        // kinematic body so their suspension is not launched by segment seams.
+        let mut rover_surface = ColliderSpec::ball(
+            collider_id(entity, ROVER_SURFACE_ROLE, 0),
+            planet.radius * BODY_BOUNDS_RADIUS_SCALE,
+        );
+        rover_surface.density = 0.0;
+        rover_surface.friction = 1.25;
+        rover_surface.restitution = 0.0;
+        rover_surface.collision_groups = CollisionGroups::new(GROUP_ROVER_SURFACE, GROUP_ROVER);
+        rover_surface.solver_groups = rover_surface.collision_groups;
+        colliders.push(rover_surface);
 
         let mut sensor = ColliderSpec::convex_polygon(
             collider_id(entity, SPACEPORT_SENSOR_ROLE, 0),
@@ -443,6 +637,7 @@ impl SpacewarsPhysics {
         gate.collision_groups =
             CollisionGroups::new(GROUP_SPACEPORT_GATE, blocked_pod_groups(planet.owner_id));
         gate.solver_groups = gate.collision_groups;
+
         colliders.push(sensor);
         colliders.push(gate);
 
@@ -573,6 +768,40 @@ fn synchronize_debris_to_physics(world: &mut PhysicsWorld, debris: &DebrisState)
     if motion.linear_velocity != debris.velocity || motion.angular_velocity != debris.omega {
         let _ = world.set_velocity(body, debris.velocity, debris.omega, true);
     }
+}
+
+/// Carry free dynamic rover motion between successive poses of its scripted
+/// kinematic planet. Rapier still resolves suspension, traction, contacts, and
+/// gravity; this supplies the non-physical frame acceleration implied by the
+/// legacy orbital path so the rover is not left behind by its moving terrain.
+fn transport_rover_with_planet(
+    world: &mut PhysicsWorld,
+    entry: &mut RoverPhysicsEntry,
+    planet: &PlanetState,
+    dt_seconds: f32,
+) {
+    if !dt_seconds.is_finite() || dt_seconds <= 0.0 {
+        entry.last_planet = *planet;
+        return;
+    }
+
+    let previous = entry.last_planet;
+    let angle_delta = planet.wrapper_angle - previous.wrapper_angle;
+    for body in entry.assembly.bodies() {
+        let Some(motion) = world.motion(body) else {
+            continue;
+        };
+        let next_position =
+            planet.position + (motion.position - previous.position).rotate_radians(angle_delta);
+        let frame_velocity = planet_surface_velocity(planet, next_position);
+        let relative_velocity =
+            motion.linear_velocity - planet_surface_velocity(&previous, motion.position);
+        let linear_velocity = frame_velocity + relative_velocity.rotate_radians(angle_delta);
+        let relative_angular_velocity = motion.angular_velocity - previous.wrapper_omega;
+        let angular_velocity = angle_delta / dt_seconds + relative_angular_velocity;
+        let _ = world.set_velocity(body, linear_velocity, angular_velocity, true);
+    }
+    entry.last_planet = *planet;
 }
 
 fn ship_collision_groups(ship: &ShipState, docked: bool) -> CollisionGroups {
@@ -872,6 +1101,11 @@ fn ship_entity(index: usize) -> PhysicsId {
     PhysicsId::new(SHIP_ENTITY_BASE + index as u64)
 }
 
+fn rover_entity(id: u64) -> PhysicsId {
+    debug_assert!(id < DEBRIS_ENTITY_BASE - ROVER_ENTITY_BASE);
+    PhysicsId::new(ROVER_ENTITY_BASE + id)
+}
+
 fn planet_index(entity: PhysicsId) -> Option<usize> {
     let value = entity.value();
     (PLANET_ENTITY_BASE..SHIP_ENTITY_BASE)
@@ -1017,7 +1251,16 @@ mod tests {
             1.0,
             engine_core::Color::WHITE,
         )];
-        let lifecycle = physics.reconcile(1, &mut ships, &mut debris, None, &[], &[false; 2]);
+        let lifecycle = physics.reconcile(PhysicsReconcileInput {
+            tick: 1,
+            dt_seconds: 1.0 / 60.0,
+            ships: &mut ships,
+            debris: &mut debris,
+            sun: None,
+            planets: &[],
+            rovers: &[],
+            docked_ships: &[false; 2],
+        });
         assert_eq!(lifecycle.added, 1);
         assert_eq!(physics.world.collider_count(), 4);
 


### PR DESCRIPTION
## Summary

- deploy one deterministic, owner-colored rover on each owned planet large enough to support it
- keep rover identity and intent in Spacewars while Rapier remains authoritative for articulated motion and lifecycle
- run rover bodies through the shared multi-source gravity system and transport them coherently with scripted moving and spinning planets
- render detailed rovers in player views and simplified owner-colored marks in overviews

## Design boundaries

- ownership changes replace the rover deterministically, and losing ownership removes it cleanly
- rover-only collision groups and a smooth traction surface preserve existing ship and spaceport collision behavior
- typed rover observations feed a small deterministic patrol policy without exposing mutable physics state
- construction economy, player control, weapon damage, and broader autonomous strategy remain follow-up work

This is an incremental foundation for the autonomous systems discussed in #13 and #14.

## Validation

- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo test --workspace
- close-scale visual render inspection
