### PR TITLE
Add Spacewars ship AI foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "sha2",
  "slint",
  "slint-build",
+ "spacewars-ai",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -4619,11 +4620,13 @@ dependencies = [
 name = "scenario-spacewars"
 version = "0.1.0"
 dependencies = [
+ "bincode 1.3.3",
  "engine-common",
  "engine-core",
  "engine-gravity",
  "engine-rapier",
  "image",
+ "serde",
 ]
 
 [[package]]
@@ -5045,6 +5048,15 @@ dependencies = [
  "web-sys",
  "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "spacewars-ai"
+version = "0.1.0"
+dependencies = [
+ "engine-common",
+ "engine-core",
+ "scenario-spacewars",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/engine-gravity",
     "crates/engine-nes",
     "crates/engine-rapier",
+    "crates/spacewars-ai",
     "crates/engine-client",
     "crates/spacewars-cli",
     "crates/engine-agent",
@@ -56,6 +57,7 @@ engine-core = { path = "crates/engine-core" }
 engine-gravity = { path = "crates/engine-gravity" }
 engine-nes = { path = "crates/engine-nes" }
 engine-rapier = { path = "crates/engine-rapier" }
+spacewars-ai = { path = "crates/spacewars-ai" }
 scenario-falling = { path = "scenarios/falling" }
 scenario-nes = { path = "scenarios/nes" }
 scenario-null = { path = "scenarios/null" }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Rover Lab uses d-pad left/right to drive, `B` or d-pad down to brake, and a
 hold/release of `A` to charge and jump. Keyboard equivalents are `W` forward,
 `S` brake, `X` reverse, `Space` jump, and `R` reset.
 
+To try the first Spacewars AI opponent, open Spacewars settings in the launcher
+and change **Player 2** from **human** to **rule bot**. **Small Duel** is the
+clearest test bed; the bot currently focuses on one-on-one pursuit, collision
+avoidance, and weapons rather than planet-capture strategy. The ordinary
+two-human setup remains the default.
+
 Falling and NES Library pass the d-pad, `A`, `B`, `Select`, and `Start` to the
 cartridge. Press `Start` + `Select` together for the host controls menu so a
 gamepad-only player can restart or return to the launcher. Keyboard equivalents

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 engine-common = { workspace = true }
 engine-core = { workspace = true }
 engine-nes = { workspace = true }
+spacewars-ai = { workspace = true }
 scenario-falling = { workspace = true }
 scenario-nes = { workspace = true }
 scenario-null = { workspace = true }

--- a/crates/engine-client/src/client_scenarios/spacewars.rs
+++ b/crates/engine-client/src/client_scenarios/spacewars.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
+use engine_common::{
+    Action, RenderFrame, Scenario, Settings, SpacewarsController, StepResult, TickModel,
+};
 use engine_core::SpacewarsConfig;
 use scenario_spacewars::{ShipForm, SpacewarsBenchmarkCounts, SpacewarsScenario, SpacewarsState};
 
@@ -30,6 +32,7 @@ pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
 
 pub(crate) struct SpacewarsClientScenario {
     pub(crate) state: Box<SpacewarsState>,
+    player_2_rule_bot: bool,
 }
 
 fn create(
@@ -39,6 +42,8 @@ fn create(
     mode: ScenarioStartMode,
     _asset: &ScenarioAsset,
 ) -> Result<Box<dyn ClientScenario>, ScenarioCreateError> {
+    let player_2_rule_bot = mode == ScenarioStartMode::Normal
+        && settings.spacewars.player_2_controller == SpacewarsController::RuleBot;
     let state = match mode {
         ScenarioStartMode::Normal => {
             SpacewarsScenario::init(spacewars_config_from_settings(settings), seed)
@@ -47,6 +52,7 @@ fn create(
     };
     Ok(Box::new(SpacewarsClientScenario {
         state: Box::new(state),
+        player_2_rule_bot,
     }))
 }
 
@@ -64,7 +70,11 @@ impl ClientScenario for SpacewarsClientScenario {
     }
 
     fn map_input(&self, input: &mut ClientInput, benchmark_active: bool) -> Vec<Action> {
-        input.actions_for_spacewars(&self.state, benchmark_active)
+        input.actions_for_spacewars(
+            &self.state,
+            benchmark_active,
+            [false, self.player_2_rule_bot],
+        )
     }
 
     fn render_frames(&self, renderer: RenderBackend, viewport: Viewport) -> Vec<RenderFrame> {
@@ -196,6 +206,9 @@ fn spacewars_config_from_settings(settings: &Settings) -> SpacewarsConfig {
     for player in &mut config.players {
         player.health_percent = setup.player_health_percent;
     }
+    if setup.player_2_controller == SpacewarsController::RuleBot {
+        config.players[1].name = "Rule Bot".into();
+    }
     config
 }
 
@@ -279,5 +292,59 @@ fn player_panel_state(state: &SpacewarsState, player_index: usize) -> PlayerPane
         status: format!("{label}: {percent}%"),
         status_fraction,
         color: player.color,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_scenarios::BenchmarkConfiguration;
+
+    #[test]
+    fn normal_launch_installs_and_labels_the_opt_in_rule_bot() {
+        let mut settings = Settings::default();
+        settings.spacewars.player_2_controller = SpacewarsController::RuleBot;
+
+        let scenario = create(
+            29,
+            &settings,
+            Viewport::new(1280.0, 720.0),
+            ScenarioStartMode::Normal,
+            &ScenarioAsset::None,
+        )
+        .unwrap();
+        let scenario = scenario
+            .as_any()
+            .downcast_ref::<SpacewarsClientScenario>()
+            .unwrap();
+
+        assert!(scenario.player_2_rule_bot);
+        assert_eq!(scenario.state.players[1].name, "Rule Bot");
+        assert_eq!(
+            player_panel_state(&scenario.state, 1).name,
+            "Player 2: Rule Bot"
+        );
+    }
+
+    #[test]
+    fn benchmark_launch_keeps_its_deterministic_benchmark_controller() {
+        let mut settings = Settings::default();
+        settings.spacewars.player_2_controller = SpacewarsController::RuleBot;
+
+        let scenario = create(
+            29,
+            &settings,
+            Viewport::new(1280.0, 720.0),
+            ScenarioStartMode::Benchmark(BenchmarkConfiguration::default()),
+            &ScenarioAsset::None,
+        )
+        .unwrap();
+        let scenario = scenario
+            .as_any()
+            .downcast_ref::<SpacewarsClientScenario>()
+            .unwrap();
+
+        assert!(!scenario.player_2_rule_bot);
+        assert_eq!(scenario.state.players[1].name, "Player 2");
     }
 }

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -7,13 +7,14 @@ use std::rc::Rc;
 use engine_common::{Action, PointerPhase, RenderPoint};
 use engine_nes::ControllerButtons;
 use scenario_spacewars::{
-    ControlSource, ShipIntent, ShipIntentEncoder, SpacewarsAction, SpacewarsScenario,
+    PlayerId, ShipIntent, ShipIntentEncoder, ShipSensorProfile, SpacewarsAction, SpacewarsScenario,
     SpacewarsState,
 };
 use slint::ComponentHandle;
 use slint::winit_030::winit::event::{ElementState, WindowEvent};
 use slint::winit_030::winit::keyboard::{KeyCode, PhysicalKey};
 use slint::winit_030::{EventResult, WinitWindowAccessor};
+use spacewars_ai::{BrainReset, RuleShipBrain, ShipBrain};
 
 use crate::MainWindow;
 
@@ -221,8 +222,11 @@ impl ClientInput {
         &mut self,
         state: &SpacewarsState,
         benchmark_active: bool,
+        bot_players: [bool; 2],
     ) -> Vec<Action> {
-        let mut actions = self.spacewars_controls.actions(state, benchmark_active);
+        let mut actions = self
+            .spacewars_controls
+            .actions(state, benchmark_active, bot_players);
         let pressed = self.pressed.borrow();
         for controls in [P1_CONTROLS, P2_CONTROLS] {
             if pressed.contains(&controls.zoom_in) {
@@ -432,8 +436,18 @@ const P2_CONTROLS: PlayerControlMap = PlayerControlMap {
 
 struct SpacewarsControls {
     seats: [ControlSeat; 2],
-    benchmark_sources: [BenchmarkSource; 2],
+    rule_brains: [RuleShipBrain; 2],
+    brain_contexts: [Option<BrainReset>; 2],
+    active_sources: [SpacewarsControlMode; 2],
     encoder: ShipIntentEncoder,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum SpacewarsControlMode {
+    #[default]
+    Human,
+    RuleBot,
+    Benchmark,
 }
 
 impl SpacewarsControls {
@@ -445,27 +459,95 @@ impl SpacewarsControls {
         p2.add_source(GamepadSource::new(gamepads, 1));
         Self {
             seats: [p1, p2],
-            benchmark_sources: [BenchmarkSource, BenchmarkSource],
+            rule_brains: [RuleShipBrain::default(), RuleShipBrain::default()],
+            brain_contexts: [None, None],
+            active_sources: [SpacewarsControlMode::Human; 2],
             encoder: ShipIntentEncoder::default(),
         }
     }
 
-    fn actions(&mut self, state: &SpacewarsState, benchmark_active: bool) -> Vec<Action> {
+    fn actions(
+        &mut self,
+        state: &SpacewarsState,
+        benchmark_active: bool,
+        bot_players: [bool; 2],
+    ) -> Vec<Action> {
         let mut actions = Vec::new();
-        for player in 0..self.seats.len() {
-            let intent = if benchmark_active {
-                self.benchmark_sources[player].intent(state, player)
+        for (player, bot_player) in bot_players.into_iter().enumerate() {
+            let mode = if benchmark_active {
+                SpacewarsControlMode::Benchmark
+            } else if bot_player {
+                SpacewarsControlMode::RuleBot
             } else {
-                self.seats[player].intent(state, player)
+                SpacewarsControlMode::Human
+            };
+
+            // Always send a neutral frame before a different source can take
+            // over. Besides making live handoff predictable, this releases any
+            // held laser/thrust state left by the previous source.
+            let intent = if self.active_sources[player] != mode {
+                self.active_sources[player] = mode;
+                self.brain_contexts[player] = None;
+                ShipIntent::default()
+            } else {
+                match mode {
+                    SpacewarsControlMode::Human => self.seats[player].intent(),
+                    SpacewarsControlMode::RuleBot => self.rule_bot_intent(state, player),
+                    SpacewarsControlMode::Benchmark => {
+                        SpacewarsScenario::benchmark_intent(state, player)
+                    }
+                }
             };
             actions.extend(self.encoder.encode(player, intent));
         }
         actions
     }
 
+    fn rule_bot_intent(&mut self, state: &SpacewarsState, player: usize) -> ShipIntent {
+        let Some(actor) = PlayerId::from_index(player) else {
+            return ShipIntent::default();
+        };
+        let context = BrainReset {
+            actor,
+            episode_seed: state.seed,
+        };
+        if self.brain_contexts[player] != Some(context) {
+            self.rule_brains[player].reset(context);
+            self.brain_contexts[player] = Some(context);
+        }
+        let Some(observation) =
+            SpacewarsScenario::observe_ship(state, actor, ShipSensorProfile::FullMapRadar)
+        else {
+            return ShipIntent::default();
+        };
+        let intent = self.rule_brains[player].intent(&observation);
+        if state.tick.is_multiple_of(60) {
+            let telemetry = self.rule_brains[player].telemetry();
+            tracing::debug!(
+                player = player + 1,
+                tick = state.tick,
+                goal = ?telemetry.goal,
+                target = ?telemetry.target,
+                hazard = ?telemetry.hazard,
+                distance = telemetry.target_distance,
+                heading_error = telemetry.heading_error,
+                ?intent,
+                "Spacewars rule-bot telemetry."
+            );
+        }
+        intent
+    }
+
     fn reset(&mut self) {
         self.encoder.reset();
+        self.rule_brains = [RuleShipBrain::default(), RuleShipBrain::default()];
+        self.brain_contexts = [None, None];
+        self.active_sources = [SpacewarsControlMode::Human; 2];
     }
+}
+
+trait ControlSource {
+    fn intent(&mut self) -> ShipIntent;
 }
 
 struct ControlSeat {
@@ -483,11 +565,11 @@ impl ControlSeat {
         self.sources.push(Box::new(source));
     }
 
-    fn intent(&mut self, state: &SpacewarsState, player: usize) -> ShipIntent {
+    fn intent(&mut self) -> ShipIntent {
         self.sources
             .iter_mut()
             .fold(ShipIntent::default(), |intent, source| {
-                intent.merged_with(source.intent(state, player))
+                intent.merged_with(source.intent())
             })
     }
 }
@@ -504,7 +586,7 @@ impl KeyboardSource {
 }
 
 impl ControlSource for KeyboardSource {
-    fn intent(&mut self, _state: &SpacewarsState, _player: usize) -> ShipIntent {
+    fn intent(&mut self) -> ShipIntent {
         let pressed = self.pressed.borrow();
         let thrust = if pressed.contains(&self.controls.thrust) {
             1.0
@@ -547,7 +629,7 @@ impl GamepadSource {
 }
 
 impl ControlSource for GamepadSource {
-    fn intent(&mut self, _state: &SpacewarsState, _player: usize) -> ShipIntent {
+    fn intent(&mut self) -> ShipIntent {
         let gamepads = self.gamepads.borrow();
         let Some(gamepad) = gamepads.seat(self.seat) else {
             return ShipIntent::default();
@@ -611,14 +693,6 @@ fn shape_axis(value: f32, deadzone: f32, signed: bool) -> f32 {
 
     let normalized = (magnitude - deadzone) / (1.0 - deadzone);
     normalized * normalized * value.signum()
-}
-
-struct BenchmarkSource;
-
-impl ControlSource for BenchmarkSource {
-    fn intent(&mut self, state: &SpacewarsState, player: usize) -> ShipIntent {
-        SpacewarsScenario::benchmark_intent(state, player)
-    }
 }
 
 fn mapped_key_event(event: &WindowEvent) -> Option<(GameKey, ElementState)> {
@@ -693,7 +767,7 @@ mod tests {
 
     fn take_spacewars_actions(input: &mut ClientInput) -> Vec<Action> {
         let state = SpacewarsScenario::init(SpacewarsConfig::deathmatch(), 0);
-        input.actions_for_spacewars(&state, false)
+        input.actions_for_spacewars(&state, false, [false; 2])
     }
 
     #[test]
@@ -1145,5 +1219,52 @@ mod tests {
             amount: 1.0,
         }));
         assert!(!has_action(&actions, 0, SpacewarsActionKind::ZoomOut));
+    }
+
+    #[test]
+    fn rule_bot_waits_one_neutral_frame_before_taking_control() {
+        let state = SpacewarsScenario::init(SpacewarsConfig::deathmatch(), 7);
+        let mut input = ClientInput::default();
+
+        let first = decoded(&input.actions_for_spacewars(&state, false, [false, true]));
+        assert!(!first.iter().any(|action| action.player() == 1));
+
+        let second = decoded(&input.actions_for_spacewars(&state, false, [false, true]));
+        assert!(second.iter().any(|action| matches!(
+            action,
+            ScenarioAction::SetTurn { player: 1, rate } if rate.abs() > 0.0
+        )));
+
+        input.reset_spacewars_controls();
+        let after_reset = decoded(&input.actions_for_spacewars(&state, false, [false, true]));
+        assert!(!after_reset.iter().any(|action| action.player() == 1));
+    }
+
+    #[test]
+    fn changing_p2_from_human_to_bot_releases_held_controls_first() {
+        let state = SpacewarsScenario::init(SpacewarsConfig::deathmatch(), 7);
+        let mut input = ClientInput::default();
+        input.press(GameKey::P2Laser);
+
+        let human = decoded(&input.actions_for_spacewars(&state, false, [false; 2]));
+        assert!(human.contains(&ScenarioAction::SetLaser {
+            player: 1,
+            on: true,
+        }));
+
+        let handoff = decoded(&input.actions_for_spacewars(&state, false, [false, true]));
+        assert_eq!(
+            handoff,
+            vec![ScenarioAction::SetLaser {
+                player: 1,
+                on: false,
+            }]
+        );
+
+        let controlled = decoded(&input.actions_for_spacewars(&state, false, [false, true]));
+        assert!(controlled.iter().any(|action| matches!(
+            action,
+            ScenarioAction::SetTurn { player: 1, rate } if rate.abs() > 0.0
+        )));
     }
 }

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -30,7 +30,7 @@ use engine_common::{
     MAX_SPACEWARS_PLAYER_VIEW_HEIGHT, MAX_SPACEWARS_UNIVERSE_RADIUS, MIN_PIZZA_BALL_SPAWN_RATE,
     MIN_SPACEWARS_ASTEROID_PROBABILITY_PER_SEC, MIN_SPACEWARS_PLAYER_HEALTH_PERCENT,
     MIN_SPACEWARS_PLAYER_VIEW_HEIGHT, MIN_SPACEWARS_UNIVERSE_RADIUS, PizzaSettings,
-    RendererSetting, Settings, SpacewarsSettings,
+    RendererSetting, Settings, SpacewarsController, SpacewarsSettings,
 };
 #[cfg(test)]
 use engine_core::SpacewarsConfig;
@@ -560,6 +560,9 @@ fn show_launcher(
     window.set_launcher_player_health_text(SharedString::from(
         setup.player_health_percent.to_string(),
     ));
+    window.set_launcher_p2_controller(SharedString::from(spacewars_controller_label(
+        setup.player_2_controller,
+    )));
     let pizza = settings.pizza.normalized();
     window
         .set_launcher_pizza_desired_balls_text(SharedString::from(pizza.desired_balls.to_string()));
@@ -1064,7 +1067,7 @@ fn cycle_launcher_scenario(window: &MainWindow, delta: i32) {
 
 fn launcher_settings_item_count(window: &MainWindow) -> i32 {
     match window.get_launcher_scenario().as_str() {
-        "spacewars" => 7,
+        "spacewars" => 8,
         "pizza" => 5,
         "falling" => 1,
         "nes" => 2,
@@ -1155,6 +1158,14 @@ fn adjust_spacewars_launcher_setting(window: &MainWindow, focus: i32, delta: i32
             window.set_launcher_player_health_text(SharedString::from(next.to_string()));
             window.set_launcher_spacewars_preset(SharedString::from(PRESET_CUSTOM));
         }
+        6 => {
+            let next = cycle_label(
+                window.get_launcher_p2_controller().as_str(),
+                &["human", "rule bot"],
+                delta,
+            );
+            window.set_launcher_p2_controller(SharedString::from(next));
+        }
         _ => {}
     }
 }
@@ -1222,7 +1233,16 @@ fn handle_launcher_apply_preset(weak_window: &slint::Weak<MainWindow>) {
 
     let preset = window.get_launcher_spacewars_preset();
     match spacewars_preset_from_label(preset.as_str()) {
-        Ok(Some(setup)) => set_spacewars_setup_fields(&window, &setup),
+        Ok(Some(mut setup)) => {
+            match spacewars_controller_from_label(window.get_launcher_p2_controller().as_str()) {
+                Ok(controller) => setup.player_2_controller = controller,
+                Err(message) => {
+                    window.set_launcher_error_text(SharedString::from(message));
+                    return;
+                }
+            }
+            set_spacewars_setup_fields(&window, &setup);
+        }
         Ok(None) => {}
         Err(message) => window.set_launcher_error_text(SharedString::from(message)),
     }
@@ -1467,6 +1487,9 @@ fn set_spacewars_setup_fields(window: &MainWindow, setup: &SpacewarsSettings) {
     window.set_launcher_player_health_text(SharedString::from(
         setup.player_health_percent.to_string(),
     ));
+    window.set_launcher_p2_controller(SharedString::from(spacewars_controller_label(
+        setup.player_2_controller,
+    )));
     window.set_launcher_p1_zoom_text(SharedString::from(format_float_setting(
         setup.player_1_view_height,
     )));
@@ -1487,7 +1510,9 @@ fn spacewars_preset_from_label(label: &str) -> Result<Option<SpacewarsSettings>,
 }
 
 fn preset_label_for_setup(setup: &SpacewarsSettings) -> &'static str {
-    let setup = setup.normalized();
+    let mut setup = setup.normalized();
+    // Controller selection is orthogonal to the world/gameplay preset.
+    setup.player_2_controller = SpacewarsController::Human;
     if setup == original_spacewars_preset() {
         PRESET_ORIGINAL
     } else if setup == small_duel_spacewars_preset() {
@@ -1581,7 +1606,7 @@ fn launch_options_from_window(window: &MainWindow) -> Result<EffectiveLaunch, St
 }
 
 fn spacewars_setup_from_window(window: &MainWindow) -> Result<SpacewarsSettings, String> {
-    spacewars_setup_from_values(
+    let mut setup = spacewars_setup_from_values(
         window.get_launcher_universe_radius_text().as_str(),
         window.get_launcher_use_planets().as_str(),
         window.get_launcher_asteroids_enabled().as_str(),
@@ -1589,7 +1614,10 @@ fn spacewars_setup_from_window(window: &MainWindow) -> Result<SpacewarsSettings,
         window.get_launcher_player_health_text().as_str(),
         window.get_launcher_p1_zoom_text().as_str(),
         window.get_launcher_p2_zoom_text().as_str(),
-    )
+    )?;
+    setup.player_2_controller =
+        spacewars_controller_from_label(window.get_launcher_p2_controller().as_str())?;
+    Ok(setup.normalized())
 }
 
 fn pizza_setup_from_window(window: &MainWindow) -> Result<PizzaSettings, String> {
@@ -1671,9 +1699,25 @@ fn spacewars_setup_from_values(
             MIN_SPACEWARS_PLAYER_VIEW_HEIGHT,
             MAX_SPACEWARS_PLAYER_VIEW_HEIGHT,
         )?,
+        player_2_controller: SpacewarsController::Human,
     };
 
     Ok(setup.normalized())
+}
+
+fn spacewars_controller_label(controller: SpacewarsController) -> &'static str {
+    match controller {
+        SpacewarsController::Human => "human",
+        SpacewarsController::RuleBot => "rule bot",
+    }
+}
+
+fn spacewars_controller_from_label(label: &str) -> Result<SpacewarsController, String> {
+    match label.trim() {
+        "human" => Ok(SpacewarsController::Human),
+        "rule bot" => Ok(SpacewarsController::RuleBot),
+        other => Err(format!("Unknown Spacewars controller {other:?}.")),
+    }
 }
 
 fn pizza_setup_from_values(
@@ -2059,6 +2103,11 @@ mod tests {
         assert_eq!(setup.player_health_percent, 250);
         assert_eq!(setup.player_1_view_height, 420.0);
         assert_eq!(setup.player_2_view_height, 640.0);
+        assert_eq!(setup.player_2_controller, SpacewarsController::Human);
+        assert_eq!(
+            spacewars_controller_from_label("rule bot").unwrap(),
+            SpacewarsController::RuleBot
+        );
 
         let clamped =
             spacewars_setup_from_values("99999", "on", "off", "9999", "0", "1", "99999").unwrap();
@@ -2107,6 +2156,7 @@ mod tests {
         assert!(
             spacewars_setup_from_values("1200", "on", "on", "20", "100", "320", "far").is_err()
         );
+        assert!(spacewars_controller_from_label("mystery").is_err());
     }
 
     #[test]
@@ -2162,6 +2212,10 @@ mod tests {
             preset_label_for_setup(&small_duel_spacewars_preset()),
             PRESET_SMALL_DUEL
         );
+
+        let mut duel_with_bot = small_duel_spacewars_preset();
+        duel_with_bot.player_2_controller = SpacewarsController::RuleBot;
+        assert_eq!(preset_label_for_setup(&duel_with_bot), PRESET_SMALL_DUEL);
 
         let mut custom = SpacewarsSettings::default();
         custom.universe_radius = 1800;
@@ -2268,6 +2322,7 @@ mod tests {
                 player_health_percent: 250,
                 player_1_view_height: 420.0,
                 player_2_view_height: 640.0,
+                player_2_controller: SpacewarsController::RuleBot,
             },
             pizza: PizzaSettings {
                 desired_balls: 321,
@@ -2340,6 +2395,7 @@ mod tests {
             player_health_percent: 250,
             player_1_view_height: 420.0,
             player_2_view_height: 640.0,
+            player_2_controller: SpacewarsController::RuleBot,
         };
 
         let config = spacewars_config_from_settings(&settings);

--- a/crates/engine-client/src/settings.rs
+++ b/crates/engine-client/src/settings.rs
@@ -251,8 +251,8 @@ mod tests {
     use std::sync::Mutex;
 
     use engine_common::{
-        AudioSettings, LaunchSettings, NesSettings, RendererSetting, SpacewarsSettings,
-        VideoSettings,
+        AudioSettings, LaunchSettings, NesSettings, RendererSetting, SpacewarsController,
+        SpacewarsSettings, VideoSettings,
     };
 
     use super::*;
@@ -359,6 +359,7 @@ mod tests {
                 asteroids_enabled: false,
                 asteroid_probability_per_sec: 80.0,
                 player_health_percent: 250,
+                player_2_controller: SpacewarsController::RuleBot,
                 ..Default::default()
             },
             ..Default::default()
@@ -389,6 +390,10 @@ mod tests {
             80.0
         );
         assert_eq!(reloaded.settings.spacewars.player_health_percent, 250);
+        assert_eq!(
+            reloaded.settings.spacewars.player_2_controller,
+            SpacewarsController::RuleBot
+        );
     }
 
     #[test]

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -247,6 +247,7 @@ export component MainWindow inherits Window {
     in-out property <string> launcher-asteroids-enabled: "on";
     in-out property <string> launcher-asteroid-probability-text: "20.0";
     in-out property <string> launcher-player-health-text: "100";
+    in-out property <string> launcher-p2-controller: "human";
     in-out property <string> launcher-p1-zoom-text: "320";
     in-out property <string> launcher-p2-zoom-text: "320";
     in-out property <string> launcher-pizza-desired-balls-text: "24";
@@ -957,7 +958,7 @@ export component MainWindow inherits Window {
                             y: 38px;
                             width: parent.width - 28px;
                             height: 22px;
-                            text: root.launcher-scenario == "spacewars" ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : root.launcher-scenario == "falling" ? "256×224 native video  ·  bounded 48 kHz audio" : root.launcher-scenario == "nes" ? (root.launcher-nes-rom-name + "  ·  " + root.launcher-nes-rom-status) : "A semi-interactive mechanics scenario";
+                            text: root.launcher-scenario == "spacewars" ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled + "  ·  P2 " + root.launcher-p2-controller) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : root.launcher-scenario == "falling" ? "256×224 native video  ·  bounded 48 kHz audio" : root.launcher-scenario == "nes" ? (root.launcher-nes-rom-name + "  ·  " + root.launcher-nes-rom-status) : "A semi-interactive mechanics scenario";
                             color: #9fb4cc;
                             font-size: 13px;
                         }
@@ -1159,6 +1160,25 @@ export component MainWindow inherits Window {
                     }
 
                     ChoiceRow {
+                        visible: root.launcher-scenario == "spacewars";
+                        x: 0px;
+                        y: 312px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Player 2";
+                        value: root.launcher-p2-controller;
+                        selected: root.launcher-settings-focus-index == 6;
+                        previous => {
+                            root.launcher-settings-focus-index = 6;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 6;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
                         visible: root.launcher-scenario == "pizza";
                         x: 0px;
                         y: 104px;
@@ -1244,11 +1264,11 @@ export component MainWindow inherits Window {
 
                     MenuButton {
                         x: 0px;
-                        y: root.launcher-scenario == "spacewars" ? 314px : root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
+                        y: root.launcher-scenario == "spacewars" ? 366px : root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
                         width: 150px;
                         height: 44px;
                         text: "Back";
-                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 6 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : 2);
+                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 7 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : 2);
                         activated => {
                             root.launcher-settings-visible = false;
                         }
@@ -1256,7 +1276,7 @@ export component MainWindow inherits Window {
 
                     MenuButton {
                         x: parent.width - 180px;
-                        y: root.launcher-scenario == "spacewars" ? 314px : root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
+                        y: root.launcher-scenario == "spacewars" ? 366px : root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
                         width: 180px;
                         height: 44px;
                         text: "Start Game";

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -595,6 +595,14 @@ pub const DEFAULT_SPACEWARS_PLAYER_VIEW_HEIGHT: f32 = 320.0;
 pub const MIN_SPACEWARS_PLAYER_VIEW_HEIGHT: f32 = 15.0;
 pub const MAX_SPACEWARS_PLAYER_VIEW_HEIGHT: f32 = 30_000.0;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SpacewarsController {
+    #[default]
+    Human,
+    RuleBot,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SpacewarsSettings {
@@ -612,6 +620,8 @@ pub struct SpacewarsSettings {
     pub player_1_view_height: f32,
     #[serde(default = "default_spacewars_player_view_height")]
     pub player_2_view_height: f32,
+    #[serde(default)]
+    pub player_2_controller: SpacewarsController,
 }
 
 impl Default for SpacewarsSettings {
@@ -624,6 +634,7 @@ impl Default for SpacewarsSettings {
             player_health_percent: DEFAULT_SPACEWARS_PLAYER_HEALTH_PERCENT,
             player_1_view_height: DEFAULT_SPACEWARS_PLAYER_VIEW_HEIGHT,
             player_2_view_height: DEFAULT_SPACEWARS_PLAYER_VIEW_HEIGHT,
+            player_2_controller: SpacewarsController::Human,
         }
     }
 }
@@ -645,6 +656,7 @@ impl SpacewarsSettings {
             ),
             player_1_view_height: normalize_spacewars_player_view_height(self.player_1_view_height),
             player_2_view_height: normalize_spacewars_player_view_height(self.player_2_view_height),
+            player_2_controller: self.player_2_controller,
         }
     }
 }

--- a/crates/spacewars-ai/Cargo.toml
+++ b/crates/spacewars-ai/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "spacewars-ai"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+engine-core = { workspace = true }
+scenario-spacewars = { workspace = true }
+
+[dev-dependencies]
+engine-common = { workspace = true }

--- a/crates/spacewars-ai/src/lib.rs
+++ b/crates/spacewars-ai/src/lib.rs
@@ -1,0 +1,571 @@
+//! Host-side Spacewars controllers built on explicit scenario observations.
+//!
+//! The scenario remains authoritative for physics and gameplay. A brain sees a
+//! versioned [`ShipObservationV1`], returns a canonical [`ShipIntent`], and has
+//! no reference through which it could mutate the simulation. Keeping this in
+//! a small library also lets the desktop client and a future headless agent
+//! runner use exactly the same guidance code.
+
+#![forbid(unsafe_code)]
+
+use core::f32::consts::PI;
+
+use engine_core::Vec2;
+use scenario_spacewars::{
+    DebrisId, HazardObservationV1, PlayerId, ShipForm, ShipIntent, ShipObservationV1,
+};
+
+const TARGET_EPSILON: f32 = 1.0e-5;
+
+/// Episode context supplied whenever a host installs or restarts a brain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BrainReset {
+    pub actor: PlayerId,
+    pub episode_seed: u64,
+}
+
+/// Stable controller boundary shared by interactive and headless hosts.
+pub trait ShipBrain {
+    fn reset(&mut self, reset: BrainReset);
+
+    fn intent(&mut self, observation: &ShipObservationV1) -> ShipIntent;
+
+    fn telemetry(&self) -> BrainTelemetry;
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BrainGoal {
+    #[default]
+    Idle,
+    Attack,
+    AvoidBody,
+    AvoidHazard,
+    Survive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BrainTelemetry {
+    pub actor: Option<PlayerId>,
+    pub goal: BrainGoal,
+    pub target: Option<PlayerId>,
+    pub hazard: Option<DebrisId>,
+    pub target_distance: f32,
+    pub heading_error: f32,
+}
+
+impl Default for BrainTelemetry {
+    fn default() -> Self {
+        Self {
+            actor: None,
+            goal: BrainGoal::Idle,
+            target: None,
+            hazard: None,
+            target_distance: 0.0,
+            heading_error: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HeadingGuidance {
+    pub error_radians: f32,
+    pub turn: f32,
+    pub aligned: bool,
+}
+
+/// Return the signed shortest heading error to a local-frame target.
+///
+/// Positive angles are to the ship's right, matching positive Spacewars turn
+/// input. The result is always in `-PI..=PI`.
+pub fn shortest_heading_error(local_target: Vec2) -> f32 {
+    if local_target.length_squared() <= TARGET_EPSILON {
+        0.0
+    } else {
+        local_target.x.atan2(local_target.y).clamp(-PI, PI)
+    }
+}
+
+/// Pure proportional/damping steering usable by rule-based and trained agents.
+pub fn guide_heading(local_target: Vec2, angular_velocity: f32) -> HeadingGuidance {
+    let error_radians = shortest_heading_error(local_target);
+    let desired_omega = (error_radians * 2.0).clamp(-1.0, 1.0);
+    let turn = ((desired_omega - angular_velocity) * 2.0).clamp(-1.0, 1.0);
+    HeadingGuidance {
+        error_radians,
+        turn,
+        aligned: error_radians.abs() <= 0.08,
+    }
+}
+
+/// Lead a moving contact using a bounded constant-speed intercept estimate.
+pub fn intercept_position(
+    local_position: Vec2,
+    local_velocity: Vec2,
+    projectile_speed: f32,
+    max_lead_seconds: f32,
+) -> Vec2 {
+    if projectile_speed <= 0.0 || !projectile_speed.is_finite() {
+        return local_position;
+    }
+    let lead_seconds =
+        (local_position.length() / projectile_speed).clamp(0.0, max_lead_seconds.max(0.0));
+    local_position + local_velocity * lead_seconds
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CollisionThreat {
+    pub hazard: DebrisId,
+    pub seconds_until_closest: f32,
+    pub closest_separation: f32,
+    pub avoidance_direction: Vec2,
+}
+
+/// Find the earliest debris contact predicted inside a short tactical horizon.
+pub fn earliest_collision_threat(
+    hazards: &[HazardObservationV1],
+    own_radius: f32,
+    horizon_seconds: f32,
+    clearance: f32,
+) -> Option<CollisionThreat> {
+    let horizon_seconds = horizon_seconds.max(0.0);
+    hazards
+        .iter()
+        .filter_map(|hazard| {
+            let relative_speed_squared = hazard.local_velocity.length_squared();
+            let seconds_until_closest = if relative_speed_squared <= TARGET_EPSILON {
+                0.0
+            } else {
+                (-hazard.local_position.dot(hazard.local_velocity) / relative_speed_squared)
+                    .clamp(0.0, horizon_seconds)
+            };
+            let closest = hazard.local_position + hazard.local_velocity * seconds_until_closest;
+            let closest_separation = closest.length();
+            let required_separation = own_radius + hazard.radius + clearance.max(0.0);
+            if closest_separation > required_separation {
+                return None;
+            }
+
+            let avoidance_direction = if closest.length_squared() > TARGET_EPSILON {
+                -closest
+            } else if hazard.local_position.length_squared() > TARGET_EPSILON {
+                -hazard.local_position
+            } else {
+                Vec2::X
+            };
+            Some(CollisionThreat {
+                hazard: hazard.id,
+                seconds_until_closest,
+                closest_separation,
+                avoidance_direction,
+            })
+        })
+        .min_by(|a, b| {
+            a.seconds_until_closest
+                .total_cmp(&b.seconds_until_closest)
+                .then_with(|| a.closest_separation.total_cmp(&b.closest_separation))
+                .then_with(|| a.hazard.cmp(&b.hazard))
+        })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RuleShipBrainConfig {
+    pub body_clearance: f32,
+    pub hazard_clearance: f32,
+    pub hazard_horizon_seconds: f32,
+    pub arrival_distance: f32,
+    pub fast_pursuit_distance: f32,
+    pub laser_range: f32,
+    pub cannon_min_range: f32,
+    pub cannon_max_range: f32,
+}
+
+impl Default for RuleShipBrainConfig {
+    fn default() -> Self {
+        Self {
+            body_clearance: 90.0,
+            hazard_clearance: 18.0,
+            hazard_horizon_seconds: 1.25,
+            arrival_distance: 120.0,
+            fast_pursuit_distance: 800.0,
+            laser_range: 1_000.0,
+            cannon_min_range: 250.0,
+            cannon_max_range: 600.0,
+        }
+    }
+}
+
+/// Deterministic first-generation opponent for a one-on-one Spacewars duel.
+///
+/// It deliberately has a narrow strategy: avoid imminent collisions, face the
+/// opponent, manage closing speed, and fire when aligned. Planet selection and
+/// capture strategy belong to later slices, while the guidance primitives here
+/// can be reused for them.
+#[derive(Debug, Clone, Default)]
+pub struct RuleShipBrain {
+    config: RuleShipBrainConfig,
+    actor: Option<PlayerId>,
+    episode_seed: u64,
+    telemetry: BrainTelemetry,
+}
+
+impl RuleShipBrain {
+    pub fn new(config: RuleShipBrainConfig) -> Self {
+        Self {
+            config,
+            ..Self::default()
+        }
+    }
+
+    fn set_telemetry(
+        &mut self,
+        goal: BrainGoal,
+        target: Option<PlayerId>,
+        hazard: Option<DebrisId>,
+        distance: f32,
+        heading: HeadingGuidance,
+    ) {
+        self.telemetry = BrainTelemetry {
+            actor: self.actor,
+            goal,
+            target,
+            hazard,
+            target_distance: distance,
+            heading_error: heading.error_radians,
+        };
+    }
+
+    fn body_avoidance(&self, observation: &ShipObservationV1) -> Option<Vec2> {
+        let mut nearest: Option<(f32, Vec2)> = None;
+        let mut consider = |position: Vec2, velocity: Vec2, radius: f32| {
+            let surface_distance =
+                position.length() - radius - observation.own_ship.collision_radius;
+            let closing = position.dot(velocity) < 0.0;
+            if surface_distance > self.config.body_clearance
+                || (!closing && surface_distance > self.config.body_clearance * 0.35)
+            {
+                return;
+            }
+            if nearest.is_none_or(|(distance, _)| surface_distance < distance) {
+                nearest = Some((surface_distance, -position));
+            }
+        };
+
+        if let Some(sun) = observation.sun {
+            consider(sun.local_position, sun.local_velocity, sun.radius);
+        }
+        for planet in &observation.planets {
+            consider(planet.local_position, planet.local_velocity, planet.radius);
+        }
+        nearest.map(|(_, direction)| direction)
+    }
+
+    fn avoidance_intent(
+        &mut self,
+        observation: &ShipObservationV1,
+        direction: Vec2,
+        goal: BrainGoal,
+        hazard: Option<DebrisId>,
+    ) -> ShipIntent {
+        let heading = guide_heading(direction, observation.own_ship.angular_velocity);
+        self.set_telemetry(goal, None, hazard, direction.length(), heading);
+        ShipIntent {
+            turn: heading.turn,
+            thrust: if heading.error_radians.abs() < 0.65 {
+                1.0
+            } else {
+                0.0
+            },
+            brake: if heading.error_radians.abs() >= 0.65 {
+                1.0
+            } else {
+                0.0
+            },
+            ..ShipIntent::default()
+        }
+    }
+}
+
+impl ShipBrain for RuleShipBrain {
+    fn reset(&mut self, reset: BrainReset) {
+        self.actor = Some(reset.actor);
+        self.episode_seed = reset.episode_seed;
+        self.telemetry = BrainTelemetry {
+            actor: self.actor,
+            ..BrainTelemetry::default()
+        };
+    }
+
+    fn intent(&mut self, observation: &ShipObservationV1) -> ShipIntent {
+        if self.actor != Some(observation.actor) || observation.own_ship.eliminated {
+            self.telemetry = BrainTelemetry {
+                actor: self.actor,
+                ..BrainTelemetry::default()
+            };
+            return ShipIntent::default();
+        }
+
+        if let Some(direction) = self.body_avoidance(observation) {
+            return self.avoidance_intent(observation, direction, BrainGoal::AvoidBody, None);
+        }
+
+        if let Some(threat) = earliest_collision_threat(
+            &observation.hazards,
+            observation.own_ship.collision_radius,
+            self.config.hazard_horizon_seconds,
+            self.config.hazard_clearance,
+        ) {
+            return self.avoidance_intent(
+                observation,
+                threat.avoidance_direction,
+                BrainGoal::AvoidHazard,
+                Some(threat.hazard),
+            );
+        }
+
+        let Some(opponent) = observation.opponent.filter(|opponent| !opponent.eliminated) else {
+            self.telemetry = BrainTelemetry {
+                actor: self.actor,
+                goal: BrainGoal::Idle,
+                ..BrainTelemetry::default()
+            };
+            return ShipIntent::default();
+        };
+
+        if observation.own_ship.form == ShipForm::EscapePod {
+            let heading = guide_heading(
+                -opponent.local_position,
+                observation.own_ship.angular_velocity,
+            );
+            self.set_telemetry(
+                BrainGoal::Survive,
+                Some(opponent.id),
+                None,
+                opponent.local_position.length(),
+                heading,
+            );
+            return ShipIntent {
+                turn: heading.turn,
+                thrust: if heading.error_radians.abs() < 0.65 {
+                    1.0
+                } else {
+                    0.0
+                },
+                ..ShipIntent::default()
+            };
+        }
+
+        let distance = opponent.local_position.length();
+        let aim_position =
+            intercept_position(opponent.local_position, opponent.local_velocity, 300.0, 1.0);
+        let heading = guide_heading(aim_position, observation.own_ship.angular_velocity);
+        let line_to_target = opponent.local_position.normalized();
+        let closing_speed = -opponent.local_velocity.dot(line_to_target);
+        let should_brake = distance < self.config.arrival_distance && closing_speed > 20.0;
+        let should_advance = !should_brake
+            && distance > self.config.arrival_distance
+            && heading.error_radians.abs() < 0.65;
+        let fast_pursuit =
+            distance > self.config.fast_pursuit_distance && heading.error_radians.abs() < 0.12;
+        let weapon_aligned = heading.error_radians.abs() < 0.08;
+
+        self.set_telemetry(
+            BrainGoal::Attack,
+            Some(opponent.id),
+            None,
+            distance,
+            heading,
+        );
+        ShipIntent {
+            turn: heading.turn,
+            thrust: if should_advance { 1.0 } else { 0.0 },
+            brake: if should_brake { 1.0 } else { 0.0 },
+            wings_closed: fast_pursuit,
+            laser: observation.own_ship.laser_available
+                && weapon_aligned
+                && distance <= self.config.laser_range,
+            cannon: observation.own_ship.cannon_ready
+                && weapon_aligned
+                && distance >= self.config.cannon_min_range
+                && distance <= self.config.cannon_max_range,
+        }
+        .normalized()
+    }
+
+    fn telemetry(&self) -> BrainTelemetry {
+        self.telemetry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine_common::Scenario;
+    use engine_core::SpacewarsConfig;
+    use scenario_spacewars::{ShipIntentEncoder, ShipSensorProfile, SpacewarsScenario};
+    use std::time::Duration;
+
+    const DT: Duration = Duration::from_nanos(16_666_667);
+
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() <= 1.0e-5,
+            "actual {actual}, expected {expected}"
+        );
+    }
+
+    #[test]
+    fn heading_error_matches_controller_turn_signs() {
+        assert_close(shortest_heading_error(Vec2::Y), 0.0);
+        assert_close(
+            shortest_heading_error(Vec2::X),
+            core::f32::consts::FRAC_PI_2,
+        );
+        assert_close(
+            shortest_heading_error(-Vec2::X),
+            -core::f32::consts::FRAC_PI_2,
+        );
+        assert_close(shortest_heading_error(-Vec2::Y).abs(), PI);
+    }
+
+    #[test]
+    fn intercept_leads_in_the_contacts_direction_of_travel() {
+        assert_eq!(
+            intercept_position(Vec2::new(0.0, 300.0), Vec2::new(20.0, 0.0), 300.0, 2.0),
+            Vec2::new(20.0, 300.0)
+        );
+    }
+
+    #[test]
+    fn aligned_distant_target_uses_thrust_and_fast_pursuit() {
+        let mut config = SpacewarsConfig::deathmatch();
+        config.asteroid_probability_per_sec = 0.0;
+        let state = SpacewarsScenario::init(config, 11);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.opponent.as_mut().unwrap().local_position = Vec2::new(0.0, 900.0);
+        observation.opponent.as_mut().unwrap().local_velocity = Vec2::ZERO;
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let intent = brain.intent(&observation);
+
+        assert_eq!(intent.turn, 0.0);
+        assert_eq!(intent.thrust, 1.0);
+        assert_eq!(intent.brake, 0.0);
+        assert!(intent.wings_closed);
+        assert!(intent.laser);
+        assert_eq!(brain.telemetry().goal, BrainGoal::Attack);
+    }
+
+    #[test]
+    fn closing_inside_arrival_distance_uses_the_brake() {
+        let mut config = SpacewarsConfig::deathmatch();
+        config.asteroid_probability_per_sec = 0.0;
+        let state = SpacewarsScenario::init(config, 13);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.opponent.as_mut().unwrap().local_position = Vec2::new(0.0, 100.0);
+        observation.opponent.as_mut().unwrap().local_velocity = Vec2::new(0.0, -50.0);
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let intent = brain.intent(&observation);
+
+        assert_eq!(intent.thrust, 0.0);
+        assert_eq!(intent.brake, 1.0);
+    }
+
+    #[test]
+    fn collision_prediction_chooses_the_earliest_bounded_contact() {
+        let hazard = |id, position, velocity| HazardObservationV1 {
+            id: DebrisId::from_value(id).unwrap(),
+            kind: scenario_spacewars::DebrisKind::Asteroid,
+            owner: None,
+            local_position: position,
+            local_velocity: velocity,
+            radius: 5.0,
+        };
+        let hazards = [
+            hazard(1, Vec2::new(0.0, 100.0), Vec2::new(0.0, -100.0)),
+            hazard(2, Vec2::new(0.0, 200.0), Vec2::new(0.0, -100.0)),
+        ];
+
+        let threat = earliest_collision_threat(&hazards, 5.0, 3.0, 10.0).unwrap();
+
+        assert_eq!(threat.hazard, DebrisId::from_value(1).unwrap());
+        assert_close(threat.seconds_until_closest, 1.0);
+        assert_eq!(threat.avoidance_direction, Vec2::new(0.0, -100.0));
+    }
+
+    #[test]
+    fn equal_reset_context_and_observation_produce_equal_output() {
+        let mut config = SpacewarsConfig::deathmatch();
+        config.asteroid_probability_per_sec = 0.0;
+        let state = SpacewarsScenario::init(config, 31);
+        let observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        let reset = BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        };
+        let mut first = RuleShipBrain::default();
+        let mut replay = RuleShipBrain::default();
+        first.reset(reset);
+        replay.reset(reset);
+
+        assert_eq!(first.intent(&observation), replay.intent(&observation));
+        assert_eq!(first.telemetry(), replay.telemetry());
+    }
+
+    #[test]
+    fn rule_brain_turns_and_damages_a_stationary_opponent() {
+        let mut config = SpacewarsConfig::deathmatch();
+        config.asteroid_probability_per_sec = 0.0;
+        config.players[0].health_percent = 100;
+        config.players[1].health_percent = 100;
+        let mut state = SpacewarsScenario::init(config, 17);
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        let mut encoder = ShipIntentEncoder::default();
+        let starting_life = state.ships[0].life;
+
+        for _ in 0..600 {
+            let observation = SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap();
+            let intent = brain.intent(&observation);
+            let actions = encoder.encode(PlayerId::PLAYER_2.index(), intent);
+            SpacewarsScenario::step(&mut state, &actions, DT);
+            if state.ships[0].life < starting_life {
+                break;
+            }
+        }
+
+        assert!(state.ships[0].life < starting_life);
+        assert_eq!(brain.telemetry().goal, BrainGoal::Attack);
+    }
+}

--- a/docs/design/ship-ai.md
+++ b/docs/design/ship-ai.md
@@ -1,0 +1,95 @@
+# Spacewars ship-controller architecture
+
+This document records the first implementation slice for
+[issue #14](https://github.com/aortez/space-wars/issues/14). It is deliberately
+small enough to play-test while establishing the boundary that later rule,
+training, and autonomous logistics controllers share.
+
+## Authority and data flow
+
+The Spacewars scenario remains authoritative for state, physics, damage,
+capture, and scoring:
+
+```text
+SpacewarsState
+    -> SpacewarsScenario::observe_ship(actor, sensor profile)
+    -> ShipObservationV1
+    -> ShipBrain::intent()
+    -> ShipIntent
+    -> ShipIntentEncoder
+    -> ordinary Spacewars actions
+    -> SpacewarsScenario::step()
+```
+
+A brain cannot receive or mutate `SpacewarsState`. Human keyboard/gamepad
+sources are even narrower: they produce `ShipIntent` from device state and no
+longer receive scenario state at all. This keeps AI policy out of simulation
+authority and makes replay behavior depend only on observations, reset context,
+and emitted actions.
+
+`spacewars-ai` is a separate library so the interactive client and a future
+headless `engine-agent` runner can use the same controller and guidance code.
+The client owns brain instances and their reset/handoff lifecycle.
+
+## Observation V1
+
+`ShipObservationV1` is serializable and uses typed `PlayerId`, `PlanetId`, and
+`DebrisId` identities. It includes:
+
+- own craft capability, health, form, velocity, weapon readiness, and docking;
+- the opposing craft's relative pose, velocity, form, and health;
+- universe center/radius, sun, and planets including moving spaceports and
+  capture state;
+- nearby tactical debris with stable scenario IDs.
+
+All vectors use an actor-local coordinate frame: positive x is right and
+positive y is forward. This removes irrelevant world translation and rotation
+from policy inputs.
+
+The initial `FullMapRadar` profile exposes the global ship and strategic-body
+awareness already available to local players. Debris requires tactical detail,
+so it is bounded to the nearest 64 contacts within 600 world units. Selection
+uses a fixed-size heap and final deterministic ordering; dense asteroid fields
+therefore cannot cause an unbounded controller allocation.
+
+Adding fog of war or specialized sensors should add named sensor profiles and
+preserve V1 field meaning. Breaking schema changes require a new observation
+version.
+
+## Brain lifecycle
+
+`ShipBrain` has three operations:
+
+- `reset(BrainReset)` installs an actor and episode seed;
+- `intent(&ShipObservationV1)` produces one normalized controller intent;
+- `telemetry()` reports the current goal, target, hazard, range, and heading
+  error without granting state access.
+
+When a host changes between human, rule-bot, or benchmark control, it forwards
+one neutral intent before the new source. This releases held thrust and weapons
+and prevents transition inputs from leaking between controllers. Restart also
+clears the encoder, brain context, and active source.
+
+## Current rule bot
+
+The first deterministic bot is selectable for Player 2 in the launcher. It:
+
+- avoids nearby celestial bodies and predicted debris collisions;
+- uses reusable shortest-heading and moving-target intercept guidance;
+- approaches and brakes around a one-on-one target;
+- uses fast wings only for long, aligned pursuit;
+- fires laser/cannon only inside configured alignment and range windows;
+- falls back to simple escape behavior when reduced to a pod.
+
+It intentionally does not choose planets, dock, or run a capture strategy yet.
+Small Duel is the clearest play-test configuration.
+
+## Next slices
+
+1. Add moving-spaceport arrival/docking guidance and deterministic guidance
+   fixtures.
+2. Add a slower strategic state machine for capture, repair, and combat goals.
+3. Surface brain telemetry in developer HUD/IPC tooling.
+4. Let `engine-agent` run the same observation/brain/action loop headlessly.
+5. Add policy adapters and batched observation storage only after the rule path
+   gives us stable semantics and measurable workloads.

--- a/scenarios/spacewars/Cargo.toml
+++ b/scenarios/spacewars/Cargo.toml
@@ -11,6 +11,8 @@ engine-common = { workspace = true }
 engine-core = { workspace = true }
 engine-gravity = { workspace = true }
 engine-rapier = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
+bincode = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -7,7 +7,8 @@
 mod physics;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    num::NonZeroU64,
     time::{Duration, Instant},
 };
 
@@ -32,6 +33,7 @@ use engine_rapier::{
     world::{BodyMotion, PhysicsStepMetrics},
 };
 use physics::{MechanicalContact, MechanicalEntity};
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 use engine_core::constants::COLLISION_TRANSLATION_SCALAR;
@@ -63,7 +65,7 @@ const MAX_PLANET_RADIUS: f32 = 150.0;
 const MIN_PLANET_SPACING: f32 = 10.0;
 const MAX_PLANET_SPACING: f32 = 50.0;
 const PLANET_MASS_DENSITY: f32 = 750.0;
-const PLANET_ORBIT_PERIOD_SCALAR: f32 = 14.0;
+const PLANET_ORBIT_PERIOD_SCALAR: f32 = 5.0;
 const BODY_BOUNDS_RADIUS_SCALE: f32 = 0.99;
 const SPACEPORT_ARC_LENGTH: f32 = 94.24778;
 const SPACEPORT_DEPTH_FACTOR: f32 = 0.4;
@@ -173,6 +175,81 @@ const GRAVITY_ROVER_FRAME_TAG: u64 = 6;
 const ROVER_BODY_COUNT: u64 = 3;
 
 pub const SPACEWARS_PLAYER_COUNT: usize = 2;
+
+/// Stable identity for a player-controlled actor within one Spacewars episode.
+///
+/// Scenario actions still carry their compact wire-format player index. AI and
+/// observation APIs use this type so callers cannot accidentally confuse a
+/// player with another indexed entity such as a planet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum PlayerId {
+    #[serde(rename = "player_1")]
+    Player1,
+    #[serde(rename = "player_2")]
+    Player2,
+}
+
+impl PlayerId {
+    pub const PLAYER_1: Self = Self::Player1;
+    pub const PLAYER_2: Self = Self::Player2;
+
+    pub const fn from_index(index: usize) -> Option<Self> {
+        match index {
+            0 => Some(Self::PLAYER_1),
+            1 => Some(Self::PLAYER_2),
+            _ => None,
+        }
+    }
+
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Player1 => 0,
+            Self::Player2 => 1,
+        }
+    }
+
+    pub const fn opponent(self) -> Self {
+        match self {
+            Self::Player1 => Self::Player2,
+            Self::Player2 => Self::Player1,
+        }
+    }
+}
+
+/// Stable index for a planet. Spacewars planets persist for the episode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct PlanetId(u32);
+
+impl PlanetId {
+    pub const fn from_index(index: usize) -> Option<Self> {
+        if index <= u32::MAX as usize {
+            Some(Self(index as u32))
+        } else {
+            None
+        }
+    }
+
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Monotonic scenario entity identity, not a Rapier body or collider handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct DebrisId(NonZeroU64);
+
+impl DebrisId {
+    pub const fn from_value(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    pub const fn value(self) -> u64 {
+        self.0.get()
+    }
+}
 
 const SHIP_THRUST_FORCE: f32 = 50_000.0;
 const SHIP_TURN_FORCE: f32 = 200.0;
@@ -461,7 +538,8 @@ pub struct DebrisState {
     physics_id: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DebrisKind {
     Asteroid,
     Fragment,
@@ -621,7 +699,8 @@ pub struct ShipState {
     death_impulse: Vec2,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ShipForm {
     Ship,
     EscapePod,
@@ -638,6 +717,108 @@ pub enum WingBehavior {
     None,
     Close,
     Open,
+}
+
+/// Named perception policy used to construct versioned ship observations.
+///
+/// `FullMapRadar` exposes both ships and every strategic body, matching the
+/// global awareness already available through local-play radar. Tactical
+/// debris is range- and count-bounded so one controller cannot turn a dense
+/// asteroid field into an unbounded per-tick allocation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShipSensorProfile {
+    #[default]
+    FullMapRadar,
+}
+
+pub const SHIP_SENSOR_HAZARD_RANGE: f32 = 600.0;
+pub const SHIP_SENSOR_MAX_HAZARDS: usize = 64;
+
+/// A ship observation's coordinate frame.
+///
+/// Positions and vectors use the observing ship as the origin. Positive `x`
+/// is to its right and positive `y` is forward. This keeps policy inputs
+/// independent of world position and camera orientation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ShipObservationV1 {
+    pub tick: u64,
+    pub delta_seconds: f32,
+    pub actor: PlayerId,
+    pub sensor_profile: ShipSensorProfile,
+    pub own_ship: OwnShipObservationV1,
+    pub opponent: Option<ShipContactObservationV1>,
+    pub universe: UniverseObservationV1,
+    pub sun: Option<CelestialBodyObservationV1>,
+    pub planets: Vec<PlanetObservationV1>,
+    pub hazards: Vec<HazardObservationV1>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct OwnShipObservationV1 {
+    pub id: PlayerId,
+    /// Absolute linear velocity expressed in the local ship frame.
+    pub local_velocity: Vec2,
+    pub angular_velocity: f32,
+    pub collision_radius: f32,
+    pub form: ShipForm,
+    pub life_fraction: f32,
+    pub eliminated: bool,
+    pub wings_closed: bool,
+    pub laser_available: bool,
+    pub cannon_ready: bool,
+    pub docked_planet: Option<PlanetId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ShipContactObservationV1 {
+    pub id: PlayerId,
+    pub local_position: Vec2,
+    /// Contact velocity minus observer velocity, in the observer frame.
+    pub local_velocity: Vec2,
+    pub local_forward: Vec2,
+    pub angular_velocity: f32,
+    pub collision_radius: f32,
+    pub form: ShipForm,
+    pub life_fraction: f32,
+    pub eliminated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct UniverseObservationV1 {
+    pub local_center: Vec2,
+    pub radius: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CelestialBodyObservationV1 {
+    pub local_position: Vec2,
+    pub local_velocity: Vec2,
+    pub radius: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PlanetObservationV1 {
+    pub id: PlanetId,
+    pub local_position: Vec2,
+    pub local_velocity: Vec2,
+    pub radius: f32,
+    pub owner: Option<PlayerId>,
+    pub capturing_player: Option<PlayerId>,
+    pub capture_progress: f32,
+    pub local_spaceport_position: Vec2,
+    pub local_spaceport_velocity: Vec2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct HazardObservationV1 {
+    pub id: DebrisId,
+    pub kind: DebrisKind,
+    pub owner: Option<PlayerId>,
+    pub local_position: Vec2,
+    /// Hazard velocity minus observer velocity, in the observer frame.
+    pub local_velocity: Vec2,
+    pub radius: f32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -715,11 +896,6 @@ impl ShipIntent {
             cannon: self_intent.cannon || other.cannon,
         }
     }
-}
-
-/// Host-side sources implement this without leaking device events into the sim.
-pub trait ControlSource {
-    fn intent(&mut self, state: &SpacewarsState, player: usize) -> ShipIntent;
 }
 
 #[derive(Debug, Clone)]
@@ -1235,6 +1411,146 @@ impl SpacewarsScenario {
             suspension_lengths: snapshot.suspension_lengths,
             life: rover.life,
             life_max: rover.life_max,
+        })
+    }
+
+    /// Build the stable, versioned controller view for one ship.
+    ///
+    /// This is intentionally a projection rather than a reference to
+    /// [`SpacewarsState`]. Brains can inspect only declared sensor data and
+    /// cannot mutate authoritative scenario state.
+    pub fn observe_ship(
+        state: &SpacewarsState,
+        actor: PlayerId,
+        sensor_profile: ShipSensorProfile,
+    ) -> Option<ShipObservationV1> {
+        let ship = state.ships.get(actor.index())?;
+        let player = state.players.get(actor.index())?;
+        let frame = ShipObservationFrame::new(ship);
+        let docked_planet = state
+            .spaceport_contacts
+            .iter()
+            .find(|contact| contact.ship == actor.index())
+            .and_then(|contact| PlanetId::from_index(contact.planet));
+
+        let own_ship = OwnShipObservationV1 {
+            id: actor,
+            local_velocity: frame.vector(ship.velocity),
+            angular_velocity: ship.omega,
+            collision_radius: ship_low_bounds(&ship_triangles(ship)).radius,
+            form: ship.form,
+            life_fraction: normalized_life_fraction(ship.life, ship.life_max),
+            eliminated: player.eliminated,
+            wings_closed: ship.wings_closed,
+            laser_available: !player.eliminated && ship.form == ShipForm::Ship,
+            cannon_ready: !player.eliminated
+                && ship.form == ShipForm::Ship
+                && ship.cannon_cooldown_remaining <= 0.0,
+            docked_planet,
+        };
+
+        let opponent_id = actor.opponent();
+        let opponent = state
+            .ships
+            .get(opponent_id.index())
+            .zip(state.players.get(opponent_id.index()))
+            .map(|(contact, contact_player)| ShipContactObservationV1 {
+                id: opponent_id,
+                local_position: frame.position(contact.position),
+                local_velocity: frame.vector(contact.velocity - ship.velocity),
+                local_forward: frame.vector(contact.direction),
+                angular_velocity: contact.omega,
+                collision_radius: ship_low_bounds(&ship_triangles(contact)).radius,
+                form: contact.form,
+                life_fraction: normalized_life_fraction(contact.life, contact.life_max),
+                eliminated: contact_player.eliminated,
+            });
+
+        let sun = state.sun.map(|sun| CelestialBodyObservationV1 {
+            local_position: frame.position(sun.position),
+            local_velocity: frame.vector(-ship.velocity),
+            radius: sun.radius,
+        });
+
+        let planets = state
+            .planets
+            .iter()
+            .enumerate()
+            .map(|(index, planet)| {
+                let id = PlanetId(index as u32);
+                let center_velocity = planet_surface_velocity(planet, planet.position);
+                let spaceport_position = spaceport_center(planet);
+                let spaceport_velocity = planet_surface_velocity(planet, spaceport_position);
+                PlanetObservationV1 {
+                    id,
+                    local_position: frame.position(planet.position),
+                    local_velocity: frame.vector(center_velocity - ship.velocity),
+                    radius: planet.radius,
+                    owner: planet.owner_id.and_then(PlayerId::from_index),
+                    capturing_player: planet.capturing_player_id.and_then(PlayerId::from_index),
+                    capture_progress: capture_progress(planet),
+                    local_spaceport_position: frame.position(spaceport_position),
+                    local_spaceport_velocity: frame.vector(spaceport_velocity - ship.velocity),
+                }
+            })
+            .collect();
+
+        let hazard_range_squared = SHIP_SENSOR_HAZARD_RANGE * SHIP_SENSOR_HAZARD_RANGE;
+        let mut nearest_hazards = BinaryHeap::with_capacity(SHIP_SENSOR_MAX_HAZARDS + 1);
+        for debris in state
+            .debris
+            .iter()
+            .filter(|debris| !debris.dead && debris.physics_id != 0)
+        {
+            let Some(id) = DebrisId::from_value(debris.physics_id) else {
+                continue;
+            };
+            let local_position = frame.position(debris.position);
+            let distance_squared = local_position.length_squared();
+            if distance_squared > hazard_range_squared {
+                continue;
+            }
+            nearest_hazards.push(RankedHazardObservation {
+                distance_squared,
+                observation: HazardObservationV1 {
+                    id,
+                    kind: debris.kind,
+                    owner: debris.owner_id.and_then(PlayerId::from_index),
+                    local_position,
+                    local_velocity: frame.vector(debris.velocity - ship.velocity),
+                    radius: debris.radius,
+                },
+            });
+            if nearest_hazards.len() > SHIP_SENSOR_MAX_HAZARDS {
+                nearest_hazards.pop();
+            }
+        }
+        let mut hazards = nearest_hazards
+            .into_iter()
+            .map(|ranked| ranked.observation)
+            .collect::<Vec<_>>();
+        hazards.sort_by(|a, b| {
+            a.local_position
+                .length_squared()
+                .total_cmp(&b.local_position.length_squared())
+                .then_with(|| a.id.cmp(&b.id))
+        });
+
+        let universe_radius = state.config.universe_radius as f32;
+        Some(ShipObservationV1 {
+            tick: state.tick,
+            delta_seconds: state.config.delta_time(),
+            actor,
+            sensor_profile,
+            own_ship,
+            opponent,
+            universe: UniverseObservationV1 {
+                local_center: frame.position(Vec2::splat(universe_radius)),
+                radius: universe_radius,
+            },
+            sun,
+            planets,
+            hazards,
         })
     }
 
@@ -4010,6 +4326,35 @@ fn spaceport_points(planet: &PlanetState) -> Vec<Vec2> {
         .collect()
 }
 
+fn spaceport_center(planet: &PlanetState) -> Vec2 {
+    let depth = planet.radius * SPACEPORT_DEPTH_FACTOR;
+    let angle = SPACEPORT_ARC_LENGTH / planet.radius;
+    let mut sum = Vec2::ZERO;
+
+    for index in 0..SPACEPORT_OUTER_POINTS {
+        let theta = index as f32 * angle / SPACEPORT_OUTER_POINTS as f32;
+        sum += Vec2::new(theta.cos() * planet.radius, theta.sin() * planet.radius);
+    }
+
+    if angle < SPACEPORT_MAX_ARC_ANGLE {
+        for index in 0..SPACEPORT_INNER_POINTS {
+            let theta =
+                (SPACEPORT_INNER_POINTS - index - 1) as f32 * angle / SPACEPORT_INNER_POINTS as f32;
+            sum += Vec2::new(theta.cos() * depth, theta.sin() * depth);
+        }
+    } else {
+        let first = Vec2::new(planet.radius, 0.0);
+        let theta = (SPACEPORT_OUTER_POINTS - 1) as f32 * angle / SPACEPORT_OUTER_POINTS as f32;
+        let last = Vec2::new(theta.cos() * planet.radius, theta.sin() * planet.radius);
+        for index in 0..SPACEPORT_INNER_POINTS {
+            sum += (first - last) / SPACEPORT_INNER_POINTS as f32 * (index as f32 + 1.0) + last;
+        }
+    }
+
+    let count = (SPACEPORT_OUTER_POINTS + SPACEPORT_INNER_POINTS) as f32;
+    planet.position + (sum / count).rotate_radians(planet.wrapper_angle)
+}
+
 fn spaceport_local_points(planet_radius: f32) -> Vec<Vec2> {
     let depth = planet_radius * SPACEPORT_DEPTH_FACTOR;
     let angle = SPACEPORT_ARC_LENGTH / planet_radius;
@@ -4143,6 +4488,75 @@ fn planet_surface_velocity(planet: &PlanetState, world_position: Vec2) -> Vec2 {
     let spin_velocity =
         surface_offset.rotate_radians(core::f32::consts::FRAC_PI_2) * planet.wrapper_omega;
     orbit_velocity + spin_velocity
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ShipObservationFrame {
+    origin: Vec2,
+    right: Vec2,
+    forward: Vec2,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RankedHazardObservation {
+    distance_squared: f32,
+    observation: HazardObservationV1,
+}
+
+impl PartialEq for RankedHazardObservation {
+    fn eq(&self, other: &Self) -> bool {
+        self.distance_squared
+            .total_cmp(&other.distance_squared)
+            .is_eq()
+            && self.observation.id == other.observation.id
+    }
+}
+
+impl Eq for RankedHazardObservation {}
+
+impl PartialOrd for RankedHazardObservation {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RankedHazardObservation {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.distance_squared
+            .total_cmp(&other.distance_squared)
+            .then_with(|| self.observation.id.cmp(&other.observation.id))
+    }
+}
+
+impl ShipObservationFrame {
+    fn new(ship: &ShipState) -> Self {
+        let forward = if ship.direction.length_squared() > REALLY_SMALL {
+            ship.direction.normalized()
+        } else {
+            Vec2::Y
+        };
+        Self {
+            origin: ship.position,
+            right: forward.rotate_radians(-core::f32::consts::FRAC_PI_2),
+            forward,
+        }
+    }
+
+    fn position(self, world_position: Vec2) -> Vec2 {
+        self.vector(world_position - self.origin)
+    }
+
+    fn vector(self, world_vector: Vec2) -> Vec2 {
+        Vec2::new(world_vector.dot(self.right), world_vector.dot(self.forward))
+    }
+}
+
+fn normalized_life_fraction(life: f32, life_max: f32) -> f32 {
+    if life_max > 0.0 {
+        (life / life_max).clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
 }
 
 impl DebrisState {
@@ -7030,14 +7444,18 @@ mod tests {
         let mut planet = test_planet(Vec2::new(100.0, 200.0), 50.0);
         let points = spaceport_points(&planet);
         let bounds = spaceport_physics(0, &planet).bounds;
+        let center = spaceport_center(&planet);
 
         planet.wrapper_angle = core::f32::consts::FRAC_PI_2;
         let rotated_bounds = spaceport_physics(0, &planet).bounds;
+        let rotated_center = spaceport_center(&planet);
 
         assert_eq!(
             points.len(),
             SPACEPORT_OUTER_POINTS + SPACEPORT_INNER_POINTS
         );
+        assert_vec_close(center, bounds.center);
+        assert_vec_close(rotated_center, rotated_bounds.center);
         assert!(bounds.radius > 0.0);
         assert_close(
             bounds.center.distance_to(planet.position),
@@ -10349,5 +10767,88 @@ mod tests {
         assert_eq!(mark.radius, ROVER_OVERVIEW_RADIUS);
         assert_eq!(mark.fill, Some(Fill::new(owner_color)));
         assert_eq!(mark.stroke, Some(Stroke::new(RenderColor::WHITE, 0.75)));
+    }
+
+    #[test]
+    fn ship_observation_uses_actor_local_coordinates_and_typed_identity() {
+        let mut config = SpacewarsConfig::deathmatch();
+        config.asteroid_probability_per_sec = 0.0;
+        let state = SpacewarsScenario::init(config, 19);
+
+        let p1 = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_1,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        let p2 = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+
+        assert_eq!(p1.actor, PlayerId::PLAYER_1);
+        assert_eq!(p1.own_ship.id, PlayerId::PLAYER_1);
+        assert_eq!(p1.opponent.unwrap().id, PlayerId::PLAYER_2);
+        assert_vec_close(p1.opponent.unwrap().local_position, Vec2::new(0.0, 50.0));
+        assert_vec_close(p2.opponent.unwrap().local_position, Vec2::new(0.0, -50.0));
+        assert_eq!(p1.own_ship.local_velocity, Vec2::ZERO);
+        assert_eq!(p1.sensor_profile, ShipSensorProfile::FullMapRadar);
+    }
+
+    #[test]
+    fn ship_observation_bounds_and_deterministically_orders_tactical_hazards() {
+        let mut config = SpacewarsConfig::deathmatch();
+        config.asteroid_probability_per_sec = 0.0;
+        let mut state = SpacewarsScenario::init(config, 23);
+        let origin = state.ships[0].position;
+        state.debris = (0..(SHIP_SENSOR_MAX_HAZARDS + 12))
+            .map(|index| {
+                let mut debris = DebrisState::new(
+                    DebrisKind::Asteroid,
+                    origin + Vec2::new(0.0, (index + 1) as f32),
+                    Vec2::ZERO,
+                    1.0,
+                    ASTEROID_DAMAGE_SCALAR,
+                    Color::DIM_GREY,
+                );
+                debris.physics_id = 10_000 - index as u64;
+                debris
+            })
+            .collect();
+
+        let observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_1,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+
+        assert_eq!(observation.hazards.len(), SHIP_SENSOR_MAX_HAZARDS);
+        assert!(observation.hazards.windows(2).all(|pair| {
+            pair[0].local_position.length_squared() <= pair[1].local_position.length_squared()
+        }));
+        assert_eq!(observation.hazards[0].id.value(), 10_000);
+        assert_eq!(
+            observation.hazards.last().unwrap().id.value(),
+            10_000 - (SHIP_SENSOR_MAX_HAZARDS - 1) as u64
+        );
+    }
+
+    #[test]
+    fn ship_observation_v1_round_trips_as_a_standalone_payload() {
+        let state = SpacewarsScenario::init(SpacewarsConfig::default(), 37);
+        let observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_1,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+
+        let bytes = bincode::serialize(&observation).unwrap();
+        let replay: ShipObservationV1 = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(replay, observation);
     }
 }


### PR DESCRIPTION
## Summary

- add a typed, actor-local `ShipObservationV1` perception boundary with stable gameplay IDs and a declared full-map radar profile
- add the reusable `spacewars-ai` crate with a deterministic rule brain, heading/intercept guidance, collision prediction, avoidance, and telemetry
- route the Player 2 rule bot through the existing `ShipIntent` to canonical `Action` path while keeping human controls isolated from scenario state
- add persisted launcher selection, safe neutral controller handoff, HUD naming, architecture documentation, and usage instructions

## Architecture

The scenario remains authoritative and policy-free:

```text
SpacewarsState -> ShipObservationV1 -> ShipBrain -> ShipIntent -> Action[] -> Scenario::step
```

Observations use craft-local coordinates and deterministic hazard ordering. The initial sensor policy exposes full-map strategic information while bounding nearby tactical hazards. The host owns brain lifecycle and resets, and switching between human and bot control emits a neutral frame so inputs cannot remain latched.

The first `RuleShipBrain` is intentionally tactical and memoryless. It can pursue and lead an opponent, select weapons by range and alignment, schedule fast wing travel, and override combat behavior for predicted celestial-body or debris collisions. Capture, docking, repair, rebuild, strategic goal memory, and evolutionary training remain follow-up work.

## Validation

- `cargo +1.89.0 fmt --all -- --check`
- `cargo +1.89.0 test --workspace -q`
- strict Clippy passes for the new AI crate; touched crates pass after allowing existing workspace lint debt
- manually ran Small Duel with Player 2 set to Rule Bot and verified pursuit, turning, laser fire, damage, HUD identity, and controller lifecycle

Advances #14.