### PR TITLE
Improve rule-bot planet navigation and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,21 @@ hold/release of `A` to charge and jump. Keyboard equivalents are `W` forward,
 
 To try the first Spacewars AI opponent, open Spacewars settings in the launcher
 and change **Player 2** from **human** to **rule bot**. **Small Duel** is the
-clearest test bed; the bot currently focuses on one-on-one pursuit, collision
-avoidance, and weapons rather than planet-capture strategy. The ordinary
-two-human setup remains the default.
+clearest combat test bed. In worlds with planets, the bot selects uncaptured
+spaceports, matches their orbital and wrapper motion, captures them, and
+departs for another target; an escape pod instead seeks an owned port for
+rebuilding. The ordinary two-human setup remains the default.
+
+On Unix, query the latest live rule-bot and docking diagnostics through the
+client control socket:
+
+```sh
+printf 'status\n' | socat - UNIX-CONNECT:/tmp/spacewars-control.sock
+```
+
+The snapshot is refreshed once per second and includes the brain phase and
+intent, ship motion, target planet, actual docked planet, and surface/port
+clearance. This keeps diagnostic formatting out of the simulation hot path.
 
 Falling and NES Library pass the d-pad, `A`, `B`, `Select`, and `Start` to the
 cartridge. Press `Start` + `Select` together for the host controls menu so a

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -426,6 +426,9 @@ pub fn start_scenario_loop(
         input.clear();
         input.reset_spacewars_controls();
     }
+    window.set_runtime_diagnostics(SharedString::from(format!(
+        "scenario={scenario_name}\npaused=false\nNo active rule-bot diagnostics."
+    )));
     let controls = controls.unwrap_or_else(new_scenario_controls);
 
     let timer = Timer::default();
@@ -496,6 +499,8 @@ pub fn start_scenario_loop(
     }
 
     let mut last_realtime_emulated_frames = 0;
+    let mut last_diagnostics_revision = u64::MAX;
+    let mut last_diagnostics_paused = true;
     timer.start(TimerMode::Repeated, TIMER_INTERVAL, move || {
         let Some(window) = weak_window.upgrade() else {
             return;
@@ -586,6 +591,18 @@ pub fn start_scenario_loop(
             window.set_scenario_error_text(SharedString::from(format!(
                 "Scenario stopped: {error}. Restart or return to the launcher."
             )));
+        }
+
+        let diagnostics_revision = input.runtime_diagnostics_revision();
+        if diagnostics_revision != last_diagnostics_revision
+            || paused != last_diagnostics_paused
+        {
+            window.set_runtime_diagnostics(SharedString::from(format!(
+                "scenario={scenario_name}\npaused={paused}\n{}",
+                input.runtime_diagnostics_text()
+            )));
+            last_diagnostics_revision = diagnostics_revision;
+            last_diagnostics_paused = paused;
         }
 
         scenario.record_realtime_displayed_loop_iteration();

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -318,6 +318,25 @@ impl ClientInput {
         self.spacewars_controls.reset();
     }
 
+    pub(crate) fn runtime_diagnostics_revision(&self) -> u64 {
+        self.spacewars_controls.diagnostics_revision
+    }
+
+    pub(crate) fn runtime_diagnostics_text(&self) -> String {
+        let diagnostics = self
+            .spacewars_controls
+            .bot_diagnostics
+            .iter()
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
+        if diagnostics.is_empty() {
+            "No active rule-bot diagnostics.".into()
+        } else {
+            diagnostics.join("\n\n")
+        }
+    }
+
     pub(crate) fn clear(&mut self) {
         self.clear_keyboard();
         self.pointer_events.clear();
@@ -329,9 +348,12 @@ impl ClientInput {
     }
 
     fn handle_focus_loss(&mut self) {
+        // Focus changes are routine on desktop: switching applications and
+        // invoking screenshot tools both generate them. Release momentary
+        // keyboard/pointer input so controls cannot stick, but leave pausing to
+        // an explicit request or an actual controller disconnect.
         self.cancel_pointer();
         self.clear_keyboard();
-        self.press(GameKey::ForcePause);
     }
 
     pub(crate) fn take_pointer_events(&mut self) -> Vec<ScreenPointerEvent> {
@@ -440,6 +462,8 @@ struct SpacewarsControls {
     brain_contexts: [Option<BrainReset>; 2],
     active_sources: [SpacewarsControlMode; 2],
     encoder: ShipIntentEncoder,
+    bot_diagnostics: [Option<String>; 2],
+    diagnostics_revision: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -463,6 +487,8 @@ impl SpacewarsControls {
             brain_contexts: [None, None],
             active_sources: [SpacewarsControlMode::Human; 2],
             encoder: ShipIntentEncoder::default(),
+            bot_diagnostics: std::array::from_fn(|_| None),
+            diagnostics_revision: 0,
         }
     }
 
@@ -481,6 +507,12 @@ impl SpacewarsControls {
             } else {
                 SpacewarsControlMode::Human
             };
+
+            if mode != SpacewarsControlMode::RuleBot
+                && self.bot_diagnostics[player].take().is_some()
+            {
+                self.diagnostics_revision = self.diagnostics_revision.wrapping_add(1);
+            }
 
             // Always send a neutral frame before a different source can take
             // over. Besides making live handoff predictable, this releases any
@@ -523,17 +555,103 @@ impl SpacewarsControls {
         let intent = self.rule_brains[player].intent(&observation);
         if state.tick.is_multiple_of(60) {
             let telemetry = self.rule_brains[player].telemetry();
+            let target_planet = telemetry.target_planet.and_then(|target| {
+                observation
+                    .planets
+                    .iter()
+                    .find(|planet| planet.id == target)
+            });
             tracing::debug!(
                 player = player + 1,
                 tick = state.tick,
                 goal = ?telemetry.goal,
                 target = ?telemetry.target,
+                target_planet = ?telemetry.target_planet,
+                port_phase = ?telemetry.port_phase,
                 hazard = ?telemetry.hazard,
                 distance = telemetry.target_distance,
                 heading_error = telemetry.heading_error,
+                desired_speed = telemetry.desired_speed,
+                relative_speed = telemetry.relative_speed,
+                docked_planet = ?observation.own_ship.docked_planet,
+                planet_owner = ?target_planet.and_then(|planet| planet.owner),
+                capturing_player = ?target_planet.and_then(|planet| planet.capturing_player),
+                capture_progress = target_planet.map_or(0.0, |planet| planet.capture_progress),
                 ?intent,
                 "Spacewars rule-bot telemetry."
             );
+            let target = target_planet.map_or_else(
+                || "none".into(),
+                |planet| {
+                    format!(
+                        "id={:?} owner={:?} capturing={:?} progress={:.3} radius={:.3} center_local={:?} port_local={:?} port_velocity_local={:?} surface_clearance={:.3}",
+                        planet.id,
+                        planet.owner,
+                        planet.capturing_player,
+                        planet.capture_progress,
+                        planet.radius,
+                        planet.local_position,
+                        planet.local_spaceport_position,
+                        planet.local_spaceport_velocity,
+                        planet.local_position.length()
+                            - planet.radius
+                            - observation.own_ship.collision_radius,
+                    )
+                },
+            );
+            let docked = observation.own_ship.docked_planet.map_or_else(
+                || "none".into(),
+                |docked| {
+                    observation
+                        .planets
+                        .iter()
+                        .find(|planet| planet.id == docked)
+                        .map_or_else(
+                            || format!("id={docked:?} observation=missing"),
+                            |planet| {
+                                format!(
+                                    "id={:?} owner={:?} surface_clearance={:.3} port_distance={:.3}",
+                                    planet.id,
+                                    planet.owner,
+                                    planet.local_position.length()
+                                        - planet.radius
+                                        - observation.own_ship.collision_radius,
+                                    planet.local_spaceport_position.length(),
+                                )
+                            },
+                        )
+                },
+            );
+            let ship = &state.ships[player];
+            self.bot_diagnostics[player] = Some(format!(
+                "player={} tick={} planets={} winner={:?}\nbrain goal={:?} target={:?} target_planet={:?} phase={:?} hazard={:?} distance={:.3} heading_error={:.3} desired_speed={:.3} relative_speed={:.3}\nintent turn={:.3} thrust={:.3} brake={:.3} wings_closed={} laser={} cannon={}\nship form={:?} position={:?} velocity={:?} omega={:.3} observed_wings_closed={} docked_planet={:?}\ntarget {target}\ndocked {docked}",
+                player + 1,
+                state.tick,
+                state.players[player].planet_count,
+                state.winner,
+                telemetry.goal,
+                telemetry.target,
+                telemetry.target_planet,
+                telemetry.port_phase,
+                telemetry.hazard,
+                telemetry.target_distance,
+                telemetry.heading_error,
+                telemetry.desired_speed,
+                telemetry.relative_speed,
+                intent.turn,
+                intent.thrust,
+                intent.brake,
+                intent.wings_closed,
+                intent.laser,
+                intent.cannon,
+                observation.own_ship.form,
+                ship.position,
+                ship.velocity,
+                ship.omega,
+                observation.own_ship.wings_closed,
+                observation.own_ship.docked_planet,
+            ));
+            self.diagnostics_revision = self.diagnostics_revision.wrapping_add(1);
         }
         intent
     }
@@ -543,6 +661,8 @@ impl SpacewarsControls {
         self.rule_brains = [RuleShipBrain::default(), RuleShipBrain::default()];
         self.brain_contexts = [None, None];
         self.active_sources = [SpacewarsControlMode::Human; 2];
+        self.bot_diagnostics = std::array::from_fn(|_| None);
+        self.diagnostics_revision = self.diagnostics_revision.wrapping_add(1);
     }
 }
 
@@ -813,7 +933,7 @@ mod tests {
     }
 
     #[test]
-    fn focus_loss_releases_controls_and_requests_a_host_pause() {
+    fn focus_loss_releases_controls_without_requesting_a_host_pause() {
         let mut input = ClientInput::default();
         input.press(GameKey::NesA);
         input.push_pointer_event(ScreenPointerEvent {
@@ -826,7 +946,6 @@ mod tests {
 
         assert_eq!(input.nes_controller_buttons(0), ControllerButtons::NONE);
         assert!(input.has_pointer_cancellation());
-        assert!(input.take_force_pause_requested());
         assert!(!input.take_force_pause_requested());
     }
 
@@ -1234,6 +1353,10 @@ mod tests {
             action,
             ScenarioAction::SetTurn { player: 1, rate } if rate.abs() > 0.0
         )));
+        let diagnostics = input.runtime_diagnostics_text();
+        assert!(diagnostics.contains("player=2 tick=0"));
+        assert!(diagnostics.contains("brain goal=Attack"));
+        assert!(diagnostics.contains("docked none"));
 
         input.reset_spacewars_controls();
         let after_reset = decoded(&input.actions_for_spacewars(&state, false, [false, true]));

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -30,6 +30,7 @@ struct ControlRequest {
 #[derive(Debug)]
 enum ControlCommand {
     Screenshot { output: PathBuf },
+    Status,
 }
 
 #[cfg(unix)]
@@ -162,6 +163,12 @@ fn parse_command(body: &str) -> Result<ControlCommand, String> {
                 output: PathBuf::from(output),
             })
         }
+        Some("status") => {
+            if lines.next().is_some() {
+                return Err("too many command lines".into());
+            }
+            Ok(ControlCommand::Status)
+        }
         Some(command) => Err(format!("unknown command {command:?}")),
         None => Err("empty command".into()),
     }
@@ -176,6 +183,7 @@ fn handle_request(window: &MainWindow, request: ControlRequest) {
                 .ok(format!("screenshot saved to {}", output.display())),
             Err(err) => request.response.error(err.to_string()),
         },
+        ControlCommand::Status => request.response.ok(window.get_runtime_diagnostics()),
     }
 }
 
@@ -221,11 +229,21 @@ mod tests {
             ControlCommand::Screenshot { output } => {
                 assert_eq!(output, PathBuf::from("/tmp/shot.png"));
             }
+            ControlCommand::Status => panic!("expected screenshot command"),
         }
     }
 
     #[test]
     fn reject_extra_lines() {
         assert!(parse_command("screenshot\n/tmp/shot.png\nextra\n").is_err());
+    }
+
+    #[test]
+    fn parse_status_command() {
+        assert!(matches!(
+            parse_command("status\n"),
+            Ok(ControlCommand::Status)
+        ));
+        assert!(parse_command("status\nextra\n").is_err());
     }
 }

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -226,6 +226,7 @@ export component MainWindow inherits Window {
     in property <bool> scenario-captures-gamepad-start: false;
     in property <bool> scenario-captures-gamepad-select: false;
     in property <string> scenario-error-text: "";
+    in-out property <string> runtime-diagnostics: "No active scenario diagnostics.";
     in-out property <bool> launcher-visible: false;
     in-out property <bool> launcher-controls-visible: false;
     in-out property <bool> launcher-settings-visible: false;

--- a/crates/spacewars-ai/src/lib.rs
+++ b/crates/spacewars-ai/src/lib.rs
@@ -12,7 +12,8 @@ use core::f32::consts::PI;
 
 use engine_core::Vec2;
 use scenario_spacewars::{
-    DebrisId, HazardObservationV1, PlayerId, ShipForm, ShipIntent, ShipObservationV1,
+    DebrisId, HazardObservationV1, PlanetId, PlanetObservationV1, PlayerId, ShipForm, ShipIntent,
+    ShipObservationV1,
 };
 
 const TARGET_EPSILON: f32 = 1.0e-5;
@@ -41,6 +42,17 @@ pub enum BrainGoal {
     AvoidBody,
     AvoidHazard,
     Survive,
+    Capture,
+    Rebuild,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortNavigationPhase {
+    Rendezvous,
+    Approach,
+    Ingress,
+    Docked,
+    Depart,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -48,9 +60,13 @@ pub struct BrainTelemetry {
     pub actor: Option<PlayerId>,
     pub goal: BrainGoal,
     pub target: Option<PlayerId>,
+    pub target_planet: Option<PlanetId>,
+    pub port_phase: Option<PortNavigationPhase>,
     pub hazard: Option<DebrisId>,
     pub target_distance: f32,
     pub heading_error: f32,
+    pub desired_speed: f32,
+    pub relative_speed: f32,
 }
 
 impl Default for BrainTelemetry {
@@ -59,9 +75,13 @@ impl Default for BrainTelemetry {
             actor: None,
             goal: BrainGoal::Idle,
             target: None,
+            target_planet: None,
+            port_phase: None,
             hazard: None,
             target_distance: 0.0,
             heading_error: 0.0,
+            desired_speed: 0.0,
+            relative_speed: 0.0,
         }
     }
 }
@@ -94,6 +114,127 @@ pub fn guide_heading(local_target: Vec2, angular_velocity: f32) -> HeadingGuidan
         error_radians,
         turn,
         aligned: error_radians.abs() <= 0.08,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ArrivalGuidanceConfig {
+    /// Maximum commanded speed relative to the moving target.
+    pub max_closing_speed: f32,
+    /// Time constant used to reduce desired speed as the target gets close.
+    pub arrival_time_seconds: f32,
+    pub position_tolerance: f32,
+    pub velocity_tolerance: f32,
+    /// Velocity error large enough to request full forward thrust or braking.
+    pub full_control_velocity_error: f32,
+    /// Maximum heading error at which forward thrust is useful.
+    pub thrust_alignment_radians: f32,
+}
+
+impl Default for ArrivalGuidanceConfig {
+    fn default() -> Self {
+        Self {
+            max_closing_speed: 120.0,
+            arrival_time_seconds: 1.5,
+            position_tolerance: 12.0,
+            velocity_tolerance: 8.0,
+            full_control_velocity_error: 30.0,
+            thrust_alignment_radians: 0.5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ArrivalGuidance {
+    pub heading: HeadingGuidance,
+    pub target_distance: f32,
+    pub desired_closing_speed: f32,
+    pub closing_speed: f32,
+    pub relative_speed: f32,
+    pub velocity_error: Vec2,
+    pub thrust: f32,
+    pub brake: f32,
+    pub arrived: bool,
+}
+
+/// Steer toward a position while matching the velocity of its moving frame.
+///
+/// `local_target_velocity` is target velocity minus craft velocity, matching
+/// Spacewars observation semantics. The controller first chooses a desired
+/// closing velocity, then points the ship at the difference between that and
+/// its current target-relative velocity. Braking is selected only when the
+/// game's omnidirectional brake would reduce that same velocity error.
+pub fn guide_arrival(
+    local_target_position: Vec2,
+    local_target_velocity: Vec2,
+    own_local_velocity: Vec2,
+    angular_velocity: f32,
+    config: ArrivalGuidanceConfig,
+) -> ArrivalGuidance {
+    let target_distance = local_target_position.length();
+    let direction = if target_distance > TARGET_EPSILON {
+        local_target_position / target_distance
+    } else {
+        Vec2::Y
+    };
+    let remaining_distance = (target_distance - config.position_tolerance.max(0.0)).max(0.0);
+    let desired_closing_speed = (remaining_distance
+        / config.arrival_time_seconds.max(TARGET_EPSILON))
+    .min(config.max_closing_speed.max(0.0));
+    let closing_speed = -local_target_velocity.dot(direction);
+    let relative_speed = local_target_velocity.length();
+    let desired_relative_velocity = direction * desired_closing_speed;
+    let current_relative_velocity = -local_target_velocity;
+    let velocity_error = desired_relative_velocity - current_relative_velocity;
+    let error_magnitude = velocity_error.length();
+    let heading_target = if error_magnitude > TARGET_EPSILON {
+        velocity_error
+    } else {
+        Vec2::Y
+    };
+    let heading = guide_heading(heading_target, angular_velocity);
+    let arrived = target_distance <= config.position_tolerance.max(0.0)
+        && relative_speed <= config.velocity_tolerance.max(0.0);
+
+    let full_control_error = config
+        .full_control_velocity_error
+        .max(config.velocity_tolerance)
+        .max(TARGET_EPSILON);
+    let control_amount = (error_magnitude / full_control_error).clamp(0.0, 1.0);
+    let brake_direction = -own_local_velocity;
+    let brake_helps = brake_direction.length_squared() > TARGET_EPSILON
+        && velocity_error.length_squared() > TARGET_EPSILON
+        && brake_direction
+            .normalized()
+            .dot(velocity_error.normalized())
+            > 0.35;
+    let moving_too_fast = closing_speed > desired_closing_speed + config.velocity_tolerance
+        || current_relative_velocity.length()
+            > desired_relative_velocity.length() + config.velocity_tolerance;
+    let brake = if brake_helps && moving_too_fast {
+        control_amount
+    } else {
+        0.0
+    };
+    let thrust = if !arrived
+        && brake == 0.0
+        && heading.error_radians.abs() <= config.thrust_alignment_radians.max(0.0)
+    {
+        control_amount
+    } else {
+        0.0
+    };
+
+    ArrivalGuidance {
+        heading,
+        target_distance,
+        desired_closing_speed,
+        closing_speed,
+        relative_speed,
+        velocity_error,
+        thrust,
+        brake,
+        arrived,
     }
 }
 
@@ -177,6 +318,15 @@ pub struct RuleShipBrainConfig {
     pub laser_range: f32,
     pub cannon_min_range: f32,
     pub cannon_max_range: f32,
+    pub spaceport_staging_margin: f32,
+    pub spaceport_staging_tolerance: f32,
+    pub spaceport_staging_velocity_tolerance: f32,
+    pub spaceport_corridor_half_width: f32,
+    pub spaceport_cruise_distance: f32,
+    pub spaceport_approach_speed: f32,
+    pub spaceport_ingress_speed: f32,
+    pub spaceport_departure_speed: f32,
+    pub spaceport_departure_alignment_radians: f32,
 }
 
 impl Default for RuleShipBrainConfig {
@@ -190,22 +340,39 @@ impl Default for RuleShipBrainConfig {
             laser_range: 1_000.0,
             cannon_min_range: 250.0,
             cannon_max_range: 600.0,
+            spaceport_staging_margin: 35.0,
+            spaceport_staging_tolerance: 40.0,
+            spaceport_staging_velocity_tolerance: 35.0,
+            spaceport_corridor_half_width: 42.0,
+            spaceport_cruise_distance: 650.0,
+            spaceport_approach_speed: 120.0,
+            spaceport_ingress_speed: 36.0,
+            spaceport_departure_speed: 80.0,
+            spaceport_departure_alignment_radians: 0.35,
         }
     }
 }
 
-/// Deterministic first-generation opponent for a one-on-one Spacewars duel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PortNavigation {
+    goal: BrainGoal,
+    planet: PlanetId,
+    phase: PortNavigationPhase,
+    departure_burn_started: bool,
+}
+
+/// Deterministic first-generation Spacewars opponent.
 ///
-/// It deliberately has a narrow strategy: avoid imminent collisions, face the
-/// opponent, manage closing speed, and fire when aligned. Planet selection and
-/// capture strategy belong to later slices, while the guidance primitives here
-/// can be reused for them.
+/// It avoids imminent collisions, fights in planet-free worlds, and uses a
+/// persistent staged maneuver to enter, hold, and leave moving spaceports.
+/// Broader utility scoring and personality-driven strategy remain later work.
 #[derive(Debug, Clone, Default)]
 pub struct RuleShipBrain {
     config: RuleShipBrainConfig,
     actor: Option<PlayerId>,
     episode_seed: u64,
     telemetry: BrainTelemetry,
+    port_navigation: Option<PortNavigation>,
 }
 
 impl RuleShipBrain {
@@ -216,33 +383,192 @@ impl RuleShipBrain {
         }
     }
 
-    fn set_telemetry(
-        &mut self,
-        goal: BrainGoal,
-        target: Option<PlayerId>,
-        hazard: Option<DebrisId>,
-        distance: f32,
-        heading: HeadingGuidance,
-    ) {
+    fn set_telemetry(&mut self, telemetry: BrainTelemetry) {
         self.telemetry = BrainTelemetry {
             actor: self.actor,
-            goal,
-            target,
-            hazard,
-            target_distance: distance,
-            heading_error: heading.error_radians,
+            ..telemetry
         };
     }
 
-    fn body_avoidance(&self, observation: &ShipObservationV1) -> Option<Vec2> {
+    fn select_port_navigation(&self, observation: &ShipObservationV1) -> Option<PortNavigation> {
+        let goal = match observation.own_ship.form {
+            ShipForm::Ship => BrainGoal::Capture,
+            ShipForm::EscapePod => BrainGoal::Rebuild,
+        };
+        observation
+            .planets
+            .iter()
+            .filter(|planet| match goal {
+                BrainGoal::Capture => planet.owner != Some(observation.actor),
+                BrainGoal::Rebuild => planet.owner == Some(observation.actor),
+                _ => false,
+            })
+            .min_by(|left, right| {
+                let clearance =
+                    observation.own_ship.collision_radius + self.config.spaceport_staging_margin;
+                let left_distance = left.spaceport_approach(clearance).local_position.length();
+                let right_distance = right.spaceport_approach(clearance).local_position.length();
+                left_distance
+                    .total_cmp(&right_distance)
+                    .then_with(|| left.id.cmp(&right.id))
+            })
+            .map(|planet| PortNavigation {
+                goal,
+                planet: planet.id,
+                phase: PortNavigationPhase::Rendezvous,
+                departure_burn_started: false,
+            })
+    }
+
+    fn refresh_port_navigation(&mut self, observation: &ShipObservationV1) {
+        if let Some(docked_planet) = observation.own_ship.docked_planet {
+            let already_tracking_contact = self
+                .port_navigation
+                .is_some_and(|navigation| navigation.planet == docked_planet);
+            if !already_tracking_contact {
+                let docked = observation
+                    .planets
+                    .iter()
+                    .find(|planet| planet.id == docked_planet);
+                self.port_navigation = match (observation.own_ship.form, docked) {
+                    (ShipForm::Ship, Some(planet)) if planet.owner == Some(observation.actor) => {
+                        Some(PortNavigation {
+                            goal: self
+                                .port_navigation
+                                .map_or(BrainGoal::Capture, |navigation| navigation.goal),
+                            planet: docked_planet,
+                            phase: PortNavigationPhase::Depart,
+                            departure_burn_started: false,
+                        })
+                    }
+                    (ShipForm::Ship, Some(_)) => Some(PortNavigation {
+                        goal: BrainGoal::Capture,
+                        planet: docked_planet,
+                        phase: PortNavigationPhase::Docked,
+                        departure_burn_started: false,
+                    }),
+                    (ShipForm::EscapePod, Some(planet))
+                        if planet.owner == Some(observation.actor) =>
+                    {
+                        Some(PortNavigation {
+                            goal: BrainGoal::Rebuild,
+                            planet: docked_planet,
+                            phase: PortNavigationPhase::Docked,
+                            departure_burn_started: false,
+                        })
+                    }
+                    _ => self.port_navigation,
+                };
+            }
+        }
+
+        if let Some(mut navigation) = self.port_navigation {
+            let planet = observation
+                .planets
+                .iter()
+                .find(|planet| planet.id == navigation.planet);
+            let keep_target = planet.is_some_and(|planet| match navigation.goal {
+                BrainGoal::Capture => {
+                    (observation.own_ship.form == ShipForm::Ship
+                        && planet.owner != Some(observation.actor))
+                        || navigation.phase == PortNavigationPhase::Depart
+                        || (navigation.phase == PortNavigationPhase::Docked
+                            && planet.owner == Some(observation.actor))
+                }
+                BrainGoal::Rebuild => {
+                    (observation.own_ship.form == ShipForm::EscapePod
+                        && planet.owner == Some(observation.actor))
+                        || navigation.phase == PortNavigationPhase::Depart
+                        || (navigation.phase == PortNavigationPhase::Docked
+                            && observation.own_ship.form == ShipForm::Ship)
+                }
+                _ => false,
+            });
+
+            if !keep_target {
+                self.port_navigation = None;
+            } else {
+                if observation.own_ship.docked_planet == Some(navigation.planet)
+                    && navigation.phase != PortNavigationPhase::Depart
+                {
+                    navigation.phase = PortNavigationPhase::Docked;
+                }
+                let completed = planet.is_some_and(|planet| match navigation.goal {
+                    BrainGoal::Capture => planet.owner == Some(observation.actor),
+                    BrainGoal::Rebuild => observation.own_ship.form == ShipForm::Ship,
+                    _ => false,
+                });
+                if navigation.phase == PortNavigationPhase::Docked && completed {
+                    navigation.phase = PortNavigationPhase::Depart;
+                }
+                self.port_navigation = Some(navigation);
+            }
+        }
+
+        if self.port_navigation.is_none() {
+            self.port_navigation = self.select_port_navigation(observation);
+        }
+
+        let Some(mut navigation) = self.port_navigation else {
+            return;
+        };
+        let Some(planet) = observation
+            .planets
+            .iter()
+            .find(|planet| planet.id == navigation.planet)
+        else {
+            return;
+        };
+        let clearance =
+            observation.own_ship.collision_radius + self.config.spaceport_staging_margin;
+        let target = match navigation.phase {
+            PortNavigationPhase::Rendezvous => {
+                let ship_from_center = -planet.local_position;
+                planet.moving_surface_approach(ship_from_center, clearance)
+            }
+            PortNavigationPhase::Approach => planet.spaceport_approach(clearance),
+            _ => return,
+        };
+        if target.local_position.length() <= self.config.spaceport_staging_tolerance
+            && target.local_velocity.length() <= self.config.spaceport_staging_velocity_tolerance
+        {
+            navigation.phase = match navigation.phase {
+                PortNavigationPhase::Rendezvous => PortNavigationPhase::Approach,
+                PortNavigationPhase::Approach => PortNavigationPhase::Ingress,
+                _ => unreachable!(),
+            };
+            self.port_navigation = Some(navigation);
+        }
+    }
+
+    fn port_corridor_contains_ship(
+        &self,
+        observation: &ShipObservationV1,
+        planet: &PlanetObservationV1,
+    ) -> bool {
+        let clearance =
+            observation.own_ship.collision_radius + self.config.spaceport_staging_margin;
+        let approach = planet.spaceport_approach(clearance);
+        let ship_from_center = -planet.local_position;
+        let axial_distance = ship_from_center.dot(approach.local_outward);
+        let lateral_distance =
+            (ship_from_center - approach.local_outward * axial_distance).length();
+        let port_radius = (planet.local_spaceport_position - planet.local_position).length();
+        axial_distance >= port_radius - observation.own_ship.collision_radius * 2.0
+            && lateral_distance <= self.config.spaceport_corridor_half_width
+    }
+
+    fn body_avoidance(
+        &self,
+        observation: &ShipObservationV1,
+        port_navigation: Option<PortNavigation>,
+    ) -> Option<Vec2> {
         let mut nearest: Option<(f32, Vec2)> = None;
-        let mut consider = |position: Vec2, velocity: Vec2, radius: f32| {
+        let mut consider = |position: Vec2, velocity: Vec2, radius: f32, clearance: f32| {
             let surface_distance =
                 position.length() - radius - observation.own_ship.collision_radius;
             let closing = position.dot(velocity) < 0.0;
-            if surface_distance > self.config.body_clearance
-                || (!closing && surface_distance > self.config.body_clearance * 0.35)
-            {
+            if surface_distance > clearance || (!closing && surface_distance > clearance * 0.35) {
                 return;
             }
             if nearest.is_none_or(|(distance, _)| surface_distance < distance) {
@@ -251,10 +577,32 @@ impl RuleShipBrain {
         };
 
         if let Some(sun) = observation.sun {
-            consider(sun.local_position, sun.local_velocity, sun.radius);
+            consider(
+                sun.local_position,
+                sun.local_velocity,
+                sun.radius,
+                self.config.body_clearance,
+            );
         }
         for planet in &observation.planets {
-            consider(planet.local_position, planet.local_velocity, planet.radius);
+            let clearance = if let Some(navigation) =
+                port_navigation.filter(|navigation| navigation.planet == planet.id)
+            {
+                if navigation.phase != PortNavigationPhase::Rendezvous
+                    && self.port_corridor_contains_ship(observation, planet)
+                {
+                    continue;
+                }
+                self.config.spaceport_staging_margin
+            } else {
+                self.config.body_clearance
+            };
+            consider(
+                planet.local_position,
+                planet.local_velocity,
+                planet.radius,
+                clearance,
+            );
         }
         nearest.map(|(_, direction)| direction)
     }
@@ -267,7 +615,16 @@ impl RuleShipBrain {
         hazard: Option<DebrisId>,
     ) -> ShipIntent {
         let heading = guide_heading(direction, observation.own_ship.angular_velocity);
-        self.set_telemetry(goal, None, hazard, direction.length(), heading);
+        let navigation = self.port_navigation;
+        self.set_telemetry(BrainTelemetry {
+            goal,
+            target_planet: navigation.map(|navigation| navigation.planet),
+            port_phase: navigation.map(|navigation| navigation.phase),
+            hazard,
+            target_distance: direction.length(),
+            heading_error: heading.error_radians,
+            ..BrainTelemetry::default()
+        });
         ShipIntent {
             turn: heading.turn,
             thrust: if heading.error_radians.abs() < 0.65 {
@@ -283,12 +640,174 @@ impl RuleShipBrain {
             ..ShipIntent::default()
         }
     }
+
+    fn docked_intent(
+        &mut self,
+        observation: &ShipObservationV1,
+        navigation: PortNavigation,
+    ) -> ShipIntent {
+        let heading = guide_heading(Vec2::Y, observation.own_ship.angular_velocity);
+        self.set_telemetry(BrainTelemetry {
+            goal: navigation.goal,
+            target_planet: Some(navigation.planet),
+            port_phase: Some(PortNavigationPhase::Docked),
+            heading_error: heading.error_radians,
+            ..BrainTelemetry::default()
+        });
+        ShipIntent::default()
+    }
+
+    fn port_navigation_intent(
+        &mut self,
+        observation: &ShipObservationV1,
+        navigation: PortNavigation,
+        planet: PlanetObservationV1,
+    ) -> ShipIntent {
+        if navigation.phase == PortNavigationPhase::Docked {
+            return self.docked_intent(observation, navigation);
+        }
+
+        let clearance =
+            observation.own_ship.collision_radius + self.config.spaceport_staging_margin;
+        let approach = planet.spaceport_approach(clearance);
+        let rendezvous = planet.moving_surface_approach(-planet.local_position, clearance);
+        if navigation.phase == PortNavigationPhase::Depart {
+            let surface_clearance = planet.local_position.length()
+                - planet.radius
+                - observation.own_ship.collision_radius;
+            let departure_clearance = self
+                .config
+                .body_clearance
+                .max(self.config.spaceport_staging_margin);
+            let cleared = observation.own_ship.docked_planet != Some(navigation.planet)
+                && surface_clearance >= departure_clearance;
+            if cleared {
+                self.port_navigation = None;
+            }
+            let heading = guide_heading(
+                approach.local_outward,
+                observation.own_ship.angular_velocity,
+            );
+            let launch_aligned =
+                heading.error_radians.abs() <= self.config.spaceport_departure_alignment_radians;
+            let departure_burn_started = navigation.departure_burn_started || launch_aligned;
+            if !cleared && departure_burn_started != navigation.departure_burn_started {
+                self.port_navigation = Some(PortNavigation {
+                    departure_burn_started,
+                    ..navigation
+                });
+            }
+            self.set_telemetry(BrainTelemetry {
+                goal: navigation.goal,
+                target_planet: Some(navigation.planet),
+                port_phase: Some(navigation.phase),
+                target_distance: (departure_clearance - surface_clearance).max(0.0),
+                heading_error: heading.error_radians,
+                desired_speed: self.config.spaceport_departure_speed,
+                relative_speed: approach.local_velocity.length(),
+                ..BrainTelemetry::default()
+            });
+            return ShipIntent {
+                turn: heading.turn,
+                thrust: if departure_burn_started { 1.0 } else { 0.0 },
+                brake: if departure_burn_started { 0.0 } else { 1.0 },
+                wings_closed: observation.own_ship.form == ShipForm::Ship && departure_burn_started,
+                ..ShipIntent::default()
+            };
+        }
+        let (target_position, target_velocity, max_closing_speed, position_tolerance) =
+            match navigation.phase {
+                PortNavigationPhase::Rendezvous => (
+                    rendezvous.local_position,
+                    rendezvous.local_velocity,
+                    self.config.spaceport_approach_speed,
+                    self.config.spaceport_staging_tolerance,
+                ),
+                PortNavigationPhase::Approach => (
+                    approach.local_position,
+                    approach.local_velocity,
+                    self.config.spaceport_approach_speed,
+                    self.config.spaceport_staging_tolerance,
+                ),
+                PortNavigationPhase::Ingress => (
+                    planet.local_spaceport_position,
+                    planet.local_spaceport_velocity,
+                    self.config.spaceport_ingress_speed,
+                    observation.own_ship.collision_radius.max(3.0),
+                ),
+                PortNavigationPhase::Docked | PortNavigationPhase::Depart => unreachable!(),
+            };
+        let guidance = guide_arrival(
+            target_position,
+            target_velocity,
+            observation.own_ship.local_velocity,
+            observation.own_ship.angular_velocity,
+            ArrivalGuidanceConfig {
+                max_closing_speed,
+                arrival_time_seconds: if navigation.phase == PortNavigationPhase::Ingress {
+                    1.0
+                } else {
+                    1.5
+                },
+                position_tolerance,
+                velocity_tolerance: if navigation.phase == PortNavigationPhase::Ingress {
+                    12.0
+                } else {
+                    self.config.spaceport_staging_velocity_tolerance
+                },
+                full_control_velocity_error: if observation.own_ship.form == ShipForm::EscapePod {
+                    120.0
+                } else {
+                    30.0
+                },
+                thrust_alignment_radians: match navigation.phase {
+                    PortNavigationPhase::Rendezvous => 1.4,
+                    PortNavigationPhase::Approach => 1.5,
+                    _ => 0.5,
+                },
+            },
+        );
+
+        self.set_telemetry(BrainTelemetry {
+            goal: navigation.goal,
+            target_planet: Some(navigation.planet),
+            port_phase: Some(navigation.phase),
+            target_distance: guidance.target_distance,
+            heading_error: guidance.heading.error_radians,
+            desired_speed: guidance.desired_closing_speed,
+            relative_speed: guidance.relative_speed,
+            ..BrainTelemetry::default()
+        });
+
+        let wings_closed = observation.own_ship.form == ShipForm::Ship
+            && navigation.phase == PortNavigationPhase::Rendezvous
+            && guidance.target_distance > self.config.spaceport_cruise_distance
+            && guidance.heading.error_radians.abs() < 0.12;
+        let (thrust, brake) = if observation.own_ship.form == ShipForm::EscapePod {
+            if guidance.thrust >= 0.75 {
+                (1.0, 0.0)
+            } else {
+                (0.0, 1.0)
+            }
+        } else {
+            (guidance.thrust, guidance.brake)
+        };
+        ShipIntent {
+            turn: guidance.heading.turn,
+            thrust,
+            brake,
+            wings_closed,
+            ..ShipIntent::default()
+        }
+        .normalized()
+    }
 }
 
 impl ShipBrain for RuleShipBrain {
     fn reset(&mut self, reset: BrainReset) {
         self.actor = Some(reset.actor);
         self.episode_seed = reset.episode_seed;
+        self.port_navigation = None;
         self.telemetry = BrainTelemetry {
             actor: self.actor,
             ..BrainTelemetry::default()
@@ -304,7 +823,29 @@ impl ShipBrain for RuleShipBrain {
             return ShipIntent::default();
         }
 
-        if let Some(direction) = self.body_avoidance(observation) {
+        self.refresh_port_navigation(observation);
+        match self.port_navigation {
+            Some(navigation) if navigation.phase == PortNavigationPhase::Docked => {
+                return self.docked_intent(observation, navigation);
+            }
+            Some(navigation) if navigation.phase == PortNavigationPhase::Depart => {
+                if let Some(planet) = observation
+                    .planets
+                    .iter()
+                    .find(|planet| planet.id == navigation.planet)
+                    .copied()
+                {
+                    // A ship inside the planet must follow the known-safe port
+                    // corridor. Generic body and hazard avoidance can point it
+                    // into the cavity wall or cancel the launch burn.
+                    return self.port_navigation_intent(observation, navigation, planet);
+                }
+                self.port_navigation = None;
+            }
+            _ => {}
+        }
+
+        if let Some(direction) = self.body_avoidance(observation, self.port_navigation) {
             return self.avoidance_intent(observation, direction, BrainGoal::AvoidBody, None);
         }
 
@@ -322,6 +863,18 @@ impl ShipBrain for RuleShipBrain {
             );
         }
 
+        if let Some(navigation) = self.port_navigation {
+            if let Some(planet) = observation
+                .planets
+                .iter()
+                .find(|planet| planet.id == navigation.planet)
+                .copied()
+            {
+                return self.port_navigation_intent(observation, navigation, planet);
+            }
+            self.port_navigation = None;
+        }
+
         let Some(opponent) = observation.opponent.filter(|opponent| !opponent.eliminated) else {
             self.telemetry = BrainTelemetry {
                 actor: self.actor,
@@ -336,20 +889,19 @@ impl ShipBrain for RuleShipBrain {
                 -opponent.local_position,
                 observation.own_ship.angular_velocity,
             );
-            self.set_telemetry(
-                BrainGoal::Survive,
-                Some(opponent.id),
-                None,
-                opponent.local_position.length(),
-                heading,
-            );
+            self.set_telemetry(BrainTelemetry {
+                goal: BrainGoal::Survive,
+                target: Some(opponent.id),
+                target_distance: opponent.local_position.length(),
+                heading_error: heading.error_radians,
+                relative_speed: opponent.local_velocity.length(),
+                ..BrainTelemetry::default()
+            });
+            let aligned = heading.error_radians.abs() < 0.65;
             return ShipIntent {
                 turn: heading.turn,
-                thrust: if heading.error_radians.abs() < 0.65 {
-                    1.0
-                } else {
-                    0.0
-                },
+                thrust: if aligned { 1.0 } else { 0.0 },
+                brake: if aligned { 0.0 } else { 1.0 },
                 ..ShipIntent::default()
             };
         }
@@ -368,13 +920,14 @@ impl ShipBrain for RuleShipBrain {
             distance > self.config.fast_pursuit_distance && heading.error_radians.abs() < 0.12;
         let weapon_aligned = heading.error_radians.abs() < 0.08;
 
-        self.set_telemetry(
-            BrainGoal::Attack,
-            Some(opponent.id),
-            None,
-            distance,
-            heading,
-        );
+        self.set_telemetry(BrainTelemetry {
+            goal: BrainGoal::Attack,
+            target: Some(opponent.id),
+            target_distance: distance,
+            heading_error: heading.error_radians,
+            relative_speed: opponent.local_velocity.length(),
+            ..BrainTelemetry::default()
+        });
         ShipIntent {
             turn: heading.turn,
             thrust: if should_advance { 1.0 } else { 0.0 },
@@ -436,6 +989,54 @@ mod tests {
     }
 
     #[test]
+    fn arrival_guidance_accelerates_toward_a_distant_stationary_target() {
+        let guidance = guide_arrival(
+            Vec2::new(0.0, 300.0),
+            Vec2::ZERO,
+            Vec2::ZERO,
+            0.0,
+            ArrivalGuidanceConfig::default(),
+        );
+
+        assert_close(guidance.desired_closing_speed, 120.0);
+        assert_close(guidance.heading.error_radians, 0.0);
+        assert_close(guidance.thrust, 1.0);
+        assert_close(guidance.brake, 0.0);
+        assert!(!guidance.arrived);
+    }
+
+    #[test]
+    fn arrival_guidance_brakes_when_closing_faster_than_requested() {
+        let guidance = guide_arrival(
+            Vec2::new(0.0, 50.0),
+            Vec2::new(0.0, -100.0),
+            Vec2::new(0.0, 100.0),
+            0.0,
+            ArrivalGuidanceConfig::default(),
+        );
+
+        assert!(guidance.closing_speed > guidance.desired_closing_speed);
+        assert_close(guidance.thrust, 0.0);
+        assert!(guidance.brake > 0.0);
+    }
+
+    #[test]
+    fn arrival_guidance_accepts_a_position_and_velocity_match() {
+        let guidance = guide_arrival(
+            Vec2::new(2.0, -1.0),
+            Vec2::ZERO,
+            Vec2::new(40.0, 10.0),
+            0.25,
+            ArrivalGuidanceConfig::default(),
+        );
+
+        assert!(guidance.arrived);
+        assert_close(guidance.thrust, 0.0);
+        assert_close(guidance.brake, 0.0);
+        assert!(guidance.heading.turn < 0.0);
+    }
+
+    #[test]
     fn aligned_distant_target_uses_thrust_and_fast_pursuit() {
         let mut config = SpacewarsConfig::deathmatch();
         config.asteroid_probability_per_sec = 0.0;
@@ -487,6 +1088,111 @@ mod tests {
 
         assert_eq!(intent.thrust, 0.0);
         assert_eq!(intent.brake, 1.0);
+    }
+
+    #[test]
+    fn escape_pod_selects_an_owned_spaceport_for_rebuild() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 19);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.own_ship.form = ShipForm::EscapePod;
+        observation.sun = None;
+        observation.hazards.clear();
+        for (index, planet) in observation.planets.iter_mut().enumerate() {
+            planet.owner = None;
+            let offset = Vec2::new(2_000.0 + index as f32 * 200.0, 2_000.0);
+            let port_axis = (planet.local_spaceport_position - planet.local_position).normalized();
+            planet.local_position = offset;
+            planet.local_spaceport_position = offset + port_axis * planet.radius * 0.7;
+            planet.local_velocity = Vec2::ZERO;
+            planet.local_spaceport_velocity = Vec2::ZERO;
+        }
+        observation.planets[1].owner = Some(PlayerId::PLAYER_2);
+        let expected_planet = observation.planets[1].id;
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let intent = brain.intent(&observation);
+
+        assert_eq!(brain.telemetry().goal, BrainGoal::Rebuild);
+        assert_eq!(brain.telemetry().target_planet, Some(expected_planet));
+        assert_eq!(
+            brain.telemetry().port_phase,
+            Some(PortNavigationPhase::Rendezvous)
+        );
+        assert!(!intent.laser);
+        assert!(!intent.cannon);
+    }
+
+    #[test]
+    fn unexpected_docking_contact_overrides_the_planned_planet() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 0);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        let planned_planet = observation.planets[0].id;
+        let docked_planet = observation.planets[1].id;
+        observation.own_ship.docked_planet = Some(docked_planet);
+        observation.planets[1].owner = Some(PlayerId::PLAYER_2);
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        brain.port_navigation = Some(PortNavigation {
+            goal: BrainGoal::Capture,
+            planet: planned_planet,
+            phase: PortNavigationPhase::Rendezvous,
+            departure_burn_started: false,
+        });
+
+        brain.intent(&observation);
+
+        assert_eq!(brain.telemetry().target_planet, Some(docked_planet));
+        assert_eq!(
+            brain.telemetry().port_phase,
+            Some(PortNavigationPhase::Depart)
+        );
+
+        observation.planets[1].owner = None;
+        let mut capture_brain = RuleShipBrain::default();
+        capture_brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        capture_brain.port_navigation = Some(PortNavigation {
+            goal: BrainGoal::Capture,
+            planet: planned_planet,
+            phase: PortNavigationPhase::Rendezvous,
+            departure_burn_started: false,
+        });
+
+        let intent = capture_brain.intent(&observation);
+
+        assert_eq!(capture_brain.telemetry().target_planet, Some(docked_planet));
+        assert_eq!(
+            capture_brain.telemetry().port_phase,
+            Some(PortNavigationPhase::Docked)
+        );
+        assert_eq!(intent, ShipIntent::default());
     }
 
     #[test]
@@ -567,5 +1273,295 @@ mod tests {
 
         assert!(state.ships[0].life < starting_life);
         assert_eq!(brain.telemetry().goal, BrainGoal::Attack);
+    }
+
+    #[test]
+    fn rule_brain_arrives_at_a_moving_spaceport_and_captures_a_planet() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            use_starfield: false,
+            use_sounds: false,
+            ..SpacewarsConfig::default()
+        };
+        let mut state = SpacewarsScenario::init(config, 17);
+        state.planets[0].owner_id = Some(PlayerId::PLAYER_1.index());
+        state.players[0].planet_count = 1;
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        let mut encoder = ShipIntentEncoder::default();
+        let mut saw_ingress = false;
+        let mut saw_docked = false;
+        let mut saw_depart = false;
+        let mut saw_next_target = false;
+        let mut captured_planet = None;
+        let mut minimum_target_distance = f32::INFINITY;
+
+        for _ in 0..7_200 {
+            let observation = SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap();
+            let intent = brain.intent(&observation);
+            let telemetry = brain.telemetry();
+            minimum_target_distance = minimum_target_distance.min(telemetry.target_distance);
+            if let Some(captured_planet) = captured_planet {
+                saw_depart |= telemetry.target_planet == Some(captured_planet)
+                    && telemetry.port_phase == Some(PortNavigationPhase::Depart);
+                saw_next_target |= saw_depart
+                    && telemetry.target_planet.is_some()
+                    && telemetry.target_planet != Some(captured_planet)
+                    && telemetry.port_phase == Some(PortNavigationPhase::Rendezvous);
+            }
+            saw_ingress |= telemetry.port_phase == Some(PortNavigationPhase::Ingress);
+            saw_docked |= telemetry.port_phase == Some(PortNavigationPhase::Docked);
+            let actions = encoder.encode(PlayerId::PLAYER_2.index(), intent);
+            SpacewarsScenario::step(&mut state, &actions, DT);
+            if captured_planet.is_none() {
+                captured_planet = state
+                    .planets
+                    .iter()
+                    .enumerate()
+                    .find_map(|(index, planet)| {
+                        if planet.owner_id == Some(PlayerId::PLAYER_2.index()) {
+                            PlanetId::from_index(index)
+                        } else {
+                            None
+                        }
+                    });
+            }
+            if saw_next_target {
+                break;
+            }
+        }
+
+        assert!(
+            saw_ingress,
+            "brain never advanced from staging to ingress; minimum distance {minimum_target_distance}; final telemetry: {:?}; ship position {:?}; velocity {:?}",
+            brain.telemetry(),
+            state.ships[1].position,
+            state.ships[1].velocity,
+        );
+        assert!(saw_docked, "brain never established a spaceport contact");
+        assert!(
+            captured_planet.is_some(),
+            "brain did not capture a planet; final telemetry: {:?}",
+            brain.telemetry()
+        );
+        assert!(saw_depart, "brain did not depart after capture");
+        assert!(
+            saw_next_target,
+            "brain did not select another uncaptured planet after departure; final telemetry: {:?}",
+            brain.telemetry()
+        );
+    }
+
+    #[test]
+    fn rule_brain_captures_and_departs_across_multiple_generated_worlds() {
+        for seed in [0, 3, 29, 47] {
+            let mut config = SpacewarsConfig {
+                asteroid_probability_per_sec: 0.0,
+                use_starfield: false,
+                use_sounds: false,
+                ..SpacewarsConfig::default()
+            };
+            for player in &mut config.players {
+                player.health_percent = 100_000;
+            }
+            let mut state = SpacewarsScenario::init(config, seed);
+            state.planets[0].owner_id = Some(PlayerId::PLAYER_1.index());
+            state.players[0].planet_count = 1;
+            let mut brain = RuleShipBrain::default();
+            brain.reset(BrainReset {
+                actor: PlayerId::PLAYER_2,
+                episode_seed: state.seed,
+            });
+            let mut encoder = ShipIntentEncoder::default();
+            let mut captured_planet = None;
+            let mut saw_depart = false;
+            let mut saw_launch_burn = false;
+            let mut saw_safe_clearance = false;
+            let mut saw_next_target = false;
+
+            for _ in 0..7_200 {
+                let observation = SpacewarsScenario::observe_ship(
+                    &state,
+                    PlayerId::PLAYER_2,
+                    ShipSensorProfile::FullMapRadar,
+                )
+                .unwrap();
+                let intent = brain.intent(&observation);
+                let telemetry = brain.telemetry();
+                if let Some(captured_planet) = captured_planet {
+                    saw_depart |= telemetry.target_planet == Some(captured_planet)
+                        && telemetry.port_phase == Some(PortNavigationPhase::Depart);
+                    saw_launch_burn |= telemetry.target_planet == Some(captured_planet)
+                        && telemetry.port_phase == Some(PortNavigationPhase::Depart)
+                        && intent.wings_closed
+                        && intent.thrust > 0.0;
+                    let selected_next_target = saw_depart
+                        && telemetry.target_planet.is_some()
+                        && telemetry.target_planet != Some(captured_planet)
+                        && telemetry.port_phase == Some(PortNavigationPhase::Rendezvous);
+                    if selected_next_target {
+                        let captured = observation
+                            .planets
+                            .iter()
+                            .find(|planet| planet.id == captured_planet)
+                            .expect("captured planet remains observable");
+                        let surface_clearance = captured.local_position.length()
+                            - captured.radius
+                            - observation.own_ship.collision_radius;
+                        saw_safe_clearance = observation.own_ship.docked_planet
+                            != Some(captured_planet)
+                            && surface_clearance >= brain.config.body_clearance;
+                        saw_next_target = true;
+                    }
+                }
+                let actions = encoder.encode(PlayerId::PLAYER_2.index(), intent);
+                SpacewarsScenario::step(&mut state, &actions, DT);
+                if captured_planet.is_none() {
+                    captured_planet =
+                        state
+                            .planets
+                            .iter()
+                            .enumerate()
+                            .find_map(|(index, planet)| {
+                                if planet.owner_id == Some(PlayerId::PLAYER_2.index()) {
+                                    PlanetId::from_index(index)
+                                } else {
+                                    None
+                                }
+                            });
+                }
+                if saw_next_target {
+                    break;
+                }
+            }
+            assert!(
+                captured_planet.is_some(),
+                "brain did not capture a planet for seed {seed}; final telemetry: {:?}",
+                brain.telemetry()
+            );
+            assert!(
+                saw_depart,
+                "brain did not begin departure for seed {seed}; final telemetry: {:?}",
+                brain.telemetry()
+            );
+            assert!(
+                saw_launch_burn,
+                "brain did not commit a wings-closed launch for seed {seed}; final telemetry: {:?}",
+                brain.telemetry()
+            );
+            assert!(
+                saw_safe_clearance,
+                "brain selected its next target before safely clearing the captured planet for seed {seed}"
+            );
+            assert!(
+                saw_next_target,
+                "brain did not physically depart for seed {seed}; final telemetry: {:?}; ship position {:?}; velocity {:?}",
+                brain.telemetry(),
+                state.ships[1].position,
+                state.ships[1].velocity,
+            );
+            assert_eq!(state.winner, None, "seed {seed} ended before departure");
+        }
+    }
+
+    #[test]
+    fn rule_brain_repeats_the_capture_cycle_in_seed_zero_world() {
+        let mut config = SpacewarsConfig {
+            universe_radius: 3_200,
+            asteroid_probability_per_sec: 0.0,
+            use_starfield: false,
+            use_sounds: false,
+            ..SpacewarsConfig::default()
+        };
+        for player in &mut config.players {
+            player.health_percent = 100_000;
+        }
+        let mut state = SpacewarsScenario::init(config, 0);
+        state.planets[0].owner_id = Some(PlayerId::PLAYER_1.index());
+        state.players[0].planet_count = 1;
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        let mut encoder = ShipIntentEncoder::default();
+        let mut final_observation = None;
+        let mut trace = Vec::new();
+        let mut last_signature = None;
+
+        for _ in 0..21_600 {
+            let observation = SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap();
+            let intent = brain.intent(&observation);
+            let telemetry = brain.telemetry();
+            let signature = (
+                telemetry.goal,
+                telemetry.target_planet,
+                telemetry.port_phase,
+                observation.own_ship.docked_planet,
+                intent.wings_closed,
+            );
+            if last_signature != Some(signature) {
+                let dock_geometry = observation.own_ship.docked_planet.and_then(|docked| {
+                    observation
+                        .planets
+                        .iter()
+                        .find(|planet| planet.id == docked)
+                        .map(|planet| {
+                            (
+                                planet.id,
+                                planet.local_position.length()
+                                    - planet.radius
+                                    - observation.own_ship.collision_radius,
+                                planet.local_spaceport_position.length(),
+                            )
+                        })
+                });
+                trace.push(format!(
+                    "tick={} planets={} goal={:?} target={:?} phase={:?} docked={:?} dock_geometry={dock_geometry:?} intent={intent:?}",
+                    state.tick,
+                    state.players[PlayerId::PLAYER_2.index()].planet_count,
+                    telemetry.goal,
+                    telemetry.target_planet,
+                    telemetry.port_phase,
+                    observation.own_ship.docked_planet,
+                ));
+                last_signature = Some(signature);
+            }
+            let actions = encoder.encode(PlayerId::PLAYER_2.index(), intent);
+            SpacewarsScenario::step(&mut state, &actions, DT);
+            final_observation = Some(observation);
+            if state.players[PlayerId::PLAYER_2.index()].planet_count >= 3 {
+                break;
+            }
+        }
+
+        let observation = final_observation.expect("simulation produced an observation");
+        let telemetry = brain.telemetry();
+        let target_planet = telemetry.target_planet.and_then(|target| {
+            observation
+                .planets
+                .iter()
+                .find(|planet| planet.id == target)
+        });
+        assert!(
+            state.players[PlayerId::PLAYER_2.index()].planet_count >= 3,
+            "brain did not complete three captures; final telemetry: {telemetry:?}; own ship: {:?}; target planet: {target_planet:?}; winner: {:?}; trace:\n{}",
+            observation.own_ship,
+            state.winner,
+            trace.join("\n"),
+        );
     }
 }

--- a/docs/design/ship-ai.md
+++ b/docs/design/ship-ai.md
@@ -77,18 +77,40 @@ The first deterministic bot is selectable for Player 2 in the launcher. It:
 - avoids nearby celestial bodies and predicted debris collisions;
 - uses reusable shortest-heading and moving-target intercept guidance;
 - approaches and brakes around a one-on-one target;
+- derives a collision-free staging point and exact rigid-frame velocity from
+  each moving spaceport observation;
+- uses persistent rendezvous, port-approach, ingress, docked, and departure
+  phases to capture uncaptured planets and then continue to another target;
+- aligns with the moving spaceport before committing to a wings-closed launch
+  burn, keeping that burn active until both port contact and the planetary
+  surface are safely cleared;
+- treats a sensed docking contact as authoritative over its planned target,
+  capturing an unexpected unowned port or relaunching from an owned one;
+- seeks an owned spaceport for rebuilding when reduced to an escape pod;
 - uses fast wings only for long, aligned pursuit;
 - fires laser/cannon only inside configured alignment and range windows;
-- falls back to simple escape behavior when reduced to a pod.
+- falls back to simple escape behavior when a pod has no accessible port.
 
-It intentionally does not choose planets, dock, or run a capture strategy yet.
-Small Duel is the clearest play-test configuration.
+The port arrival controller first reaches a safe moving ring around the target
+planet, then tracks the port around that ring. At each target it chooses a
+bounded desired closing velocity and steers toward the error between that
+velocity and the craft's current target-relative velocity. The ordinary brake
+is used only when braking would reduce that error. Entry and departure are
+deliberately different maneuvers: entry matches the rotating port, while
+departure commits to an outward burn until the hull has safe surface
+clearance.
+
+This is still a narrow deterministic strategy. It does not yet score capture,
+repair, defend, and attack goals against each other or use personality weights.
+Small Duel remains the clearest combat test; a normal planet world exercises
+the docking path.
 
 ## Next slices
 
-1. Add moving-spaceport arrival/docking guidance and deterministic guidance
-   fixtures.
-2. Add a slower strategic state machine for capture, repair, and combat goals.
+1. Add a slower strategic state machine for capture, repair, defend, and combat
+   goals, including commitment and hysteresis.
+2. Add deterministic repair and full escape-pod rebuild episodes around the
+   moving-spaceport fixture.
 3. Surface brain telemetry in developer HUD/IPC tooling.
 4. Let `engine-agent` run the same observation/brain/action loop headlessly.
 5. Add policy adapters and batched observation storage only after the rule path

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -72,6 +72,7 @@ const SPACEPORT_DEPTH_FACTOR: f32 = 0.4;
 const SPACEPORT_MAX_ARC_ANGLE: f32 = 2.7488937;
 const SPACEPORT_OUTER_POINTS: usize = 15;
 const SPACEPORT_INNER_POINTS: usize = 7;
+const SPACEPORT_APPROACH_EPSILON: f32 = 1.0e-5;
 const SPACEPORT_DAMPING: f32 = 0.94;
 const SPACEPORT_PULL_SCALE: f32 = 3.0;
 const FLAG_CENTER_RADIUS: f32 = 6.0;
@@ -808,6 +809,76 @@ pub struct PlanetObservationV1 {
     pub capture_progress: f32,
     pub local_spaceport_position: Vec2,
     pub local_spaceport_velocity: Vec2,
+}
+
+/// A collision-free staging point on a spaceport's outward axis.
+///
+/// The position and velocity use the same actor-local frame as the containing
+/// [`ShipObservationV1`]. The velocity is extrapolated along the rotating
+/// planet wrapper, so a controller can match a moving approach point without
+/// knowing the scenario's orbit or wrapper implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SpaceportApproachObservationV1 {
+    pub local_position: Vec2,
+    pub local_velocity: Vec2,
+    pub local_outward: Vec2,
+}
+
+impl PlanetObservationV1 {
+    /// Derive a safe staging point outside the planet on its spaceport axis.
+    ///
+    /// `clearance` is measured outward from the planet surface. Callers can
+    /// include their collision radius and a policy-specific maneuver margin.
+    pub fn spaceport_approach(&self, clearance: f32) -> SpaceportApproachObservationV1 {
+        let port_offset = self.local_spaceport_position - self.local_position;
+        let port_radius = port_offset.length();
+        let local_outward = if port_radius > SPACEPORT_APPROACH_EPSILON {
+            port_offset / port_radius
+        } else {
+            Vec2::Y
+        };
+        self.moving_surface_approach(local_outward, clearance)
+    }
+
+    /// Derive a moving staging point on any outward axis around the planet.
+    ///
+    /// This is useful for first reaching a safe holding ring before tracking a
+    /// rotating spaceport. The returned velocity includes both center motion
+    /// and wrapper rotation inferred from the observed port motion.
+    pub fn moving_surface_approach(
+        &self,
+        local_outward: Vec2,
+        clearance: f32,
+    ) -> SpaceportApproachObservationV1 {
+        let port_offset = self.local_spaceport_position - self.local_position;
+        let port_radius_squared = port_offset.length_squared();
+        let fallback_outward = if port_radius_squared > SPACEPORT_APPROACH_EPSILON {
+            port_offset.normalized()
+        } else {
+            Vec2::Y
+        };
+        let local_outward = if local_outward.length_squared() > SPACEPORT_APPROACH_EPSILON {
+            local_outward.normalized()
+        } else {
+            fallback_outward
+        };
+        let approach_radius = self.radius + clearance.max(0.0);
+        let approach_offset = local_outward * approach_radius;
+        let port_velocity_delta = self.local_spaceport_velocity - self.local_velocity;
+        let wrapper_omega = if port_radius_squared > SPACEPORT_APPROACH_EPSILON {
+            (port_offset.x * port_velocity_delta.y - port_offset.y * port_velocity_delta.x)
+                / port_radius_squared
+        } else {
+            0.0
+        };
+        let wrapper_velocity = Vec2::new(-approach_offset.y, approach_offset.x) * wrapper_omega;
+
+        SpaceportApproachObservationV1 {
+            local_position: self.local_position + approach_offset,
+            local_velocity: self.local_velocity + wrapper_velocity,
+            local_outward,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -10833,6 +10904,52 @@ mod tests {
         assert_eq!(
             observation.hazards.last().unwrap().id.value(),
             10_000 - (SHIP_SENSOR_MAX_HAZARDS - 1) as u64
+        );
+    }
+
+    #[test]
+    fn ship_observation_derives_a_rigidly_moving_spaceport_approach() {
+        let mut state = init_default(29);
+        state.planets[0].wrapper_angle = 0.73;
+        state.planets[0].wrapper_omega = -0.41;
+        let ship = &state.ships[0];
+        let planet = &state.planets[0];
+        let frame = ShipObservationFrame::new(ship);
+        let clearance = 23.0;
+        let world_outward = (spaceport_center(planet) - planet.position).normalized();
+        let world_position = planet.position + world_outward * (planet.radius + clearance);
+        let expected_position = frame.position(world_position);
+        let expected_velocity =
+            frame.vector(planet_surface_velocity(planet, world_position) - ship.velocity);
+
+        let observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_1,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        let approach = observation.planets[0].spaceport_approach(clearance);
+
+        assert_vec_close(approach.local_position, expected_position);
+        assert_vec_close(approach.local_velocity, expected_velocity);
+        assert_vec_close(
+            approach.local_outward,
+            frame.vector(world_outward).normalized(),
+        );
+        assert_close(
+            (approach.local_position - observation.planets[0].local_position).length(),
+            planet.radius + clearance,
+        );
+
+        let local_outward = Vec2::new(-0.6, 0.8);
+        let holding = observation.planets[0].moving_surface_approach(local_outward, clearance);
+        let world_outward =
+            (frame.right * local_outward.x + frame.forward * local_outward.y).normalized();
+        let world_position = planet.position + world_outward * (planet.radius + clearance);
+        assert_vec_close(holding.local_position, frame.position(world_position));
+        assert_vec_close(
+            holding.local_velocity,
+            frame.vector(planet_surface_velocity(planet, world_position) - ship.velocity),
         );
     }
 


### PR DESCRIPTION
## Summary

- Extend typed ship observations with stable planet identities and moving-surface and spaceport navigation affordances.
- Add deterministic rendezvous, approach, ingress, docking, capture, rebuild, and departure behavior to the rule bot.
- Recover coherently from unexpected docking contacts and retain a safe launch burn until the ship clears the planet.
- Expose read-only live rule-bot telemetry through the local control socket status command.
- Keep gameplay running across ordinary desktop focus changes while still releasing keyboard and pointer input; genuine controller disconnects continue to pause safely.
- Update the AI design and operator documentation for the implemented behavior.

## Validation

- cargo +1.89.0 fmt --all -- --check
- cargo +1.89.0 test --workspace -q
- cargo +1.89.0 clippy -p spacewars-ai --all-targets --no-deps -- -D warnings
- cargo +1.89.0 build --release -p engine-client
- Live seed-0 session: the bot captured multiple planets, recovered from an escape pod at an owned port, and continued ticking with paused=false while the client was in the background.

Advances #14.
Closes #26.