### PR TITLE
Add deterministic agent evaluation and harden bot navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,9 +1461,11 @@ dependencies = [
  "clap",
  "engine-common",
  "engine-core",
- "scenario-null",
- "tracing",
- "tracing-subscriber",
+ "scenario-spacewars",
+ "serde",
+ "serde_json",
+ "sha2",
+ "spacewars-ai",
 ]
 
 [[package]]
@@ -5057,6 +5059,7 @@ dependencies = [
  "engine-common",
  "engine-core",
  "scenario-spacewars",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rapier2d = { version = "0.34", default-features = false, features = [
     "std",
 ] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 sha2 = "0.10"
 slint = { version = "1", default-features = false }
 slint-build = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ and change **Player 2** from **human** to **rule bot**. **Small Duel** is the
 clearest combat test bed. In worlds with planets, the bot selects uncaptured
 spaceports, matches their orbital and wrapper motion, captures them, and
 departs for another target; an escape pod instead seeks an owned port for
-rebuilding. The ordinary two-human setup remains the default.
+rebuilding. Pods treat the moving staging rings as geometric waypoints rather
+than trying to hover at ship-only velocity tolerances, and reacquire an owned
+port if contact is lost before the rebuild completes. The ordinary two-human
+setup remains the default.
 
 On Unix, query the latest live rule-bot and docking diagnostics through the
 client control socket:
@@ -118,9 +121,11 @@ client control socket:
 printf 'status\n' | socat - UNIX-CONNECT:/tmp/spacewars-control.sock
 ```
 
-The snapshot is refreshed once per second and includes the brain phase and
-intent, ship motion, target planet, actual docked planet, and surface/port
-clearance. This keeps diagnostic formatting out of the simulation hot path.
+The snapshot is refreshed once per second and includes the world seed, brain
+phase and intent, ship motion, target planet, actual docked planet, and
+surface/port clearance. During body avoidance it also identifies the sun or
+planet being avoided and reports the craft's signed surface clearance. This
+keeps diagnostic formatting out of the simulation hot path.
 
 ## Run headless AI episodes
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,72 @@ The snapshot is refreshed once per second and includes the brain phase and
 intent, ship motion, target planet, actual docked planet, and surface/port
 clearance. This keeps diagnostic formatting out of the simulation hot path.
 
+## Run headless AI episodes
+
+`engine-agent` embeds Spacewars directly and runs fixed-timestep controller
+episodes without a window, renderer, audio, or realtime pacing. Its defaults
+match the interactive AI setup: an idle Player 1 against the rule bot in the
+standard planet world.
+
+Run ten consecutive seeds and report aggregate outcomes and throughput:
+
+```sh
+cargo run --release -p engine-agent -- \
+  --seed 0 --episodes 10 --max-ticks 36000
+```
+
+Run rule-bot self-play in Small Duel and emit a versioned JSON report:
+
+```sh
+cargo run --release -p engine-agent -- \
+  --preset deathmatch --player-1 rule --player-2 rule \
+  --seed 0 --episodes 10 --output json > agent-report.json
+```
+
+Episode reports include the winner or tick-limit outcome, captures, ship
+losses, rebuilds, eliminations, collision incidents, docking/departure outcomes,
+final planet/form/health state, canonical action count, and a deterministic
+trace fingerprint. The batch summary adds winner counts and measured ticks and
+simulated seconds per wall second.
+`--seed-step` changes the interval between seeds; setting it to zero repeats
+the same seed for reproducibility or throughput measurements. Release builds
+are recommended whenever performance numbers matter.
+
+Run the checked-in navigation baseline with one stable command:
+
+```sh
+cargo run --release -p engine-agent -- --suite navigation-v1
+```
+
+`navigation-v1` fixes seeds 0 through 5, rule-brain self-play, 36,000 ticks per
+episode, no random asteroids, and very high ship health. Planet and ship
+collisions remain enabled and are measured, but they should not terminate a
+navigation episode. Body/ship contact metrics re-arm only after 30 quiet ticks,
+so a sustained or briefly flickering scrape counts as one incident. Docking
+metrics report contact entries and exits. A capture/rebuild departure succeeds
+only after the craft clears the planet surface by 90 world units beyond its
+collision hull.
+
+For ad hoc controlled runs, `--preset standard-no-asteroids` is identical to
+the standard world except that random asteroid spawning is disabled. The
+ordinary `standard` preset continues to match normal gameplay.
+
+Trace one controller's navigation decisions without changing the simulation:
+
+```sh
+cargo run --release -p engine-agent -- \
+  --preset navigation --seed 4 --player-1 rule --player-2 rule \
+  --trace-player 2
+```
+
+The event trace records brain/port transitions, captures, safe departures, and
+a five-second heartbeat while a captured departure remains unfinished. Each
+sample includes docking state, surface clearance, outward speed, world
+velocity, guidance telemetry, contacts, and the emitted intent. `--output json`
+includes the same structured events for offline comparison. Tracing is
+available on custom batches rather than named suites so the suite contract and
+its normal report size remain fixed.
+
 Falling and NES Library pass the d-pad, `A`, `B`, `Select`, and `Start` to the
 cartridge. Press `Start` + `Select` together for the host controls menu so a
 gamepad-only player can restart or return to the launcher. Keyboard equivalents

--- a/crates/engine-agent/Cargo.toml
+++ b/crates/engine-agent/Cargo.toml
@@ -13,7 +13,9 @@ path = "src/main.rs"
 [dependencies]
 engine-common = { workspace = true }
 engine-core = { workspace = true }
-scenario-null = { workspace = true }
+scenario-spacewars = { workspace = true }
+spacewars-ai = { workspace = true }
 clap = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/engine-agent/src/lib.rs
+++ b/crates/engine-agent/src/lib.rs
@@ -1,0 +1,1580 @@
+//! Deterministic, headless episode execution for Spacewars controllers.
+//!
+//! The evaluator owns authoritative scenario state for measurement, while
+//! controllers receive only typed observations and emit canonical actions.
+
+#![forbid(unsafe_code)]
+
+use std::{
+    fmt,
+    time::{Duration, Instant},
+};
+
+use engine_common::{Action, PointerPhase, Scenario};
+use engine_core::SpacewarsConfig;
+use scenario_spacewars::{
+    BodyCollision, BodyId, DebrisKind, LaserTarget, PlayerId, SPACEWARS_PLAYER_COUNT,
+    ShipCollision, ShipForm, ShipIntent, ShipIntentEncoder, ShipSensorProfile, SpacewarsScenario,
+    SpacewarsState,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use spacewars_ai::{
+    BrainGoal, BrainReset, BrainTelemetry, PortNavigationPhase, RULE_SHIP_BRAIN_POLICY_ID,
+    RuleShipBrain, ShipBrain,
+};
+
+pub const REPORT_SCHEMA_VERSION: u32 = 1;
+pub const NAVIGATION_V1_SUITE_ID: &str = "navigation_v1";
+pub const NAVIGATION_V1_SEEDS: [u64; 6] = [0, 1, 2, 3, 4, 5];
+pub const NAVIGATION_V1_MAX_TICKS: u64 = 36_000;
+const NAVIGATION_HEALTH_PERCENT: u32 = 100_000;
+const NAVIGATION_SAFE_DEPARTURE_CLEARANCE: f32 = 90.0;
+const CONTACT_INCIDENT_REARM_TICKS: u64 = 30;
+const NAVIGATION_TRACE_HEARTBEAT_TICKS: u64 = 300;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControllerKind {
+    Idle,
+    Rule,
+}
+
+impl ControllerKind {
+    pub const fn policy_id(self) -> &'static str {
+        match self {
+            Self::Idle => "idle_v1",
+            Self::Rule => RULE_SHIP_BRAIN_POLICY_ID,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpacewarsPreset {
+    Standard,
+    StandardNoAsteroids,
+    Navigation,
+    Deathmatch,
+}
+
+impl SpacewarsPreset {
+    fn config(self) -> SpacewarsConfig {
+        match self {
+            Self::Standard => SpacewarsConfig::default(),
+            Self::StandardNoAsteroids => SpacewarsConfig {
+                asteroid_probability_per_sec: 0.0,
+                ..SpacewarsConfig::default()
+            },
+            Self::Navigation => {
+                let mut config = Self::StandardNoAsteroids.config();
+                for player in &mut config.players {
+                    player.health_percent = NAVIGATION_HEALTH_PERCENT;
+                }
+                config
+            }
+            Self::Deathmatch => SpacewarsConfig::deathmatch(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvaluationSuite {
+    NavigationV1,
+}
+
+impl EvaluationSuite {
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::NavigationV1 => NAVIGATION_V1_SUITE_ID,
+        }
+    }
+
+    pub fn episode_configs(self) -> Vec<EpisodeConfig> {
+        match self {
+            Self::NavigationV1 => NAVIGATION_V1_SEEDS
+                .into_iter()
+                .map(|seed| EpisodeConfig {
+                    seed,
+                    preset: SpacewarsPreset::Navigation,
+                    controllers: [ControllerKind::Rule; SPACEWARS_PLAYER_COUNT],
+                    max_ticks: NAVIGATION_V1_MAX_TICKS,
+                    trace_player: None,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ControllerDescriptor {
+    pub kind: ControllerKind,
+    pub policy_id: &'static str,
+}
+
+impl From<ControllerKind> for ControllerDescriptor {
+    fn from(kind: ControllerKind) -> Self {
+        Self {
+            kind,
+            policy_id: kind.policy_id(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EpisodeConfig {
+    pub seed: u64,
+    pub preset: SpacewarsPreset,
+    pub controllers: [ControllerKind; SPACEWARS_PLAYER_COUNT],
+    pub max_ticks: u64,
+    pub trace_player: Option<PlayerId>,
+}
+
+impl Default for EpisodeConfig {
+    fn default() -> Self {
+        Self {
+            seed: 0,
+            preset: SpacewarsPreset::Standard,
+            controllers: [ControllerKind::Idle, ControllerKind::Rule],
+            max_ticks: 36_000,
+            trace_player: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchConfig {
+    pub start_seed: u64,
+    pub seed_step: u64,
+    pub episodes: u32,
+    pub preset: SpacewarsPreset,
+    pub controllers: [ControllerKind; SPACEWARS_PLAYER_COUNT],
+    pub max_ticks: u64,
+    pub trace_player: Option<PlayerId>,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        let episode = EpisodeConfig::default();
+        Self {
+            start_seed: episode.seed,
+            seed_step: 1,
+            episodes: 1,
+            preset: episode.preset,
+            controllers: episode.controllers,
+            max_ticks: episode.max_ticks,
+            trace_player: episode.trace_player,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EpisodeOutcome {
+    Winner { player: PlayerId },
+    TickLimit,
+}
+
+impl fmt::Display for EpisodeOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Winner { player } => write!(formatter, "winner:p{}", player.index() + 1),
+            Self::TickLimit => formatter.write_str("tick_limit"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NavigationTraceReason {
+    Start,
+    BrainTransition,
+    DockingTransition,
+    Capture,
+    SafeDeparture,
+    Heartbeat,
+    EpisodeEnd,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct NavigationTraceIntent {
+    pub turn: f32,
+    pub thrust: f32,
+    pub brake: f32,
+    pub wings_closed: bool,
+    pub laser: bool,
+    pub cannon: bool,
+}
+
+impl From<ShipIntent> for NavigationTraceIntent {
+    fn from(intent: ShipIntent) -> Self {
+        Self {
+            turn: intent.turn,
+            thrust: intent.thrust,
+            brake: intent.brake,
+            wings_closed: intent.wings_closed,
+            laser: intent.laser,
+            cannon: intent.cannon,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct NavigationTraceEvent {
+    pub tick: u64,
+    pub player: PlayerId,
+    pub reasons: Vec<NavigationTraceReason>,
+    pub goal: BrainGoal,
+    pub target_planet: Option<usize>,
+    pub port_phase: Option<PortNavigationPhase>,
+    pub docked_planet: Option<usize>,
+    pub focus_planet: Option<usize>,
+    pub pending_capture_planet: Option<usize>,
+    pub pending_capture_ticks: Option<u64>,
+    pub surface_clearance: Option<f32>,
+    pub outward_speed: Option<f32>,
+    pub spaceport_angular_speed: Option<f32>,
+    pub world_velocity: [f32; 2],
+    pub world_speed: f32,
+    pub world_rotation: f32,
+    pub spaceport_rotation: Option<f32>,
+    pub angular_velocity: f32,
+    pub measured_angular_speed: f32,
+    pub target_distance: f32,
+    pub heading_error: f32,
+    pub desired_speed: f32,
+    pub relative_speed: f32,
+    pub body_contact: bool,
+    pub ship_contact: bool,
+    pub intent: NavigationTraceIntent,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct EpisodeSummary {
+    pub seed: u64,
+    pub preset: SpacewarsPreset,
+    pub controllers: [ControllerDescriptor; SPACEWARS_PLAYER_COUNT],
+    pub max_ticks: u64,
+    pub ticks: u64,
+    pub simulated_seconds: f64,
+    pub outcome: EpisodeOutcome,
+    pub captures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub ship_losses: [u64; SPACEWARS_PLAYER_COUNT],
+    pub rebuilds: [u64; SPACEWARS_PLAYER_COUNT],
+    pub eliminations: [u64; SPACEWARS_PLAYER_COUNT],
+    pub body_contacts: [u64; SPACEWARS_PLAYER_COUNT],
+    pub ship_contacts: [u64; SPACEWARS_PLAYER_COUNT],
+    pub debris_impacts: [u64; SPACEWARS_PLAYER_COUNT],
+    pub laser_hits_received: [u64; SPACEWARS_PLAYER_COUNT],
+    pub port_dockings: [u64; SPACEWARS_PLAYER_COUNT],
+    pub port_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub safe_capture_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub safe_rebuild_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub final_planet_counts: [usize; SPACEWARS_PLAYER_COUNT],
+    pub final_ship_forms: [ShipForm; SPACEWARS_PLAYER_COUNT],
+    pub final_life_fractions: [f32; SPACEWARS_PLAYER_COUNT],
+    pub actions_emitted: u64,
+    pub trace_sha256: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub navigation_trace: Vec<NavigationTraceEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BatchSummary {
+    pub episodes: u32,
+    pub total_ticks: u64,
+    pub total_simulated_seconds: f64,
+    pub winner_counts: [u32; SPACEWARS_PLAYER_COUNT],
+    pub tick_limits: u32,
+    pub captures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub ship_losses: [u64; SPACEWARS_PLAYER_COUNT],
+    pub rebuilds: [u64; SPACEWARS_PLAYER_COUNT],
+    pub body_contacts: [u64; SPACEWARS_PLAYER_COUNT],
+    pub ship_contacts: [u64; SPACEWARS_PLAYER_COUNT],
+    pub debris_impacts: [u64; SPACEWARS_PLAYER_COUNT],
+    pub laser_hits_received: [u64; SPACEWARS_PLAYER_COUNT],
+    pub port_dockings: [u64; SPACEWARS_PLAYER_COUNT],
+    pub port_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub safe_capture_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub safe_rebuild_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub wall_seconds: f64,
+    pub ticks_per_wall_second: f64,
+    pub simulated_seconds_per_wall_second: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RunReport {
+    pub schema_version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suite_id: Option<&'static str>,
+    pub episodes: Vec<EpisodeSummary>,
+    pub summary: BatchSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunError {
+    NoEpisodes,
+    ZeroTickLimit,
+    SeedOverflow { episode_index: u32 },
+    MissingObservation { player: PlayerId },
+}
+
+impl fmt::Display for RunError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoEpisodes => formatter.write_str("episode count must be greater than zero"),
+            Self::ZeroTickLimit => {
+                formatter.write_str("maximum tick count must be greater than zero")
+            }
+            Self::SeedOverflow { episode_index } => {
+                write!(formatter, "seed overflow at episode index {episode_index}")
+            }
+            Self::MissingObservation { player } => {
+                write!(
+                    formatter,
+                    "scenario did not produce an observation for player {}",
+                    player.index() + 1
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RunError {}
+
+enum SeatController {
+    Idle,
+    Rule(RuleShipBrain),
+}
+
+impl SeatController {
+    fn new(kind: ControllerKind, actor: PlayerId, episode_seed: u64) -> Self {
+        match kind {
+            ControllerKind::Idle => Self::Idle,
+            ControllerKind::Rule => {
+                let mut brain = RuleShipBrain::default();
+                brain.reset(BrainReset {
+                    actor,
+                    episode_seed,
+                });
+                Self::Rule(brain)
+            }
+        }
+    }
+
+    fn intent(&mut self, state: &SpacewarsState, actor: PlayerId) -> Result<ShipIntent, RunError> {
+        match self {
+            Self::Idle => Ok(ShipIntent::default()),
+            Self::Rule(brain) => {
+                let observation =
+                    SpacewarsScenario::observe_ship(state, actor, ShipSensorProfile::FullMapRadar)
+                        .ok_or(RunError::MissingObservation { player: actor })?;
+                Ok(brain.intent(&observation))
+            }
+        }
+    }
+
+    fn telemetry(&self) -> BrainTelemetry {
+        match self {
+            Self::Idle => BrainTelemetry::default(),
+            Self::Rule(brain) => brain.telemetry(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NavigationTraceSemantic {
+    goal: BrainGoal,
+    target_planet: Option<usize>,
+    port_phase: Option<PortNavigationPhase>,
+    docked_planet: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingCapture {
+    planet: usize,
+    tick: u64,
+}
+
+#[derive(Debug)]
+struct NavigationTraceCollector {
+    player: PlayerId,
+    previous_planet_owners: Vec<Option<usize>>,
+    previous_semantic: Option<NavigationTraceSemantic>,
+    previous_docked_planet: Option<usize>,
+    pending_capture: Option<PendingCapture>,
+    last_heartbeat_tick: Option<u64>,
+    previous_rotation: f32,
+    previous_rotation_tick: u64,
+    events: Vec<NavigationTraceEvent>,
+}
+
+impl NavigationTraceCollector {
+    fn new(state: &SpacewarsState, player: PlayerId) -> Self {
+        Self {
+            player,
+            previous_planet_owners: state.planets.iter().map(|planet| planet.owner_id).collect(),
+            previous_semantic: None,
+            previous_docked_planet: docked_planet(state, player.index()),
+            pending_capture: None,
+            last_heartbeat_tick: None,
+            previous_rotation: state.ships[player.index()].rotation_radians,
+            previous_rotation_tick: state.tick,
+            events: Vec::new(),
+        }
+    }
+
+    fn observe(
+        &mut self,
+        state: &SpacewarsState,
+        telemetry: BrainTelemetry,
+        intent: ShipIntent,
+        episode_end: bool,
+    ) {
+        let player = self.player.index();
+        let ship = &state.ships[player];
+        let rotation_delta = (ship.rotation_radians - self.previous_rotation
+            + core::f32::consts::PI)
+            .rem_euclid(core::f32::consts::TAU)
+            - core::f32::consts::PI;
+        let elapsed_ticks = state.tick.saturating_sub(self.previous_rotation_tick);
+        let measured_angular_speed = if elapsed_ticks == 0 {
+            0.0
+        } else {
+            rotation_delta * state.config.fps as f32 / elapsed_ticks as f32
+        };
+        let docked_planet = docked_planet(state, player);
+        let semantic = NavigationTraceSemantic {
+            goal: telemetry.goal,
+            target_planet: telemetry.target_planet.map(|planet| planet.index()),
+            port_phase: telemetry.port_phase,
+            docked_planet,
+        };
+        let captured_planet = self.capture_transition(state);
+        let mut reasons = Vec::new();
+
+        if self.previous_semantic.is_none() {
+            reasons.push(NavigationTraceReason::Start);
+        } else if self.previous_semantic != Some(semantic) {
+            reasons.push(NavigationTraceReason::BrainTransition);
+        }
+        if docked_planet != self.previous_docked_planet {
+            reasons.push(NavigationTraceReason::DockingTransition);
+        }
+        if let Some(planet) = captured_planet {
+            reasons.push(NavigationTraceReason::Capture);
+            self.pending_capture = Some(PendingCapture {
+                planet,
+                tick: state.tick,
+            });
+            self.last_heartbeat_tick = Some(state.tick);
+        }
+
+        let pending_capture = self.pending_capture;
+        let focus_planet = pending_capture
+            .map(|pending| pending.planet)
+            .or(semantic.target_planet)
+            .or(docked_planet);
+        let geometry =
+            focus_planet.and_then(|planet| trace_planet_geometry(state, self.player, planet));
+        let safe_departure = pending_capture.is_some_and(|pending| {
+            docked_planet != Some(pending.planet)
+                && geometry.is_some_and(|geometry| {
+                    geometry.surface_clearance >= NAVIGATION_SAFE_DEPARTURE_CLEARANCE
+                })
+        });
+        if safe_departure {
+            reasons.push(NavigationTraceReason::SafeDeparture);
+        } else if pending_capture.is_some()
+            && captured_planet.is_none()
+            && self.last_heartbeat_tick.is_none_or(|last| {
+                state.tick.saturating_sub(last) >= NAVIGATION_TRACE_HEARTBEAT_TICKS
+            })
+        {
+            reasons.push(NavigationTraceReason::Heartbeat);
+            self.last_heartbeat_tick = Some(state.tick);
+        }
+        if episode_end {
+            reasons.push(NavigationTraceReason::EpisodeEnd);
+        }
+
+        if !reasons.is_empty() {
+            self.events.push(NavigationTraceEvent {
+                tick: state.tick,
+                player: self.player,
+                reasons,
+                goal: telemetry.goal,
+                target_planet: semantic.target_planet,
+                port_phase: telemetry.port_phase,
+                docked_planet,
+                focus_planet,
+                pending_capture_planet: pending_capture.map(|pending| pending.planet),
+                pending_capture_ticks: pending_capture
+                    .map(|pending| state.tick.saturating_sub(pending.tick)),
+                surface_clearance: geometry.map(|geometry| geometry.surface_clearance),
+                outward_speed: geometry.map(|geometry| geometry.outward_speed),
+                spaceport_angular_speed: geometry.map(|geometry| geometry.spaceport_angular_speed),
+                world_velocity: [ship.velocity.x, ship.velocity.y],
+                world_speed: ship.velocity.length(),
+                world_rotation: ship.rotation_radians,
+                spaceport_rotation: geometry.map(|geometry| geometry.spaceport_rotation),
+                angular_velocity: ship.omega,
+                measured_angular_speed,
+                target_distance: telemetry.target_distance,
+                heading_error: telemetry.heading_error,
+                desired_speed: telemetry.desired_speed,
+                relative_speed: telemetry.relative_speed,
+                body_contact: mechanical_body_contacts(state)
+                    .iter()
+                    .any(|contact| contact.ship == player),
+                ship_contact: state
+                    .ship_collisions
+                    .iter()
+                    .any(|contact| contact.a == player || contact.b == player),
+                intent: intent.into(),
+            });
+        }
+
+        if safe_departure {
+            self.pending_capture = None;
+            self.last_heartbeat_tick = None;
+        }
+        self.previous_semantic = Some(semantic);
+        self.previous_docked_planet = docked_planet;
+        self.previous_rotation = ship.rotation_radians;
+        self.previous_rotation_tick = state.tick;
+    }
+
+    fn capture_transition(&mut self, state: &SpacewarsState) -> Option<usize> {
+        debug_assert_eq!(self.previous_planet_owners.len(), state.planets.len());
+        let mut captured_planet = None;
+        for (planet, (previous_owner, current)) in self
+            .previous_planet_owners
+            .iter_mut()
+            .zip(&state.planets)
+            .enumerate()
+        {
+            if *previous_owner != current.owner_id && current.owner_id == Some(self.player.index())
+            {
+                captured_planet = Some(planet);
+            }
+            *previous_owner = current.owner_id;
+        }
+        captured_planet
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TracePlanetGeometry {
+    surface_clearance: f32,
+    outward_speed: f32,
+    spaceport_angular_speed: f32,
+    spaceport_rotation: f32,
+}
+
+fn trace_planet_geometry(
+    state: &SpacewarsState,
+    player: PlayerId,
+    planet_index: usize,
+) -> Option<TracePlanetGeometry> {
+    let spaceport_rotation = state.planets.get(planet_index)?.wrapper_angle;
+    let observation =
+        SpacewarsScenario::observe_ship(state, player, ShipSensorProfile::FullMapRadar)?;
+    let planet = observation
+        .planets
+        .iter()
+        .find(|candidate| candidate.id.index() == planet_index)?;
+    let distance = planet.local_position.length();
+    let outward_speed = if distance > f32::EPSILON {
+        planet.local_velocity.dot(planet.local_position / distance)
+    } else {
+        0.0
+    };
+    let port_offset = planet.local_spaceport_position - planet.local_position;
+    let port_radius_squared = port_offset.length_squared();
+    let port_velocity_delta = planet.local_spaceport_velocity - planet.local_velocity;
+    let spaceport_angular_speed = if port_radius_squared > f32::EPSILON {
+        (port_offset.x * port_velocity_delta.y - port_offset.y * port_velocity_delta.x)
+            / port_radius_squared
+    } else {
+        0.0
+    };
+    Some(TracePlanetGeometry {
+        surface_clearance: distance - planet.radius - observation.own_ship.collision_radius,
+        outward_speed,
+        spaceport_angular_speed,
+        spaceport_rotation,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DockingSession {
+    planet: usize,
+    captured: bool,
+    rebuilt: bool,
+    in_contact: bool,
+}
+
+#[derive(Debug)]
+struct TransitionTracker {
+    previous_planet_owners: Vec<Option<usize>>,
+    previous_forms: [ShipForm; SPACEWARS_PLAYER_COUNT],
+    previous_eliminated: [bool; SPACEWARS_PLAYER_COUNT],
+    body_contact_history: Vec<(BodyCollision, u64)>,
+    ship_contact_history: Vec<(ShipCollision, u64)>,
+    docking_sessions: [Option<DockingSession>; SPACEWARS_PLAYER_COUNT],
+    captures: [u64; SPACEWARS_PLAYER_COUNT],
+    ship_losses: [u64; SPACEWARS_PLAYER_COUNT],
+    rebuilds: [u64; SPACEWARS_PLAYER_COUNT],
+    eliminations: [u64; SPACEWARS_PLAYER_COUNT],
+    body_contacts: [u64; SPACEWARS_PLAYER_COUNT],
+    ship_contacts: [u64; SPACEWARS_PLAYER_COUNT],
+    debris_impacts: [u64; SPACEWARS_PLAYER_COUNT],
+    laser_hits_received: [u64; SPACEWARS_PLAYER_COUNT],
+    port_dockings: [u64; SPACEWARS_PLAYER_COUNT],
+    port_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    safe_capture_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    safe_rebuild_departures: [u64; SPACEWARS_PLAYER_COUNT],
+}
+
+impl TransitionTracker {
+    fn new(state: &SpacewarsState) -> Self {
+        Self {
+            previous_planet_owners: state.planets.iter().map(|planet| planet.owner_id).collect(),
+            previous_forms: std::array::from_fn(|player| state.ships[player].form),
+            previous_eliminated: std::array::from_fn(|player| state.players[player].eliminated),
+            body_contact_history: mechanical_body_contacts(state)
+                .into_iter()
+                .map(|contact| (contact, state.tick))
+                .collect(),
+            ship_contact_history: state
+                .ship_collisions
+                .iter()
+                .copied()
+                .map(|contact| (contact, state.tick))
+                .collect(),
+            docking_sessions: std::array::from_fn(|player| {
+                docked_planet(state, player).map(|planet| DockingSession {
+                    planet,
+                    captured: false,
+                    rebuilt: false,
+                    in_contact: true,
+                })
+            }),
+            captures: [0; SPACEWARS_PLAYER_COUNT],
+            ship_losses: [0; SPACEWARS_PLAYER_COUNT],
+            rebuilds: [0; SPACEWARS_PLAYER_COUNT],
+            eliminations: [0; SPACEWARS_PLAYER_COUNT],
+            body_contacts: [0; SPACEWARS_PLAYER_COUNT],
+            ship_contacts: [0; SPACEWARS_PLAYER_COUNT],
+            debris_impacts: [0; SPACEWARS_PLAYER_COUNT],
+            laser_hits_received: [0; SPACEWARS_PLAYER_COUNT],
+            port_dockings: [0; SPACEWARS_PLAYER_COUNT],
+            port_departures: [0; SPACEWARS_PLAYER_COUNT],
+            safe_capture_departures: [0; SPACEWARS_PLAYER_COUNT],
+            safe_rebuild_departures: [0; SPACEWARS_PLAYER_COUNT],
+        }
+    }
+
+    fn observe(&mut self, state: &SpacewarsState) {
+        debug_assert_eq!(self.previous_planet_owners.len(), state.planets.len());
+        let mut captured_planets = [None; SPACEWARS_PLAYER_COUNT];
+        for (planet_index, (previous, planet)) in self
+            .previous_planet_owners
+            .iter_mut()
+            .zip(&state.planets)
+            .enumerate()
+        {
+            if *previous != planet.owner_id {
+                if let Some(owner) = planet
+                    .owner_id
+                    .filter(|owner| *owner < SPACEWARS_PLAYER_COUNT)
+                {
+                    self.captures[owner] += 1;
+                    captured_planets[owner] = Some(planet_index);
+                }
+                *previous = planet.owner_id;
+            }
+        }
+
+        let body_collisions = mechanical_body_contacts(state);
+        for contact in
+            rearmed_contacts(&body_collisions, &mut self.body_contact_history, state.tick)
+        {
+            if contact.ship < SPACEWARS_PLAYER_COUNT {
+                self.body_contacts[contact.ship] += 1;
+            }
+        }
+
+        for contact in rearmed_contacts(
+            &state.ship_collisions,
+            &mut self.ship_contact_history,
+            state.tick,
+        ) {
+            if contact.a < SPACEWARS_PLAYER_COUNT {
+                self.ship_contacts[contact.a] += 1;
+            }
+            if contact.b < SPACEWARS_PLAYER_COUNT {
+                self.ship_contacts[contact.b] += 1;
+            }
+        }
+
+        for impact in &state.ship_debris_collisions {
+            if impact.ship < SPACEWARS_PLAYER_COUNT {
+                self.debris_impacts[impact.ship] += 1;
+            }
+        }
+        for hit in &state.laser_hits {
+            let LaserTarget::Ship(player) = hit.target else {
+                continue;
+            };
+            if player < SPACEWARS_PLAYER_COUNT {
+                self.laser_hits_received[player] += 1;
+            }
+        }
+
+        for (player, &captured_planet) in captured_planets.iter().enumerate() {
+            let form = state.ships[player].form;
+            let rebuilt = match (self.previous_forms[player], form) {
+                (ShipForm::Ship, ShipForm::EscapePod) => {
+                    self.ship_losses[player] += 1;
+                    false
+                }
+                (ShipForm::EscapePod, ShipForm::Ship) => {
+                    self.rebuilds[player] += 1;
+                    true
+                }
+                _ => false,
+            };
+            self.previous_forms[player] = form;
+
+            self.update_docking_session(state, player, rebuilt, captured_planet);
+
+            let eliminated = state.players[player].eliminated;
+            if eliminated && !self.previous_eliminated[player] {
+                self.eliminations[player] += 1;
+            }
+            self.previous_eliminated[player] = eliminated;
+        }
+    }
+
+    fn update_docking_session(
+        &mut self,
+        state: &SpacewarsState,
+        player: usize,
+        rebuilt: bool,
+        captured_planet: Option<usize>,
+    ) {
+        let current_planet = docked_planet(state, player);
+        let mut completed = None;
+        if let Some(session) = &mut self.docking_sessions[player] {
+            session.captured |= captured_planet == Some(session.planet);
+            session.rebuilt |= rebuilt;
+
+            let in_contact = current_planet == Some(session.planet);
+            if session.in_contact && !in_contact {
+                self.port_departures[player] += 1;
+            } else if !session.in_contact && in_contact {
+                self.port_dockings[player] += 1;
+            }
+            session.in_contact = in_contact;
+
+            if !in_contact && has_safe_planet_clearance(state, player, session.planet) {
+                completed = Some(*session);
+            }
+        }
+
+        if let Some(completed) = completed {
+            self.safe_capture_departures[player] += u64::from(completed.captured);
+            self.safe_rebuild_departures[player] += u64::from(completed.rebuilt);
+            self.docking_sessions[player] = None;
+        }
+
+        if self.docking_sessions[player].is_some() {
+            return;
+        }
+        let Some(planet) = current_planet else {
+            return;
+        };
+        self.port_dockings[player] += 1;
+        self.docking_sessions[player] = Some(DockingSession {
+            planet,
+            captured: captured_planet == Some(planet),
+            rebuilt,
+            in_contact: true,
+        });
+    }
+}
+
+fn docked_planet(state: &SpacewarsState, player: usize) -> Option<usize> {
+    state
+        .spaceport_contacts
+        .iter()
+        .find(|contact| contact.ship == player)
+        .map(|contact| contact.planet)
+}
+
+fn mechanical_body_contacts(state: &SpacewarsState) -> Vec<BodyCollision> {
+    state
+        .body_collisions
+        .iter()
+        .copied()
+        .filter(|collision| {
+            let BodyId::Planet(planet) = collision.body else {
+                return true;
+            };
+            !state
+                .spaceport_contacts
+                .iter()
+                .any(|contact| contact.ship == collision.ship && contact.planet == planet)
+        })
+        .collect()
+}
+
+fn has_safe_planet_clearance(state: &SpacewarsState, player: usize, planet: usize) -> bool {
+    let Some(ship) = state.ships.get(player) else {
+        return false;
+    };
+    let Some(planet) = state.planets.get(planet) else {
+        return false;
+    };
+    let Some(actor) = PlayerId::from_index(player) else {
+        return false;
+    };
+    let Some(observation) =
+        SpacewarsScenario::observe_ship(state, actor, ShipSensorProfile::FullMapRadar)
+    else {
+        return false;
+    };
+    ship.position.distance_to(planet.position)
+        - planet.radius
+        - observation.own_ship.collision_radius
+        >= NAVIGATION_SAFE_DEPARTURE_CLEARANCE
+}
+
+fn rearmed_contacts<T: Copy + Eq>(
+    contacts: &[T],
+    history: &mut Vec<(T, u64)>,
+    tick: u64,
+) -> Vec<T> {
+    let mut incidents = Vec::new();
+    for &contact in contacts {
+        if let Some((_, last_seen)) = history.iter_mut().find(|(known, _)| *known == contact) {
+            if tick.saturating_sub(*last_seen) > CONTACT_INCIDENT_REARM_TICKS {
+                incidents.push(contact);
+            }
+            *last_seen = tick;
+        } else {
+            history.push((contact, tick));
+            incidents.push(contact);
+        }
+    }
+    history
+        .retain(|(_, last_seen)| tick.saturating_sub(*last_seen) <= CONTACT_INCIDENT_REARM_TICKS);
+    incidents
+}
+
+pub fn run_episode(config: EpisodeConfig) -> Result<EpisodeSummary, RunError> {
+    if config.max_ticks == 0 {
+        return Err(RunError::ZeroTickLimit);
+    }
+
+    let scenario_config = config.preset.config();
+    let ticks_per_second = scenario_config.fps;
+    let tick_duration = Duration::from_secs_f64(1.0 / f64::from(ticks_per_second));
+    let mut state = SpacewarsScenario::init(scenario_config, config.seed);
+    let mut controllers = [
+        SeatController::new(config.controllers[0], PlayerId::PLAYER_1, config.seed),
+        SeatController::new(config.controllers[1], PlayerId::PLAYER_2, config.seed),
+    ];
+    let mut encoder = ShipIntentEncoder::default();
+    let mut transitions = TransitionTracker::new(&state);
+    let mut navigation_trace = config
+        .trace_player
+        .map(|player| NavigationTraceCollector::new(&state, player));
+    let mut last_traced_decision = None;
+    let mut trace = Sha256::new();
+    initialize_trace(&mut trace, config);
+    let mut actions_emitted = 0_u64;
+
+    while state.winner.is_none() && state.tick < config.max_ticks {
+        let tick = state.tick;
+        let mut actions = Vec::new();
+        for (player, controller) in controllers.iter_mut().enumerate() {
+            let actor = PlayerId::from_index(player).expect("Spacewars has exactly two players");
+            let intent = controller.intent(&state, actor)?;
+            if config.trace_player == Some(actor) {
+                let telemetry = controller.telemetry();
+                if let Some(collector) = &mut navigation_trace {
+                    collector.observe(&state, telemetry, intent, false);
+                }
+                last_traced_decision = Some((telemetry, intent));
+            }
+            actions.extend(encoder.encode(player, intent));
+        }
+        actions_emitted += actions.len() as u64;
+        hash_actions(&mut trace, tick, &actions);
+        SpacewarsScenario::step(&mut state, &actions, tick_duration);
+        transitions.observe(&state);
+    }
+
+    hash_terminal_state(&mut trace, &state);
+    let outcome = state
+        .winner
+        .map_or(EpisodeOutcome::TickLimit, |winner| EpisodeOutcome::Winner {
+            player: PlayerId::from_index(winner).expect("winner must be a Spacewars player"),
+        });
+    let navigation_trace = if let Some(mut collector) = navigation_trace {
+        let (telemetry, intent) =
+            last_traced_decision.unwrap_or((BrainTelemetry::default(), ShipIntent::default()));
+        collector.observe(&state, telemetry, intent, true);
+        collector.events
+    } else {
+        Vec::new()
+    };
+
+    Ok(EpisodeSummary {
+        seed: config.seed,
+        preset: config.preset,
+        controllers: config.controllers.map(ControllerDescriptor::from),
+        max_ticks: config.max_ticks,
+        ticks: state.tick,
+        simulated_seconds: state.tick as f64 / f64::from(ticks_per_second),
+        outcome,
+        captures: transitions.captures,
+        ship_losses: transitions.ship_losses,
+        rebuilds: transitions.rebuilds,
+        eliminations: transitions.eliminations,
+        body_contacts: transitions.body_contacts,
+        ship_contacts: transitions.ship_contacts,
+        debris_impacts: transitions.debris_impacts,
+        laser_hits_received: transitions.laser_hits_received,
+        port_dockings: transitions.port_dockings,
+        port_departures: transitions.port_departures,
+        safe_capture_departures: transitions.safe_capture_departures,
+        safe_rebuild_departures: transitions.safe_rebuild_departures,
+        final_planet_counts: std::array::from_fn(|player| state.players[player].planet_count),
+        final_ship_forms: std::array::from_fn(|player| state.ships[player].form),
+        final_life_fractions: std::array::from_fn(|player| {
+            let ship = &state.ships[player];
+            if ship.life_max > 0.0 {
+                (ship.life / ship.life_max).clamp(0.0, 1.0)
+            } else {
+                0.0
+            }
+        }),
+        actions_emitted,
+        trace_sha256: format!("{:x}", trace.finalize()),
+        navigation_trace,
+    })
+}
+
+pub fn run_batch(config: BatchConfig) -> Result<RunReport, RunError> {
+    if config.episodes == 0 {
+        return Err(RunError::NoEpisodes);
+    }
+    if config.max_ticks == 0 {
+        return Err(RunError::ZeroTickLimit);
+    }
+
+    let mut episode_configs = Vec::with_capacity(config.episodes as usize);
+    for episode_index in 0..config.episodes {
+        let offset = config
+            .seed_step
+            .checked_mul(u64::from(episode_index))
+            .ok_or(RunError::SeedOverflow { episode_index })?;
+        let seed = config
+            .start_seed
+            .checked_add(offset)
+            .ok_or(RunError::SeedOverflow { episode_index })?;
+        episode_configs.push(EpisodeConfig {
+            seed,
+            preset: config.preset,
+            controllers: config.controllers,
+            max_ticks: config.max_ticks,
+            trace_player: config.trace_player,
+        });
+    }
+    run_episode_configs(None, episode_configs)
+}
+
+pub fn run_suite(suite: EvaluationSuite) -> Result<RunReport, RunError> {
+    run_episode_configs(Some(suite.id()), suite.episode_configs())
+}
+
+fn run_episode_configs(
+    suite_id: Option<&'static str>,
+    configs: Vec<EpisodeConfig>,
+) -> Result<RunReport, RunError> {
+    let started = Instant::now();
+    let episodes = configs
+        .into_iter()
+        .map(run_episode)
+        .collect::<Result<Vec<_>, _>>()?;
+    let wall_seconds = started.elapsed().as_secs_f64();
+    let summary = summarize_batch(&episodes, wall_seconds);
+    Ok(RunReport {
+        schema_version: REPORT_SCHEMA_VERSION,
+        suite_id,
+        episodes,
+        summary,
+    })
+}
+
+fn summarize_batch(episodes: &[EpisodeSummary], wall_seconds: f64) -> BatchSummary {
+    let mut winner_counts = [0_u32; SPACEWARS_PLAYER_COUNT];
+    let mut tick_limits = 0_u32;
+    let mut captures = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut ship_losses = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut rebuilds = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut body_contacts = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut ship_contacts = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut debris_impacts = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut laser_hits_received = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut port_dockings = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut port_departures = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut safe_capture_departures = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut safe_rebuild_departures = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut total_ticks = 0_u64;
+    let mut total_simulated_seconds = 0.0;
+    for episode in episodes {
+        total_ticks += episode.ticks;
+        total_simulated_seconds += episode.simulated_seconds;
+        match episode.outcome {
+            EpisodeOutcome::Winner { player } => winner_counts[player.index()] += 1,
+            EpisodeOutcome::TickLimit => tick_limits += 1,
+        }
+        for player in 0..SPACEWARS_PLAYER_COUNT {
+            captures[player] += episode.captures[player];
+            ship_losses[player] += episode.ship_losses[player];
+            rebuilds[player] += episode.rebuilds[player];
+            body_contacts[player] += episode.body_contacts[player];
+            ship_contacts[player] += episode.ship_contacts[player];
+            debris_impacts[player] += episode.debris_impacts[player];
+            laser_hits_received[player] += episode.laser_hits_received[player];
+            port_dockings[player] += episode.port_dockings[player];
+            port_departures[player] += episode.port_departures[player];
+            safe_capture_departures[player] += episode.safe_capture_departures[player];
+            safe_rebuild_departures[player] += episode.safe_rebuild_departures[player];
+        }
+    }
+
+    let measured_seconds = wall_seconds.max(f64::EPSILON);
+    BatchSummary {
+        episodes: episodes.len() as u32,
+        total_ticks,
+        total_simulated_seconds,
+        winner_counts,
+        tick_limits,
+        captures,
+        ship_losses,
+        rebuilds,
+        body_contacts,
+        ship_contacts,
+        debris_impacts,
+        laser_hits_received,
+        port_dockings,
+        port_departures,
+        safe_capture_departures,
+        safe_rebuild_departures,
+        wall_seconds,
+        ticks_per_wall_second: total_ticks as f64 / measured_seconds,
+        simulated_seconds_per_wall_second: total_simulated_seconds / measured_seconds,
+    }
+}
+
+fn initialize_trace(trace: &mut Sha256, config: EpisodeConfig) {
+    trace.update(b"spacewars-episode-trace-v1");
+    trace.update(config.seed.to_le_bytes());
+    trace.update(config.max_ticks.to_le_bytes());
+    trace.update([match config.preset {
+        SpacewarsPreset::Standard => 0,
+        SpacewarsPreset::StandardNoAsteroids => 1,
+        SpacewarsPreset::Navigation => 2,
+        SpacewarsPreset::Deathmatch => 3,
+    }]);
+    for controller in config.controllers {
+        let policy_id = controller.policy_id().as_bytes();
+        trace.update((policy_id.len() as u64).to_le_bytes());
+        trace.update(policy_id);
+    }
+}
+
+fn hash_actions(trace: &mut Sha256, tick: u64, actions: &[Action]) {
+    trace.update(tick.to_le_bytes());
+    trace.update((actions.len() as u64).to_le_bytes());
+    for action in actions {
+        match action {
+            Action::Scenario { kind, payload } => {
+                trace.update([0]);
+                trace.update(kind.to_le_bytes());
+                trace.update((payload.len() as u64).to_le_bytes());
+                trace.update(payload);
+            }
+            Action::Pointer(pointer) => {
+                trace.update([1]);
+                trace.update(pointer.position.x.to_bits().to_le_bytes());
+                trace.update(pointer.position.y.to_bits().to_le_bytes());
+                trace.update([match pointer.phase {
+                    PointerPhase::Press => 0,
+                    PointerPhase::Drag => 1,
+                    PointerPhase::Release => 2,
+                    PointerPhase::Cancel => 3,
+                }]);
+            }
+        }
+    }
+}
+
+fn hash_terminal_state(trace: &mut Sha256, state: &SpacewarsState) {
+    trace.update(state.tick.to_le_bytes());
+    hash_optional_index(trace, state.winner);
+    for player in &state.players {
+        trace.update((player.planet_count as u64).to_le_bytes());
+        trace.update([u8::from(player.eliminated)]);
+    }
+    for ship in &state.ships {
+        trace.update([match ship.form {
+            ShipForm::Ship => 0,
+            ShipForm::EscapePod => 1,
+        }]);
+        for value in [
+            ship.position.x,
+            ship.position.y,
+            ship.velocity.x,
+            ship.velocity.y,
+            ship.rotation_radians,
+            ship.omega,
+            ship.life,
+        ] {
+            trace.update(value.to_bits().to_le_bytes());
+        }
+        trace.update([u8::from(ship.dead)]);
+    }
+    trace.update((state.planets.len() as u64).to_le_bytes());
+    for planet in &state.planets {
+        hash_optional_index(trace, planet.owner_id);
+        hash_optional_index(trace, planet.capturing_player_id);
+        for value in [
+            planet.position.x,
+            planet.position.y,
+            planet.orbit_angle,
+            planet.wrapper_angle,
+            planet.taking_ownership_time,
+            planet.building_new_ship_time,
+        ] {
+            trace.update(value.to_bits().to_le_bytes());
+        }
+    }
+    trace.update((state.debris.len() as u64).to_le_bytes());
+    for debris in &state.debris {
+        trace.update([match debris.kind {
+            DebrisKind::Asteroid => 0,
+            DebrisKind::Fragment => 1,
+            DebrisKind::Shell => 2,
+        }]);
+        for value in [
+            debris.position.x,
+            debris.position.y,
+            debris.velocity.x,
+            debris.velocity.y,
+            debris.radius,
+            debris.life,
+        ] {
+            trace.update(value.to_bits().to_le_bytes());
+        }
+        trace.update([u8::from(debris.dead)]);
+        hash_optional_index(trace, debris.owner_id);
+    }
+}
+
+fn hash_optional_index(trace: &mut Sha256, value: Option<usize>) {
+    match value {
+        Some(value) => {
+            trace.update([1]);
+            trace.update((value as u64).to_le_bytes());
+        }
+        None => trace.update([0]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_episode_configs_reproduce_the_same_summary_and_trace() {
+        let config = EpisodeConfig {
+            max_ticks: 120,
+            ..EpisodeConfig::default()
+        };
+
+        let first = run_episode(config).unwrap();
+        let replay = run_episode(config).unwrap();
+
+        assert_eq!(first, replay);
+        assert!(first.actions_emitted > 0);
+        assert_eq!(first.trace_sha256.len(), 64);
+    }
+
+    #[test]
+    fn enabling_navigation_trace_does_not_change_episode_behavior() {
+        let untraced = run_episode(EpisodeConfig {
+            max_ticks: 30,
+            ..EpisodeConfig::default()
+        })
+        .unwrap();
+        let traced = run_episode(EpisodeConfig {
+            max_ticks: 30,
+            trace_player: Some(PlayerId::PLAYER_2),
+            ..EpisodeConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(traced.trace_sha256, untraced.trace_sha256);
+        assert_eq!(traced.actions_emitted, untraced.actions_emitted);
+        assert!(!traced.navigation_trace.is_empty());
+        assert!(
+            traced.navigation_trace[0]
+                .reasons
+                .contains(&NavigationTraceReason::Start)
+        );
+        assert!(
+            traced
+                .navigation_trace
+                .last()
+                .unwrap()
+                .reasons
+                .contains(&NavigationTraceReason::EpisodeEnd)
+        );
+    }
+
+    #[test]
+    fn asteroid_free_standard_preset_changes_only_the_spawn_rate() {
+        let expected = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+
+        assert_eq!(SpacewarsPreset::StandardNoAsteroids.config(), expected);
+    }
+
+    #[test]
+    fn navigation_preset_removes_asteroids_and_raises_ship_health() {
+        let config = SpacewarsPreset::Navigation.config();
+
+        assert_eq!(config.asteroid_probability_per_sec, 0.0);
+        assert!(
+            config
+                .players
+                .iter()
+                .all(|player| player.health_percent == NAVIGATION_HEALTH_PERCENT)
+        );
+    }
+
+    #[test]
+    fn navigation_suite_has_a_fixed_reproducible_contract() {
+        let configs = EvaluationSuite::NavigationV1.episode_configs();
+
+        assert_eq!(EvaluationSuite::NavigationV1.id(), NAVIGATION_V1_SUITE_ID);
+        assert_eq!(configs.len(), NAVIGATION_V1_SEEDS.len());
+        assert_eq!(
+            configs.iter().map(|config| config.seed).collect::<Vec<_>>(),
+            NAVIGATION_V1_SEEDS
+        );
+        assert!(configs.iter().all(|config| {
+            config.preset == SpacewarsPreset::Navigation
+                && config.controllers == [ControllerKind::Rule; SPACEWARS_PLAYER_COUNT]
+                && config.max_ticks == NAVIGATION_V1_MAX_TICKS
+                && config.trace_player.is_none()
+        }));
+    }
+
+    #[test]
+    fn navigation_trace_records_capture_heartbeat_and_safe_departure() {
+        let mut state = SpacewarsScenario::init(SpacewarsConfig::default(), 12);
+        let actor = PlayerId::PLAYER_2;
+        let mut trace = NavigationTraceCollector::new(&state, actor);
+        let telemetry = |phase| BrainTelemetry {
+            actor: Some(actor),
+            goal: BrainGoal::Capture,
+            target_planet: scenario_spacewars::PlanetId::from_index(0),
+            port_phase: Some(phase),
+            ..BrainTelemetry::default()
+        };
+
+        state.tick = 10;
+        state
+            .spaceport_contacts
+            .push(scenario_spacewars::SpaceportContact { ship: 1, planet: 0 });
+        trace.observe(
+            &state,
+            telemetry(PortNavigationPhase::Docked),
+            ShipIntent::default(),
+            false,
+        );
+
+        state.tick = 20;
+        state.planets[0].owner_id = Some(1);
+        trace.observe(
+            &state,
+            telemetry(PortNavigationPhase::Docked),
+            ShipIntent::default(),
+            false,
+        );
+
+        state.tick = 20 + NAVIGATION_TRACE_HEARTBEAT_TICKS;
+        trace.observe(
+            &state,
+            telemetry(PortNavigationPhase::Docked),
+            ShipIntent::default(),
+            false,
+        );
+
+        state.tick += 1;
+        state.spaceport_contacts.clear();
+        state.ships[1].position = state.planets[0].position + engine_core::Vec2::X * 1_000.0;
+        trace.observe(
+            &state,
+            telemetry(PortNavigationPhase::Depart),
+            ShipIntent {
+                thrust: 1.0,
+                wings_closed: true,
+                ..ShipIntent::default()
+            },
+            false,
+        );
+
+        assert!(trace.events.iter().any(|event| {
+            event.reasons.contains(&NavigationTraceReason::Capture)
+                && event.pending_capture_ticks == Some(0)
+        }));
+        assert!(trace.events.iter().any(|event| {
+            event.reasons.contains(&NavigationTraceReason::Heartbeat)
+                && event.pending_capture_ticks == Some(NAVIGATION_TRACE_HEARTBEAT_TICKS)
+        }));
+        let departure = trace
+            .events
+            .iter()
+            .find(|event| {
+                event
+                    .reasons
+                    .contains(&NavigationTraceReason::SafeDeparture)
+            })
+            .unwrap();
+        assert_eq!(departure.pending_capture_planet, Some(0));
+        assert!(departure.surface_clearance.unwrap() >= NAVIGATION_SAFE_DEPARTURE_CLEARANCE);
+        assert_eq!(departure.intent.thrust, 1.0);
+        assert!(trace.pending_capture.is_none());
+    }
+
+    #[test]
+    fn seed_four_reproduces_player_two_departure_deadlock() {
+        // Characterize the known failure before changing departure guidance.
+        // Once repaired, this fixture should be inverted to require a safe
+        // departure within the same bounded episode.
+        let episode = run_episode(EpisodeConfig {
+            seed: 4,
+            preset: SpacewarsPreset::Navigation,
+            controllers: [ControllerKind::Rule; SPACEWARS_PLAYER_COUNT],
+            max_ticks: 4_000,
+            trace_player: Some(PlayerId::PLAYER_2),
+        })
+        .unwrap();
+
+        assert_eq!(episode.outcome, EpisodeOutcome::TickLimit);
+        assert_eq!(episode.captures[PlayerId::PLAYER_2.index()], 1);
+        assert_eq!(
+            episode.safe_capture_departures[PlayerId::PLAYER_2.index()],
+            0
+        );
+
+        let capture = episode
+            .navigation_trace
+            .iter()
+            .find(|event| event.reasons.contains(&NavigationTraceReason::Capture))
+            .unwrap();
+        assert_eq!(capture.tick, 2_714);
+        assert_eq!(capture.docked_planet, Some(3));
+        assert_eq!(capture.pending_capture_planet, Some(3));
+        assert_eq!(capture.pending_capture_ticks, Some(0));
+
+        let terminal = episode.navigation_trace.last().unwrap();
+        assert!(
+            terminal
+                .reasons
+                .contains(&NavigationTraceReason::EpisodeEnd)
+        );
+        assert_eq!(terminal.port_phase, Some(PortNavigationPhase::Depart));
+        assert_eq!(terminal.docked_planet, Some(3));
+        assert_eq!(terminal.pending_capture_planet, Some(3));
+        assert_eq!(terminal.pending_capture_ticks, Some(1_286));
+        assert!(terminal.surface_clearance.unwrap() < 0.0);
+        assert_eq!(terminal.intent.turn, -1.0);
+        assert_eq!(terminal.intent.brake, 1.0);
+        assert_eq!(terminal.intent.thrust, 0.0);
+    }
+
+    #[test]
+    fn batch_walks_seeds_and_reports_tick_limits() {
+        let report = run_batch(BatchConfig {
+            start_seed: 5,
+            seed_step: 3,
+            episodes: 3,
+            controllers: [ControllerKind::Idle; SPACEWARS_PLAYER_COUNT],
+            max_ticks: 1,
+            ..BatchConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(
+            report
+                .episodes
+                .iter()
+                .map(|episode| episode.seed)
+                .collect::<Vec<_>>(),
+            vec![5, 8, 11]
+        );
+        assert_eq!(report.schema_version, REPORT_SCHEMA_VERSION);
+        assert_eq!(report.summary.total_ticks, 3);
+        assert_eq!(report.summary.tick_limits, 3);
+        assert_eq!(report.summary.winner_counts, [0, 0]);
+    }
+
+    #[test]
+    fn transition_metrics_count_captures_losses_rebuilds_and_eliminations() {
+        let mut state = SpacewarsScenario::init(SpacewarsConfig::default(), 9);
+        let mut tracker = TransitionTracker::new(&state);
+        assert!(!state.planets.is_empty());
+
+        state
+            .spaceport_contacts
+            .push(scenario_spacewars::SpaceportContact { ship: 1, planet: 0 });
+        tracker.observe(&state);
+
+        state.planets[0].owner_id = Some(1);
+        state.ships[1].form = ShipForm::EscapePod;
+        state.players[1].eliminated = true;
+        tracker.observe(&state);
+
+        state.ships[1].form = ShipForm::Ship;
+        state.players[1].eliminated = false;
+        tracker.observe(&state);
+
+        state.spaceport_contacts.clear();
+        state.ships[1].position = state.planets[0].position + engine_core::Vec2::X * 1_000.0;
+        tracker.observe(&state);
+
+        assert_eq!(tracker.captures, [0, 1]);
+        assert_eq!(tracker.ship_losses, [0, 1]);
+        assert_eq!(tracker.rebuilds, [0, 1]);
+        assert_eq!(tracker.eliminations, [0, 1]);
+        assert_eq!(tracker.port_dockings, [0, 1]);
+        assert_eq!(tracker.port_departures, [0, 1]);
+        assert_eq!(tracker.safe_capture_departures, [0, 1]);
+        assert_eq!(tracker.safe_rebuild_departures, [0, 1]);
+    }
+
+    #[test]
+    fn leaving_an_already_owned_planet_is_not_a_capture_departure() {
+        let mut state = SpacewarsScenario::init(SpacewarsConfig::default(), 11);
+        state.planets[0].owner_id = Some(0);
+        let mut tracker = TransitionTracker::new(&state);
+
+        state
+            .spaceport_contacts
+            .push(scenario_spacewars::SpaceportContact { ship: 0, planet: 0 });
+        state.body_collisions.push(BodyCollision {
+            ship: 0,
+            body: BodyId::Planet(0),
+        });
+        tracker.observe(&state);
+        state.spaceport_contacts.clear();
+        state.body_collisions.clear();
+        state.ships[0].position = state.planets[0].position + engine_core::Vec2::X * 1_000.0;
+        tracker.observe(&state);
+
+        assert_eq!(tracker.port_dockings, [1, 0]);
+        assert_eq!(tracker.port_departures, [1, 0]);
+        assert_eq!(tracker.safe_capture_departures, [0, 0]);
+        assert_eq!(tracker.body_contacts, [0, 0]);
+    }
+
+    #[test]
+    fn contact_metrics_count_incidents_instead_of_contact_ticks() {
+        let mut state = SpacewarsScenario::init(SpacewarsConfig::default(), 10);
+        let mut tracker = TransitionTracker::new(&state);
+
+        state.body_collisions.push(BodyCollision {
+            ship: 0,
+            body: scenario_spacewars::BodyId::Sun,
+        });
+        state.ship_collisions.push(ShipCollision { a: 0, b: 1 });
+        state
+            .ship_debris_collisions
+            .push(scenario_spacewars::ShipDebrisCollision { ship: 0, debris: 0 });
+        state.laser_hits.push(scenario_spacewars::LaserHit {
+            shooter: 0,
+            target: LaserTarget::Ship(1),
+            point: engine_core::Vec2::ZERO,
+            damage: 1.0,
+        });
+        tracker.observe(&state);
+
+        state.ship_debris_collisions.clear();
+        state.laser_hits.clear();
+        tracker.observe(&state);
+
+        assert_eq!(tracker.body_contacts, [1, 0]);
+        assert_eq!(tracker.ship_contacts, [1, 1]);
+        assert_eq!(tracker.debris_impacts, [1, 0]);
+        assert_eq!(tracker.laser_hits_received, [0, 1]);
+
+        state.body_collisions.clear();
+        state.ship_collisions.clear();
+        tracker.observe(&state);
+        state.tick += CONTACT_INCIDENT_REARM_TICKS + 1;
+        state.body_collisions.push(BodyCollision {
+            ship: 0,
+            body: scenario_spacewars::BodyId::Sun,
+        });
+        state.ship_collisions.push(ShipCollision { a: 0, b: 1 });
+        tracker.observe(&state);
+
+        assert_eq!(tracker.body_contacts, [2, 0]);
+        assert_eq!(tracker.ship_contacts, [2, 2]);
+    }
+
+    #[test]
+    fn reports_are_machine_serializable() {
+        let report = run_batch(BatchConfig {
+            controllers: [ControllerKind::Idle; SPACEWARS_PLAYER_COUNT],
+            max_ticks: 1,
+            ..BatchConfig::default()
+        })
+        .unwrap();
+        let json = serde_json::to_string(&report).unwrap();
+
+        assert!(json.contains("\"schema_version\":1"));
+        assert!(json.contains("\"policy_id\":\"idle_v1\""));
+        assert!(json.contains("\"trace_sha256\""));
+    }
+
+    #[test]
+    fn invalid_batch_limits_are_rejected() {
+        assert_eq!(
+            run_batch(BatchConfig {
+                episodes: 0,
+                ..BatchConfig::default()
+            }),
+            Err(RunError::NoEpisodes)
+        );
+        assert_eq!(
+            run_batch(BatchConfig {
+                max_ticks: 0,
+                ..BatchConfig::default()
+            }),
+            Err(RunError::ZeroTickLimit)
+        );
+    }
+}

--- a/crates/engine-agent/src/lib.rs
+++ b/crates/engine-agent/src/lib.rs
@@ -607,14 +607,6 @@ fn trace_planet_geometry(
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct DockingSession {
-    planet: usize,
-    captured: bool,
-    rebuilt: bool,
-    in_contact: bool,
-}
-
 #[derive(Debug)]
 struct TransitionTracker {
     previous_planet_owners: Vec<Option<usize>>,
@@ -622,7 +614,9 @@ struct TransitionTracker {
     previous_eliminated: [bool; SPACEWARS_PLAYER_COUNT],
     body_contact_history: Vec<(BodyCollision, u64)>,
     ship_contact_history: Vec<(ShipCollision, u64)>,
-    docking_sessions: [Option<DockingSession>; SPACEWARS_PLAYER_COUNT],
+    previous_docked_planets: [Option<usize>; SPACEWARS_PLAYER_COUNT],
+    pending_capture_departures: [Vec<usize>; SPACEWARS_PLAYER_COUNT],
+    pending_rebuild_departures: [Vec<usize>; SPACEWARS_PLAYER_COUNT],
     captures: [u64; SPACEWARS_PLAYER_COUNT],
     ship_losses: [u64; SPACEWARS_PLAYER_COUNT],
     rebuilds: [u64; SPACEWARS_PLAYER_COUNT],
@@ -653,14 +647,9 @@ impl TransitionTracker {
                 .copied()
                 .map(|contact| (contact, state.tick))
                 .collect(),
-            docking_sessions: std::array::from_fn(|player| {
-                docked_planet(state, player).map(|planet| DockingSession {
-                    planet,
-                    captured: false,
-                    rebuilt: false,
-                    in_contact: true,
-                })
-            }),
+            previous_docked_planets: std::array::from_fn(|player| docked_planet(state, player)),
+            pending_capture_departures: std::array::from_fn(|_| Vec::new()),
+            pending_rebuild_departures: std::array::from_fn(|_| Vec::new()),
             captures: [0; SPACEWARS_PLAYER_COUNT],
             ship_losses: [0; SPACEWARS_PLAYER_COUNT],
             rebuilds: [0; SPACEWARS_PLAYER_COUNT],
@@ -748,7 +737,23 @@ impl TransitionTracker {
             };
             self.previous_forms[player] = form;
 
-            self.update_docking_session(state, player, rebuilt, captured_planet);
+            if let Some(planet) = captured_planet {
+                self.pending_capture_departures[player].push(planet);
+            }
+            if rebuilt && let Some(planet) = docked_planet(state, player) {
+                self.pending_rebuild_departures[player].push(planet);
+            }
+            self.update_docking_transition(state, player);
+            self.safe_capture_departures[player] += complete_safe_departures(
+                state,
+                player,
+                &mut self.pending_capture_departures[player],
+            );
+            self.safe_rebuild_departures[player] += complete_safe_departures(
+                state,
+                player,
+                &mut self.pending_rebuild_departures[player],
+            );
 
             let eliminated = state.players[player].eliminated;
             if eliminated && !self.previous_eliminated[player] {
@@ -758,52 +763,35 @@ impl TransitionTracker {
         }
     }
 
-    fn update_docking_session(
-        &mut self,
-        state: &SpacewarsState,
-        player: usize,
-        rebuilt: bool,
-        captured_planet: Option<usize>,
-    ) {
+    fn update_docking_transition(&mut self, state: &SpacewarsState, player: usize) {
         let current_planet = docked_planet(state, player);
-        let mut completed = None;
-        if let Some(session) = &mut self.docking_sessions[player] {
-            session.captured |= captured_planet == Some(session.planet);
-            session.rebuilt |= rebuilt;
-
-            let in_contact = current_planet == Some(session.planet);
-            if session.in_contact && !in_contact {
+        let previous_planet = self.previous_docked_planets[player];
+        if previous_planet != current_planet {
+            if previous_planet.is_some() {
                 self.port_departures[player] += 1;
-            } else if !session.in_contact && in_contact {
+            }
+            if current_planet.is_some() {
                 self.port_dockings[player] += 1;
             }
-            session.in_contact = in_contact;
-
-            if !in_contact && has_safe_planet_clearance(state, player, session.planet) {
-                completed = Some(*session);
-            }
         }
-
-        if let Some(completed) = completed {
-            self.safe_capture_departures[player] += u64::from(completed.captured);
-            self.safe_rebuild_departures[player] += u64::from(completed.rebuilt);
-            self.docking_sessions[player] = None;
-        }
-
-        if self.docking_sessions[player].is_some() {
-            return;
-        }
-        let Some(planet) = current_planet else {
-            return;
-        };
-        self.port_dockings[player] += 1;
-        self.docking_sessions[player] = Some(DockingSession {
-            planet,
-            captured: captured_planet == Some(planet),
-            rebuilt,
-            in_contact: true,
-        });
+        self.previous_docked_planets[player] = current_planet;
     }
+}
+
+fn complete_safe_departures(
+    state: &SpacewarsState,
+    player: usize,
+    pending_planets: &mut Vec<usize>,
+) -> u64 {
+    let current_planet = docked_planet(state, player);
+    let mut completed = 0;
+    pending_planets.retain(|&planet| {
+        let safely_departed =
+            current_planet != Some(planet) && has_safe_planet_clearance(state, player, planet);
+        completed += u64::from(safely_departed);
+        !safely_departed
+    });
+    completed
 }
 
 fn docked_planet(state: &SpacewarsState, player: usize) -> Option<usize> {
@@ -1369,10 +1357,7 @@ mod tests {
     }
 
     #[test]
-    fn seed_four_reproduces_player_two_departure_deadlock() {
-        // Characterize the known failure before changing departure guidance.
-        // Once repaired, this fixture should be inverted to require a safe
-        // departure within the same bounded episode.
+    fn seed_four_player_two_safely_departs_within_bounded_episode() {
         let episode = run_episode(EpisodeConfig {
             seed: 4,
             preset: SpacewarsPreset::Navigation,
@@ -1383,10 +1368,11 @@ mod tests {
         .unwrap();
 
         assert_eq!(episode.outcome, EpisodeOutcome::TickLimit);
-        assert_eq!(episode.captures[PlayerId::PLAYER_2.index()], 1);
+        let player = PlayerId::PLAYER_2.index();
+        assert!(episode.captures[player] >= 1);
         assert_eq!(
-            episode.safe_capture_departures[PlayerId::PLAYER_2.index()],
-            0
+            episode.safe_capture_departures[player], episode.captures[player],
+            "every capture should be followed by safe clearance"
         );
 
         let capture = episode
@@ -1394,10 +1380,25 @@ mod tests {
             .iter()
             .find(|event| event.reasons.contains(&NavigationTraceReason::Capture))
             .unwrap();
-        assert_eq!(capture.tick, 2_714);
         assert_eq!(capture.docked_planet, Some(3));
         assert_eq!(capture.pending_capture_planet, Some(3));
         assert_eq!(capture.pending_capture_ticks, Some(0));
+
+        let departure = episode
+            .navigation_trace
+            .iter()
+            .find(|event| {
+                event
+                    .reasons
+                    .contains(&NavigationTraceReason::SafeDeparture)
+                    && event.pending_capture_planet == Some(3)
+            })
+            .expect("Player 2 should clear planet 3 after capturing it");
+        assert!(departure.tick > capture.tick);
+        assert!(departure.tick - capture.tick <= NAVIGATION_TRACE_HEARTBEAT_TICKS);
+        assert!(departure.surface_clearance.unwrap() >= NAVIGATION_SAFE_DEPARTURE_CLEARANCE);
+        assert_eq!(departure.intent.brake, 0.0);
+        assert_eq!(departure.intent.thrust, 1.0);
 
         let terminal = episode.navigation_trace.last().unwrap();
         assert!(
@@ -1405,14 +1406,8 @@ mod tests {
                 .reasons
                 .contains(&NavigationTraceReason::EpisodeEnd)
         );
-        assert_eq!(terminal.port_phase, Some(PortNavigationPhase::Depart));
-        assert_eq!(terminal.docked_planet, Some(3));
-        assert_eq!(terminal.pending_capture_planet, Some(3));
-        assert_eq!(terminal.pending_capture_ticks, Some(1_286));
-        assert!(terminal.surface_clearance.unwrap() < 0.0);
-        assert_eq!(terminal.intent.turn, -1.0);
-        assert_eq!(terminal.intent.brake, 1.0);
-        assert_eq!(terminal.intent.thrust, 0.0);
+        assert_eq!(terminal.pending_capture_planet, None);
+        assert_eq!(terminal.pending_capture_ticks, None);
     }
 
     #[test]
@@ -1498,6 +1493,37 @@ mod tests {
         assert_eq!(tracker.port_departures, [1, 0]);
         assert_eq!(tracker.safe_capture_departures, [0, 0]);
         assert_eq!(tracker.body_contacts, [0, 0]);
+    }
+
+    #[test]
+    fn back_to_back_captures_keep_independent_safe_departures() {
+        let mut state = SpacewarsScenario::init(SpacewarsConfig::default(), 12);
+        let mut tracker = TransitionTracker::new(&state);
+        state.planets[0].position = engine_core::Vec2::ZERO;
+        state.planets[1].position = engine_core::Vec2::X * 20.0;
+        state.ships[0].position = engine_core::Vec2::ZERO;
+
+        state.spaceport_contacts =
+            vec![scenario_spacewars::SpaceportContact { ship: 0, planet: 0 }];
+        state.planets[0].owner_id = Some(0);
+        tracker.observe(&state);
+
+        // Reach and capture the next nearby port before attaining the first
+        // port's 90-unit safe-clearance threshold.
+        state.spaceport_contacts =
+            vec![scenario_spacewars::SpaceportContact { ship: 0, planet: 1 }];
+        state.planets[1].owner_id = Some(0);
+        tracker.observe(&state);
+        assert_eq!(tracker.captures, [2, 0]);
+        assert_eq!(tracker.safe_capture_departures, [0, 0]);
+
+        state.spaceport_contacts.clear();
+        state.ships[0].position = engine_core::Vec2::X * 2_000.0;
+        tracker.observe(&state);
+
+        assert_eq!(tracker.port_dockings, [2, 0]);
+        assert_eq!(tracker.port_departures, [2, 0]);
+        assert_eq!(tracker.safe_capture_departures, [2, 0]);
     }
 
     #[test]

--- a/crates/engine-agent/src/main.rs
+++ b/crates/engine-agent/src/main.rs
@@ -1,22 +1,277 @@
-//! Spacewars agent: training entry point. Embeds scenarios directly for speed.
-//!
-//! Stub for M3.
+//! Headless Spacewars episode runner and future training entry point.
 
-use clap::Parser;
+use std::{io, process::ExitCode};
+
+use clap::{Parser, ValueEnum};
+use engine_agent::{
+    BatchConfig, ControllerKind, EvaluationSuite, RunReport, SpacewarsPreset, run_batch, run_suite,
+};
+use scenario_spacewars::PlayerId;
 
 #[derive(Parser, Debug)]
-#[command(name = "engine-agent", about = "Spacewars agent training entry point")]
+#[command(
+    name = "engine-agent",
+    about = "Run deterministic Spacewars controller episodes without rendering"
+)]
 struct Args {
-    /// Scenario to train against.
-    #[arg(long, default_value = "null")]
-    scenario: String,
+    /// Run a fixed, named evaluation suite instead of a custom batch.
+    #[arg(
+        long,
+        value_enum,
+        conflicts_with_all = [
+            "scenario",
+            "preset",
+            "seed",
+            "seed_step",
+            "episodes",
+            "max_ticks",
+            "player_1",
+            "player_2"
+        ]
+    )]
+    suite: Option<SuiteArg>,
+
+    /// Scenario to evaluate.
+    #[arg(long, value_enum, default_value = "spacewars")]
+    scenario: ScenarioArg,
+
+    /// Spacewars world preset.
+    #[arg(long, value_enum, default_value = "standard")]
+    preset: PresetArg,
+
+    /// First episode seed.
+    #[arg(long, default_value_t = 0)]
+    seed: u64,
+
+    /// Amount added to the seed after each episode.
+    #[arg(long, default_value_t = 1)]
+    seed_step: u64,
+
+    /// Number of episodes to run.
+    #[arg(long, default_value_t = 1)]
+    episodes: u32,
+
+    /// Maximum fixed simulation ticks per episode.
+    #[arg(long, default_value_t = 36_000)]
+    max_ticks: u64,
+
+    /// Controller installed in player seat 1.
+    #[arg(long, value_enum, default_value = "idle")]
+    player_1: ControllerArg,
+
+    /// Controller installed in player seat 2.
+    #[arg(long, value_enum, default_value = "rule")]
+    player_2: ControllerArg,
+
+    /// Record navigation events for player 1 or 2 in a custom batch.
+    #[arg(long, value_parser = parse_trace_player, conflicts_with = "suite")]
+    trace_player: Option<PlayerId>,
+
+    /// Human-readable summary or versioned JSON report.
+    #[arg(long, value_enum, default_value = "text")]
+    output: OutputArg,
 }
 
-fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ScenarioArg {
+    Spacewars,
+}
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum PresetArg {
+    Standard,
+    StandardNoAsteroids,
+    Navigation,
+    Deathmatch,
+}
+
+impl From<PresetArg> for SpacewarsPreset {
+    fn from(value: PresetArg) -> Self {
+        match value {
+            PresetArg::Standard => Self::Standard,
+            PresetArg::StandardNoAsteroids => Self::StandardNoAsteroids,
+            PresetArg::Navigation => Self::Navigation,
+            PresetArg::Deathmatch => Self::Deathmatch,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SuiteArg {
+    NavigationV1,
+}
+
+impl From<SuiteArg> for EvaluationSuite {
+    fn from(value: SuiteArg) -> Self {
+        match value {
+            SuiteArg::NavigationV1 => Self::NavigationV1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ControllerArg {
+    Idle,
+    Rule,
+}
+
+impl From<ControllerArg> for ControllerKind {
+    fn from(value: ControllerArg) -> Self {
+        match value {
+            ControllerArg::Idle => Self::Idle,
+            ControllerArg::Rule => Self::Rule,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputArg {
+    Text,
+    Json,
+}
+
+fn parse_trace_player(value: &str) -> Result<PlayerId, String> {
+    match value {
+        "1" => Ok(PlayerId::PLAYER_1),
+        "2" => Ok(PlayerId::PLAYER_2),
+        _ => Err("trace player must be 1 or 2".to_owned()),
+    }
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("engine-agent: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    tracing::info!(scenario = %args.scenario, "engine-agent starting (stub).");
+    let report = if let Some(suite) = args.suite {
+        run_suite(suite.into())?
+    } else {
+        match args.scenario {
+            ScenarioArg::Spacewars => {}
+        }
+        run_batch(BatchConfig {
+            start_seed: args.seed,
+            seed_step: args.seed_step,
+            episodes: args.episodes,
+            preset: args.preset.into(),
+            controllers: [args.player_1.into(), args.player_2.into()],
+            max_ticks: args.max_ticks,
+            trace_player: args.trace_player,
+        })?
+    };
+
+    match args.output {
+        OutputArg::Text => print_text_report(&report),
+        OutputArg::Json => {
+            let stdout = io::stdout();
+            serde_json::to_writer_pretty(stdout.lock(), &report)?;
+            println!();
+        }
+    }
+    Ok(())
+}
+
+fn print_text_report(report: &RunReport) {
+    if let Some(suite_id) = report.suite_id {
+        println!("suite={suite_id}");
+    }
+    for episode in &report.episodes {
+        println!(
+            "seed={} outcome={} ticks={} sim={:.1}s captures={:?} losses={:?} rebuilds={:?} contacts(body/ship)={:?}/{:?} impacts(debris/laser)={:?}/{:?} docks={:?} departures(port/safe-capture/safe-rebuild)={:?}/{:?}/{:?} planets={:?} actions={} trace={}",
+            episode.seed,
+            episode.outcome,
+            episode.ticks,
+            episode.simulated_seconds,
+            episode.captures,
+            episode.ship_losses,
+            episode.rebuilds,
+            episode.body_contacts,
+            episode.ship_contacts,
+            episode.debris_impacts,
+            episode.laser_hits_received,
+            episode.port_dockings,
+            episode.port_departures,
+            episode.safe_capture_departures,
+            episode.safe_rebuild_departures,
+            episode.final_planet_counts,
+            episode.actions_emitted,
+            episode
+                .trace_sha256
+                .get(..12)
+                .unwrap_or(&episode.trace_sha256),
+        );
+        for event in &episode.navigation_trace {
+            println!(
+                "  nav tick={} p={} reason={:?} goal={:?} phase={:?} target={:?} docked={:?} pending={:?} age={} focus={:?} clearance={} outward={} port-omega={} velocity=({:.1},{:.1}) speed={:.1} rotation={:.2} port-rotation={} omega(control/measured)={:.2}/{:.2} heading={:.2} desired={:.1} relative={:.1} contact(body/ship)={}/{} intent(turn={:.2} thrust={:.1} brake={:.1} wings={} laser={} cannon={})",
+                event.tick,
+                event.player.index() + 1,
+                event.reasons,
+                event.goal,
+                event.port_phase,
+                event.target_planet,
+                event.docked_planet,
+                event.pending_capture_planet,
+                optional_u64(event.pending_capture_ticks),
+                event.focus_planet,
+                optional_f32(event.surface_clearance),
+                optional_f32(event.outward_speed),
+                optional_f32(event.spaceport_angular_speed),
+                event.world_velocity[0],
+                event.world_velocity[1],
+                event.world_speed,
+                event.world_rotation,
+                optional_f32(event.spaceport_rotation),
+                event.angular_velocity,
+                event.measured_angular_speed,
+                event.heading_error,
+                event.desired_speed,
+                event.relative_speed,
+                event.body_contact,
+                event.ship_contact,
+                event.intent.turn,
+                event.intent.thrust,
+                event.intent.brake,
+                event.intent.wings_closed,
+                event.intent.laser,
+                event.intent.cannon,
+            );
+        }
+    }
+    let summary = &report.summary;
+    println!(
+        "episodes={} winners={:?} tick_limits={} ticks={} wall={:.3}s ticks/s={:.0} realtime={:.1}x captures={:?} losses={:?} rebuilds={:?} contacts(body/ship)={:?}/{:?} impacts(debris/laser)={:?}/{:?} docks={:?} departures(port/safe-capture/safe-rebuild)={:?}/{:?}/{:?}",
+        summary.episodes,
+        summary.winner_counts,
+        summary.tick_limits,
+        summary.total_ticks,
+        summary.wall_seconds,
+        summary.ticks_per_wall_second,
+        summary.simulated_seconds_per_wall_second,
+        summary.captures,
+        summary.ship_losses,
+        summary.rebuilds,
+        summary.body_contacts,
+        summary.ship_contacts,
+        summary.debris_impacts,
+        summary.laser_hits_received,
+        summary.port_dockings,
+        summary.port_departures,
+        summary.safe_capture_departures,
+        summary.safe_rebuild_departures,
+    );
+}
+
+fn optional_f32(value: Option<f32>) -> String {
+    value.map_or_else(|| "-".to_owned(), |value| format!("{value:.1}"))
+}
+
+fn optional_u64(value: Option<u64>) -> String {
+    value.map_or_else(|| "-".to_owned(), |value| value.to_string())
 }

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -563,12 +563,15 @@ impl SpacewarsControls {
             });
             tracing::debug!(
                 player = player + 1,
+                seed = state.seed,
                 tick = state.tick,
                 goal = ?telemetry.goal,
                 target = ?telemetry.target,
                 target_planet = ?telemetry.target_planet,
                 port_phase = ?telemetry.port_phase,
                 hazard = ?telemetry.hazard,
+                avoided_body = ?telemetry.avoided_body,
+                avoidance_surface_clearance = ?telemetry.avoidance_surface_clearance,
                 distance = telemetry.target_distance,
                 heading_error = telemetry.heading_error,
                 desired_speed = telemetry.desired_speed,
@@ -580,6 +583,9 @@ impl SpacewarsControls {
                 ?intent,
                 "Spacewars rule-bot telemetry."
             );
+            let avoidance_surface_clearance = telemetry
+                .avoidance_surface_clearance
+                .map_or_else(|| "none".into(), |clearance| format!("{clearance:.3}"));
             let target = target_planet.map_or_else(
                 || "none".into(),
                 |planet| {
@@ -624,8 +630,9 @@ impl SpacewarsControls {
             );
             let ship = &state.ships[player];
             self.bot_diagnostics[player] = Some(format!(
-                "player={} tick={} planets={} winner={:?}\nbrain goal={:?} target={:?} target_planet={:?} phase={:?} hazard={:?} distance={:.3} heading_error={:.3} desired_speed={:.3} relative_speed={:.3}\nintent turn={:.3} thrust={:.3} brake={:.3} wings_closed={} laser={} cannon={}\nship form={:?} position={:?} velocity={:?} omega={:.3} observed_wings_closed={} docked_planet={:?}\ntarget {target}\ndocked {docked}",
+                "player={} seed={} tick={} planets={} winner={:?}\nbrain goal={:?} target={:?} target_planet={:?} phase={:?} hazard={:?} avoided_body={:?} avoidance_surface_clearance={} distance={:.3} heading_error={:.3} desired_speed={:.3} relative_speed={:.3}\nintent turn={:.3} thrust={:.3} brake={:.3} wings_closed={} laser={} cannon={}\nship form={:?} position={:?} velocity={:?} omega={:.3} observed_wings_closed={} docked_planet={:?}\ntarget {target}\ndocked {docked}",
                 player + 1,
+                state.seed,
                 state.tick,
                 state.players[player].planet_count,
                 state.winner,
@@ -634,6 +641,8 @@ impl SpacewarsControls {
                 telemetry.target_planet,
                 telemetry.port_phase,
                 telemetry.hazard,
+                telemetry.avoided_body,
+                avoidance_surface_clearance,
                 telemetry.target_distance,
                 telemetry.heading_error,
                 telemetry.desired_speed,
@@ -1354,8 +1363,9 @@ mod tests {
             ScenarioAction::SetTurn { player: 1, rate } if rate.abs() > 0.0
         )));
         let diagnostics = input.runtime_diagnostics_text();
-        assert!(diagnostics.contains("player=2 tick=0"));
+        assert!(diagnostics.contains("player=2 seed=7 tick=0"));
         assert!(diagnostics.contains("brain goal=Attack"));
+        assert!(diagnostics.contains("avoided_body=None avoidance_surface_clearance=none"));
         assert!(diagnostics.contains("docked none"));
 
         input.reset_spacewars_controls();

--- a/crates/spacewars-ai/Cargo.toml
+++ b/crates/spacewars-ai/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 engine-core = { workspace = true }
 scenario-spacewars = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 engine-common = { workspace = true }

--- a/crates/spacewars-ai/src/lib.rs
+++ b/crates/spacewars-ai/src/lib.rs
@@ -23,7 +23,7 @@ const TARGET_EPSILON: f32 = 1.0e-5;
 ///
 /// Bump this when rule-brain decision semantics change enough that evaluation
 /// results should no longer be compared as the same policy version.
-pub const RULE_SHIP_BRAIN_POLICY_ID: &str = "rule_ship_v1";
+pub const RULE_SHIP_BRAIN_POLICY_ID: &str = "rule_ship_v2";
 
 /// Episode context supplied whenever a host installs or restarts a brain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -719,7 +719,10 @@ impl RuleShipBrain {
             return ShipIntent {
                 turn: heading.turn,
                 thrust: if departure_burn_started { 1.0 } else { 0.0 },
-                brake: if departure_burn_started { 0.0 } else { 1.0 },
+                // Spaceport contact already damps and centers linear motion.
+                // Leaving the general brake off preserves angular authority
+                // while the ship turns inside the bay before launch.
+                brake: 0.0,
                 wings_closed: observation.own_ship.form == ShipForm::Ship && departure_burn_started,
                 ..ShipIntent::default()
             };
@@ -1173,13 +1176,14 @@ mod tests {
             departure_burn_started: false,
         });
 
-        brain.intent(&observation);
+        let depart_intent = brain.intent(&observation);
 
         assert_eq!(brain.telemetry().target_planet, Some(docked_planet));
         assert_eq!(
             brain.telemetry().port_phase,
             Some(PortNavigationPhase::Depart)
         );
+        assert_eq!(depart_intent.brake, 0.0);
 
         observation.planets[1].owner = None;
         let mut capture_brain = RuleShipBrain::default();

--- a/crates/spacewars-ai/src/lib.rs
+++ b/crates/spacewars-ai/src/lib.rs
@@ -23,7 +23,7 @@ const TARGET_EPSILON: f32 = 1.0e-5;
 ///
 /// Bump this when rule-brain decision semantics change enough that evaluation
 /// results should no longer be compared as the same policy version.
-pub const RULE_SHIP_BRAIN_POLICY_ID: &str = "rule_ship_v2";
+pub const RULE_SHIP_BRAIN_POLICY_ID: &str = "rule_ship_v3";
 
 /// Episode context supplied whenever a host installs or restarts a brain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -64,6 +64,13 @@ pub enum PortNavigationPhase {
     Depart,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AvoidanceBody {
+    Sun,
+    Planet(PlanetId),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct BrainTelemetry {
     pub actor: Option<PlayerId>,
@@ -72,6 +79,8 @@ pub struct BrainTelemetry {
     pub target_planet: Option<PlanetId>,
     pub port_phase: Option<PortNavigationPhase>,
     pub hazard: Option<DebrisId>,
+    pub avoided_body: Option<AvoidanceBody>,
+    pub avoidance_surface_clearance: Option<f32>,
     pub target_distance: f32,
     pub heading_error: f32,
     pub desired_speed: f32,
@@ -87,6 +96,8 @@ impl Default for BrainTelemetry {
             target_planet: None,
             port_phase: None,
             hazard: None,
+            avoided_body: None,
+            avoidance_surface_clearance: None,
             target_distance: 0.0,
             heading_error: 0.0,
             desired_speed: 0.0,
@@ -123,6 +134,21 @@ pub fn guide_heading(local_target: Vec2, angular_velocity: f32) -> HeadingGuidan
         error_radians,
         turn,
         aligned: error_radians.abs() <= 0.08,
+    }
+}
+
+/// Preserve a pod's angular authority while it is turning toward a target.
+///
+/// Spacewars pods cruise automatically when the brake is released, while the
+/// brake damps both linear and angular velocity. Combining a meaningful
+/// heading correction with braking therefore makes the pod cancel its own
+/// escape turn. Ships have independent thrust and steering, so their requested
+/// brake remains unchanged.
+fn steering_safe_brake(form: ShipForm, heading: HeadingGuidance, requested_brake: f32) -> f32 {
+    if form == ShipForm::EscapePod && !heading.aligned {
+        0.0
+    } else {
+        requested_brake
     }
 }
 
@@ -370,6 +396,13 @@ struct PortNavigation {
     departure_burn_started: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct BodyAvoidance {
+    body: AvoidanceBody,
+    direction: Vec2,
+    surface_clearance: f32,
+}
+
 /// Deterministic first-generation Spacewars opponent.
 ///
 /// It avoids imminent collisions, fights in planet-free worlds, and uses a
@@ -497,9 +530,8 @@ impl RuleShipBrain {
             if !keep_target {
                 self.port_navigation = None;
             } else {
-                if observation.own_ship.docked_planet == Some(navigation.planet)
-                    && navigation.phase != PortNavigationPhase::Depart
-                {
+                let docked_here = observation.own_ship.docked_planet == Some(navigation.planet);
+                if docked_here && navigation.phase != PortNavigationPhase::Depart {
                     navigation.phase = PortNavigationPhase::Docked;
                 }
                 let completed = planet.is_some_and(|planet| match navigation.goal {
@@ -509,6 +541,16 @@ impl RuleShipBrain {
                 });
                 if navigation.phase == PortNavigationPhase::Docked && completed {
                     navigation.phase = PortNavigationPhase::Depart;
+                } else if navigation.goal == BrainGoal::Rebuild
+                    && observation.own_ship.form == ShipForm::EscapePod
+                    && navigation.phase == PortNavigationPhase::Docked
+                    && !docked_here
+                {
+                    // Contact is authoritative, not the remembered phase. A
+                    // fast pod can clip the sensor before the rebuild timer is
+                    // complete; returning to ingress makes it reacquire the
+                    // port instead of waiting forever in empty space.
+                    navigation.phase = PortNavigationPhase::Ingress;
                 }
                 self.port_navigation = Some(navigation);
             }
@@ -538,8 +580,18 @@ impl RuleShipBrain {
             PortNavigationPhase::Approach => planet.spaceport_approach(clearance),
             _ => return,
         };
-        if target.local_position.length() <= self.config.spaceport_staging_tolerance
-            && target.local_velocity.length() <= self.config.spaceport_staging_velocity_tolerance
+        let reached_staging_position =
+            target.local_position.length() <= self.config.spaceport_staging_tolerance;
+        let matched_staging_velocity =
+            target.local_velocity.length() <= self.config.spaceport_staging_velocity_tolerance;
+        // A full ship can independently steer and throttle, so it should
+        // establish a stable position-and-velocity match before changing
+        // targets. A pod auto-cruises whenever its brake is released and
+        // cannot hold that same moving-ring match. Reaching the ring is enough
+        // to advance it toward the concrete spaceport instead of orbiting the
+        // radial rendezvous point forever.
+        if reached_staging_position
+            && (observation.own_ship.form == ShipForm::EscapePod || matched_staging_velocity)
         {
             navigation.phase = match navigation.phase {
                 PortNavigationPhase::Rendezvous => PortNavigationPhase::Approach,
@@ -571,22 +623,29 @@ impl RuleShipBrain {
         &self,
         observation: &ShipObservationV1,
         port_navigation: Option<PortNavigation>,
-    ) -> Option<Vec2> {
-        let mut nearest: Option<(f32, Vec2)> = None;
-        let mut consider = |position: Vec2, velocity: Vec2, radius: f32, clearance: f32| {
-            let surface_distance =
-                position.length() - radius - observation.own_ship.collision_radius;
-            let closing = position.dot(velocity) < 0.0;
-            if surface_distance > clearance || (!closing && surface_distance > clearance * 0.35) {
-                return;
-            }
-            if nearest.is_none_or(|(distance, _)| surface_distance < distance) {
-                nearest = Some((surface_distance, -position));
-            }
-        };
+    ) -> Option<BodyAvoidance> {
+        let mut nearest: Option<BodyAvoidance> = None;
+        let mut consider =
+            |body: AvoidanceBody, position: Vec2, velocity: Vec2, radius: f32, clearance: f32| {
+                let surface_distance =
+                    position.length() - radius - observation.own_ship.collision_radius;
+                let closing = position.dot(velocity) < 0.0;
+                if surface_distance > clearance || (!closing && surface_distance > clearance * 0.35)
+                {
+                    return;
+                }
+                if nearest.is_none_or(|avoidance| surface_distance < avoidance.surface_clearance) {
+                    nearest = Some(BodyAvoidance {
+                        body,
+                        direction: -position,
+                        surface_clearance: surface_distance,
+                    });
+                }
+            };
 
         if let Some(sun) = observation.sun {
             consider(
+                AvoidanceBody::Sun,
                 sun.local_position,
                 sun.local_velocity,
                 sun.radius,
@@ -607,13 +666,14 @@ impl RuleShipBrain {
                 self.config.body_clearance
             };
             consider(
+                AvoidanceBody::Planet(planet.id),
                 planet.local_position,
                 planet.local_velocity,
                 planet.radius,
                 clearance,
             );
         }
-        nearest.map(|(_, direction)| direction)
+        nearest
     }
 
     fn avoidance_intent(
@@ -622,6 +682,8 @@ impl RuleShipBrain {
         direction: Vec2,
         goal: BrainGoal,
         hazard: Option<DebrisId>,
+        avoided_body: Option<AvoidanceBody>,
+        avoidance_surface_clearance: Option<f32>,
     ) -> ShipIntent {
         let heading = guide_heading(direction, observation.own_ship.angular_velocity);
         let navigation = self.port_navigation;
@@ -630,10 +692,17 @@ impl RuleShipBrain {
             target_planet: navigation.map(|navigation| navigation.planet),
             port_phase: navigation.map(|navigation| navigation.phase),
             hazard,
+            avoided_body,
+            avoidance_surface_clearance,
             target_distance: direction.length(),
             heading_error: heading.error_radians,
             ..BrainTelemetry::default()
         });
+        let requested_brake = if heading.error_radians.abs() >= 0.65 {
+            1.0
+        } else {
+            0.0
+        };
         ShipIntent {
             turn: heading.turn,
             thrust: if heading.error_radians.abs() < 0.65 {
@@ -641,11 +710,7 @@ impl RuleShipBrain {
             } else {
                 0.0
             },
-            brake: if heading.error_radians.abs() >= 0.65 {
-                1.0
-            } else {
-                0.0
-            },
+            brake: steering_safe_brake(observation.own_ship.form, heading, requested_brake),
             ..ShipIntent::default()
         }
     }
@@ -795,7 +860,7 @@ impl RuleShipBrain {
             && navigation.phase == PortNavigationPhase::Rendezvous
             && guidance.target_distance > self.config.spaceport_cruise_distance
             && guidance.heading.error_radians.abs() < 0.12;
-        let (thrust, brake) = if observation.own_ship.form == ShipForm::EscapePod {
+        let (thrust, requested_brake) = if observation.own_ship.form == ShipForm::EscapePod {
             if guidance.thrust >= 0.75 {
                 (1.0, 0.0)
             } else {
@@ -804,6 +869,8 @@ impl RuleShipBrain {
         } else {
             (guidance.thrust, guidance.brake)
         };
+        let brake =
+            steering_safe_brake(observation.own_ship.form, guidance.heading, requested_brake);
         ShipIntent {
             turn: guidance.heading.turn,
             thrust,
@@ -857,8 +924,15 @@ impl ShipBrain for RuleShipBrain {
             _ => {}
         }
 
-        if let Some(direction) = self.body_avoidance(observation, self.port_navigation) {
-            return self.avoidance_intent(observation, direction, BrainGoal::AvoidBody, None);
+        if let Some(avoidance) = self.body_avoidance(observation, self.port_navigation) {
+            return self.avoidance_intent(
+                observation,
+                avoidance.direction,
+                BrainGoal::AvoidBody,
+                None,
+                Some(avoidance.body),
+                Some(avoidance.surface_clearance),
+            );
         }
 
         if let Some(threat) = earliest_collision_threat(
@@ -872,6 +946,8 @@ impl ShipBrain for RuleShipBrain {
                 threat.avoidance_direction,
                 BrainGoal::AvoidHazard,
                 Some(threat.hazard),
+                None,
+                None,
             );
         }
 
@@ -910,10 +986,11 @@ impl ShipBrain for RuleShipBrain {
                 ..BrainTelemetry::default()
             });
             let aligned = heading.error_radians.abs() < 0.65;
+            let requested_brake = if aligned { 0.0 } else { 1.0 };
             return ShipIntent {
                 turn: heading.turn,
                 thrust: if aligned { 1.0 } else { 0.0 },
-                brake: if aligned { 0.0 } else { 1.0 },
+                brake: steering_safe_brake(observation.own_ship.form, heading, requested_brake),
                 ..ShipIntent::default()
             };
         }
@@ -1148,6 +1225,454 @@ mod tests {
     }
 
     #[test]
+    fn pod_staging_is_position_driven_while_ship_staging_requires_velocity_match() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 21);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        let target_planet = observation.planets[0].id;
+        let brain_config = RuleShipBrainConfig::default();
+        let staging_radius = observation.planets[0].radius
+            + observation.own_ship.collision_radius
+            + brain_config.spaceport_staging_margin;
+        observation.planets[0].local_position = -Vec2::Y * staging_radius;
+        observation.planets[0].local_spaceport_position =
+            observation.planets[0].local_position + Vec2::X * observation.planets[0].radius;
+        observation.planets[0].local_velocity = Vec2::X * 100.0;
+        observation.planets[0].local_spaceport_velocity = Vec2::X * 100.0;
+
+        observation.own_ship.form = ShipForm::EscapePod;
+        observation.planets[0].owner = Some(PlayerId::PLAYER_2);
+        let mut pod_brain = RuleShipBrain::new(brain_config);
+        pod_brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        pod_brain.port_navigation = Some(PortNavigation {
+            goal: BrainGoal::Rebuild,
+            planet: target_planet,
+            phase: PortNavigationPhase::Rendezvous,
+            departure_burn_started: false,
+        });
+
+        pod_brain.refresh_port_navigation(&observation);
+
+        assert_eq!(
+            pod_brain.port_navigation.unwrap().phase,
+            PortNavigationPhase::Approach
+        );
+
+        observation.own_ship.form = ShipForm::Ship;
+        observation.planets[0].owner = None;
+        let mut ship_brain = RuleShipBrain::new(brain_config);
+        ship_brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        ship_brain.port_navigation = Some(PortNavigation {
+            goal: BrainGoal::Capture,
+            planet: target_planet,
+            phase: PortNavigationPhase::Rendezvous,
+            departure_burn_started: false,
+        });
+
+        ship_brain.refresh_port_navigation(&observation);
+
+        assert_eq!(
+            ship_brain.port_navigation.unwrap().phase,
+            PortNavigationPhase::Rendezvous
+        );
+    }
+
+    #[test]
+    fn escape_pod_steers_around_unowned_planet_without_braking() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 23);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.own_ship.form = ShipForm::EscapePod;
+        observation.sun = None;
+        observation.hazards.clear();
+        for (index, planet) in observation.planets.iter_mut().enumerate() {
+            planet.owner = None;
+            let offset = Vec2::new(2_000.0 + index as f32 * 200.0, 2_000.0);
+            let port_axis = (planet.local_spaceport_position - planet.local_position).normalized();
+            planet.local_position = offset;
+            planet.local_spaceport_position = offset + port_axis * planet.radius * 0.7;
+            planet.local_velocity = Vec2::ZERO;
+            planet.local_spaceport_velocity = Vec2::ZERO;
+        }
+        observation.planets[1].owner = Some(PlayerId::PLAYER_2);
+        let rebuild_planet = observation.planets[1].id;
+        let avoided_planet = observation.planets[0].id;
+        observation.planets[0].radius = 40.0;
+        observation.planets[0].local_position = Vec2::new(100.0, 0.0);
+        observation.planets[0].local_velocity = Vec2::new(-10.0, 0.0);
+        let expected_surface_clearance = 100.0 - 40.0 - observation.own_ship.collision_radius;
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let intent = brain.intent(&observation);
+
+        assert_eq!(brain.telemetry().goal, BrainGoal::AvoidBody);
+        assert_eq!(brain.telemetry().target_planet, Some(rebuild_planet));
+        assert_eq!(
+            brain.telemetry().port_phase,
+            Some(PortNavigationPhase::Rendezvous)
+        );
+        assert_eq!(
+            brain.telemetry().avoided_body,
+            Some(AvoidanceBody::Planet(avoided_planet))
+        );
+        assert_close(
+            brain.telemetry().avoidance_surface_clearance.unwrap(),
+            expected_surface_clearance,
+        );
+        assert!(intent.turn < 0.0);
+        assert_eq!(intent.brake, 0.0);
+    }
+
+    #[test]
+    fn escape_pod_physically_clears_an_unowned_planet_while_seeking_rebuild() {
+        let config = SpacewarsConfig {
+            universe_radius: 10_000,
+            asteroid_probability_per_sec: 0.0,
+            use_starfield: false,
+            use_sounds: false,
+            ..SpacewarsConfig::default()
+        };
+        let mut state = SpacewarsScenario::init(config, 25);
+        state.sun = None;
+        for (index, planet) in state.planets.iter_mut().enumerate() {
+            planet.position = Vec2::new(2_000.0 + index as f32 * 250.0, 2_000.0);
+            planet.owner_id = None;
+        }
+        state.planets[0].position = Vec2::ZERO;
+        state.planets[1].position = Vec2::new(-2_000.0, -1_500.0);
+        state.planets[1].owner_id = Some(PlayerId::PLAYER_2.index());
+        state.players[1].planet_count = 1;
+        state.ships[0].position = Vec2::new(-3_000.0, 3_000.0);
+        state.ships[0].velocity = Vec2::ZERO;
+        state.ships[1].life = 0.0;
+        state.ships[1].dead = true;
+        SpacewarsScenario::step(&mut state, &[], DT);
+        assert_eq!(state.ships[1].form, ShipForm::EscapePod);
+        state.debris.clear();
+
+        let pod_radius = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap()
+        .own_ship
+        .collision_radius;
+        let obstacle_radius = state.planets[0].radius;
+        let initial_surface_clearance = 45.0;
+        state.ships[1].position =
+            Vec2::X * (obstacle_radius + pod_radius + initial_surface_clearance);
+        state.ships[1].velocity = Vec2::new(-15.0, 0.0);
+        state.ships[1].rotation_radians = 0.0;
+        state.ships[1].direction = Vec2::Y;
+        state.ships[1].omega = 0.0;
+
+        let obstacle = PlanetId::from_index(0).unwrap();
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        let mut encoder = ShipIntentEncoder::default();
+        let mut maximum_surface_clearance = initial_surface_clearance;
+
+        for tick in 0..600 {
+            let observation = SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap();
+            let intent = brain.intent(&observation);
+            if tick == 0 {
+                assert_eq!(brain.telemetry().goal, BrainGoal::AvoidBody);
+                assert_eq!(
+                    brain.telemetry().avoided_body,
+                    Some(AvoidanceBody::Planet(obstacle))
+                );
+                assert!(intent.turn.abs() > 0.0);
+                assert_eq!(intent.brake, 0.0);
+            }
+            let actions = encoder.encode(PlayerId::PLAYER_2.index(), intent);
+            SpacewarsScenario::step(&mut state, &actions, DT);
+            let surface_clearance = state.ships[1]
+                .position
+                .distance_to(state.planets[0].position)
+                - obstacle_radius
+                - pod_radius;
+            maximum_surface_clearance = maximum_surface_clearance.max(surface_clearance);
+            if surface_clearance >= brain.config.body_clearance + 20.0 {
+                break;
+            }
+        }
+
+        assert!(
+            maximum_surface_clearance >= brain.config.body_clearance + 20.0,
+            "pod did not clear the unowned planet; maximum surface clearance {maximum_surface_clearance:.3}, telemetry {:?}, position {:?}, velocity {:?}",
+            brain.telemetry(),
+            state.ships[1].position,
+            state.ships[1].velocity,
+        );
+    }
+
+    fn assert_rule_brain_pod_rebuild_cycle(seed: u64) {
+        let config = SpacewarsConfig {
+            universe_radius: 5_000,
+            asteroid_probability_per_sec: 0.0,
+            use_starfield: false,
+            use_sounds: false,
+            ..SpacewarsConfig::default()
+        };
+        let mut state = SpacewarsScenario::init(config, seed);
+        let target_planet_index = 9;
+        assert!(state.planets.len() > target_planet_index);
+        for planet in &mut state.planets {
+            planet.owner_id = None;
+        }
+        state.planets[target_planet_index].owner_id = Some(PlayerId::PLAYER_2.index());
+        state.players[1].planet_count = 1;
+        state.ships[1].life = 0.0;
+        state.ships[1].dead = true;
+        SpacewarsScenario::step(&mut state, &[], DT);
+        assert_eq!(state.ships[1].form, ShipForm::EscapePod);
+        state.debris.clear();
+
+        let pod_radius = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap()
+        .own_ship
+        .collision_radius;
+        let target_planet_state = state.planets[target_planet_index];
+        state.ships[1].position = target_planet_state.position
+            + Vec2::X * (target_planet_state.radius + pod_radius + 60.0);
+        state.ships[1].velocity = Vec2::Y * 150.0;
+        state.ships[1].rotation_radians = 0.0;
+        state.ships[1].direction = Vec2::Y;
+        state.ships[1].omega = 0.0;
+
+        let target_planet = PlanetId::from_index(target_planet_index).unwrap();
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        let mut encoder = ShipIntentEncoder::default();
+        let mut saw_approach = false;
+        let mut saw_ingress = false;
+        let mut saw_docked = false;
+        let mut saw_rebuilt = false;
+        let mut saw_depart = false;
+        let mut saw_safe_departure = false;
+        let mut first_docked_tick = None;
+        let mut first_rebuilt_tick = None;
+        let mut minimum_target_distance = f32::INFINITY;
+        let mut docking_entries = 0_u64;
+        let mut continuous_docked_ticks = 0_u64;
+        let mut maximum_docked_ticks = 0_u64;
+        let mut was_docked = false;
+
+        for _ in 0..7_200 {
+            let observation = SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap();
+            let intent = brain.intent(&observation);
+            let telemetry = brain.telemetry();
+            minimum_target_distance = minimum_target_distance.min(telemetry.target_distance);
+            saw_approach |= telemetry.port_phase == Some(PortNavigationPhase::Approach);
+            saw_ingress |= telemetry.port_phase == Some(PortNavigationPhase::Ingress);
+            let docked = observation.own_ship.docked_planet == Some(target_planet);
+            if docked {
+                saw_docked = true;
+                first_docked_tick.get_or_insert(state.tick);
+                if !was_docked {
+                    docking_entries += 1;
+                }
+                continuous_docked_ticks += 1;
+                maximum_docked_ticks = maximum_docked_ticks.max(continuous_docked_ticks);
+            } else {
+                continuous_docked_ticks = 0;
+            }
+            was_docked = docked;
+            if observation.own_ship.form == ShipForm::Ship {
+                saw_rebuilt = true;
+                first_rebuilt_tick.get_or_insert(state.tick);
+            }
+            saw_depart |= saw_rebuilt
+                && telemetry.target_planet == Some(target_planet)
+                && telemetry.port_phase == Some(PortNavigationPhase::Depart);
+            if saw_depart && observation.own_ship.docked_planet != Some(target_planet) {
+                let target = observation
+                    .planets
+                    .iter()
+                    .find(|planet| planet.id == target_planet)
+                    .unwrap();
+                let surface_clearance = target.local_position.length()
+                    - target.radius
+                    - observation.own_ship.collision_radius;
+                saw_safe_departure = surface_clearance >= brain.config.body_clearance;
+            }
+            if saw_safe_departure {
+                break;
+            }
+
+            let actions = encoder.encode(PlayerId::PLAYER_2.index(), intent);
+            SpacewarsScenario::step(&mut state, &actions, DT);
+        }
+
+        assert!(saw_approach, "seed {seed} never reached port approach");
+        assert!(saw_ingress, "seed {seed} never began port ingress");
+        assert!(
+            saw_docked,
+            "seed {seed} pod never docked; minimum target distance {minimum_target_distance:.3}, telemetry {:?}, position {:?}, velocity {:?}",
+            brain.telemetry(),
+            state.ships[1].position,
+            state.ships[1].velocity,
+        );
+        assert!(
+            saw_rebuilt,
+            "seed {seed} docked pod never rebuilt; entries {docking_entries}, longest contact {maximum_docked_ticks} ticks, telemetry {:?}, form {:?}, docked {:?}, position {:?}, velocity {:?}",
+            brain.telemetry(),
+            state.ships[1].form,
+            SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap()
+            .own_ship
+            .docked_planet,
+            state.ships[1].position,
+            state.ships[1].velocity,
+        );
+        assert!(
+            first_rebuilt_tick.unwrap() - first_docked_tick.unwrap() >= 480,
+            "seed {seed} rebuild bypassed the eight-second dock timer"
+        );
+        assert!(saw_depart, "seed {seed} rebuilt ship never began departure");
+        assert!(
+            saw_safe_departure,
+            "seed {seed} rebuilt ship never safely departed"
+        );
+    }
+
+    #[test]
+    fn rule_brain_pod_docks_rebuilds_and_safely_departs() {
+        for seed in [0, 1, 2, 3, 4, 5] {
+            assert_rule_brain_pod_rebuild_cycle(seed);
+        }
+    }
+
+    #[test]
+    fn escape_pod_rendezvous_turn_does_not_apply_the_brake() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 27);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.own_ship.form = ShipForm::EscapePod;
+        observation.own_ship.local_velocity = Vec2::ZERO;
+        observation.own_ship.angular_velocity = 0.0;
+        observation.sun = None;
+        observation.hazards.clear();
+        for (index, planet) in observation.planets.iter_mut().enumerate() {
+            planet.owner = None;
+            let offset = Vec2::new(2_000.0 + index as f32 * 200.0, 2_000.0);
+            let port_axis = (planet.local_spaceport_position - planet.local_position).normalized();
+            planet.local_position = offset;
+            planet.local_spaceport_position = offset + port_axis * planet.radius * 0.7;
+            planet.local_velocity = Vec2::ZERO;
+            planet.local_spaceport_velocity = Vec2::ZERO;
+        }
+        let rebuild_planet = observation.planets[1].id;
+        observation.planets[1].owner = Some(PlayerId::PLAYER_2);
+        observation.planets[1].local_position = Vec2::new(0.0, -2_000.0);
+        observation.planets[1].local_spaceport_position = Vec2::new(0.0, -1_950.0);
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let intent = brain.intent(&observation);
+
+        assert_eq!(brain.telemetry().goal, BrainGoal::Rebuild);
+        assert_eq!(brain.telemetry().target_planet, Some(rebuild_planet));
+        assert_eq!(
+            brain.telemetry().port_phase,
+            Some(PortNavigationPhase::Rendezvous)
+        );
+        assert!(intent.turn.abs() > 0.0);
+        assert_eq!(intent.brake, 0.0);
+    }
+
+    #[test]
+    fn escape_pod_survival_turn_does_not_apply_the_brake() {
+        let mut config = SpacewarsConfig::deathmatch();
+        config.asteroid_probability_per_sec = 0.0;
+        let state = SpacewarsScenario::init(config, 29);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.own_ship.form = ShipForm::EscapePod;
+        observation.own_ship.angular_velocity = 0.0;
+        observation.sun = None;
+        observation.hazards.clear();
+        observation.opponent.as_mut().unwrap().local_position = Vec2::new(-100.0, 0.0);
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let intent = brain.intent(&observation);
+
+        assert_eq!(brain.telemetry().goal, BrainGoal::Survive);
+        assert!(intent.turn > 0.0);
+        assert_eq!(intent.brake, 0.0);
+    }
+
+    #[test]
     fn unexpected_docking_contact_overrides_the_planned_planet() {
         let config = SpacewarsConfig {
             asteroid_probability_per_sec: 0.0,
@@ -1206,6 +1731,53 @@ mod tests {
             Some(PortNavigationPhase::Docked)
         );
         assert_eq!(intent, ShipIntent::default());
+    }
+
+    #[test]
+    fn incomplete_pod_rebuild_reacquires_port_after_contact_loss() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 33);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.own_ship.form = ShipForm::EscapePod;
+        observation.sun = None;
+        observation.hazards.clear();
+        for (index, planet) in observation.planets.iter_mut().enumerate() {
+            planet.owner = None;
+            planet.local_position = Vec2::new(2_000.0 + index as f32 * 200.0, 2_000.0);
+        }
+        observation.planets[0].owner = Some(PlayerId::PLAYER_2);
+        let rebuild_planet = observation.planets[0].id;
+        let mut brain = RuleShipBrain::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let _ = brain.intent(&observation);
+        observation.own_ship.docked_planet = Some(rebuild_planet);
+        let _ = brain.intent(&observation);
+        assert_eq!(
+            brain.telemetry().port_phase,
+            Some(PortNavigationPhase::Docked)
+        );
+
+        observation.own_ship.docked_planet = None;
+        let _ = brain.intent(&observation);
+
+        assert_eq!(brain.telemetry().goal, BrainGoal::Rebuild);
+        assert_eq!(brain.telemetry().target_planet, Some(rebuild_planet));
+        assert_eq!(
+            brain.telemetry().port_phase,
+            Some(PortNavigationPhase::Ingress)
+        );
     }
 
     #[test]

--- a/crates/spacewars-ai/src/lib.rs
+++ b/crates/spacewars-ai/src/lib.rs
@@ -15,8 +15,15 @@ use scenario_spacewars::{
     DebrisId, HazardObservationV1, PlanetId, PlanetObservationV1, PlayerId, ShipForm, ShipIntent,
     ShipObservationV1,
 };
+use serde::Serialize;
 
 const TARGET_EPSILON: f32 = 1.0e-5;
+
+/// Stable policy identity stored in episode artifacts.
+///
+/// Bump this when rule-brain decision semantics change enough that evaluation
+/// results should no longer be compared as the same policy version.
+pub const RULE_SHIP_BRAIN_POLICY_ID: &str = "rule_ship_v1";
 
 /// Episode context supplied whenever a host installs or restarts a brain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,7 +41,8 @@ pub trait ShipBrain {
     fn telemetry(&self) -> BrainTelemetry;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BrainGoal {
     #[default]
     Idle,
@@ -46,7 +54,8 @@ pub enum BrainGoal {
     Rebuild,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PortNavigationPhase {
     Rendezvous,
     Approach,
@@ -55,7 +64,7 @@ pub enum PortNavigationPhase {
     Depart,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct BrainTelemetry {
     pub actor: Option<PlayerId>,
     pub goal: BrainGoal,

--- a/docs/design/ship-ai.md
+++ b/docs/design/ship-ai.md
@@ -126,13 +126,15 @@ The evaluator is allowed to read authoritative state to measure captures,
 ship losses, rebuilds, eliminations, collision incidents, docking, departures,
 and outcomes. Body and ship collision incidents re-arm after 30 contact-free
 ticks, preventing a sustained or briefly flickering scrape from dominating the
-count; debris and laser hits are already discrete events. A docking session
-records whether capture or rebuilding happened there, and counts successful
-departure only after the craft reaches 90 world units of surface clearance
-beyond its collision hull. This does not widen the controller boundary: each
-rule brain still receives only `ShipObservationV1`, and every intent still
-passes through `ShipIntentEncoder` and ordinary scenario actions before
-`Scenario::step()`.
+count; debris and laser hits are already discrete events. Docking contact
+transitions count port sessions, while each capture or rebuild opens its own
+pending departure window. A window completes only after the craft reaches 90
+world units of surface clearance beyond its collision hull. Keeping these
+windows independent preserves attribution even if a fast craft reaches another
+port before clearing the previous window. This does not widen the controller
+boundary: each rule brain still receives only `ShipObservationV1`, and every
+intent still passes through `ShipIntentEncoder` and ordinary scenario actions
+before `Scenario::step()`.
 
 Each deterministic episode summary includes its action stream and selected
 outcome-relevant terminal state in a SHA-256 trace fingerprint. Wall-clock
@@ -149,31 +151,38 @@ alter controller actions or the deterministic episode fingerprint, and normal
 untraced batches do not pay its extra observation cost.
 
 The first traced baseline isolated two unfinished departures. In seed 4,
-Player 2 captures planet 3 at tick 2,714 and remains docked through tick 36,000;
-seed 2 leaves Player 1 similarly docked after its fourth capture. Both brains
-remain in `Depart`, continuously request a turn plus brake, never request
-thrust, and stay roughly 45–50 units inside the surface. Their measured hull
-rotation repeatedly reverses while the turn command does not. The evidence
-points to a dock-bay rotation deadlock: solid contact opposes the attempted
-alignment, while the general brake removes angular authority along with linear
-motion.
+Player 2 captured planet 3 at tick 2,714 and remained docked through tick
+36,000; seed 2 left Player 1 similarly docked after its fourth capture. Both
+brains remained in `Depart`, continuously requesting a turn plus brake without
+ever starting thrust, roughly 45–50 units inside the surface. Two effects made
+that state self-sustaining: the general brake canceled the requested angular
+motion, and the broad asymmetric ship hull could bridge the inner planet and a
+spaceport wall while trying to turn.
 
-A bounded characterization test now reproduces the seed-4 failure at tick
-4,000. It pins the capture at tick 2,714 and verifies that Player 2 remains
-docked on planet 3 for the next 1,286 ticks with negative surface clearance,
-full turn, full brake, and no thrust. This assertion is intentionally a
-temporary bug contract; the departure repair should invert it to require safe
-clearance within the same budget.
+The departure repair is intentionally split at the controller/physics
+boundary. Rule policy `rule_ship_v2` does not apply the omnidirectional brake
+while aligning for launch; spaceport contact already damps and centers linear
+motion. A docked full ship that is actively maneuvering to leave keeps its
+ordinary collision groups and mass but temporarily uses a body-sized circular
+solver collider, so it remains contained while being free to rotate. A
+zero-mass copy of the normal hull preserves the established spaceport sensor
+footprint during that maneuver. The full physical hull remains in use while
+landing and capturing, and is restored when departure/ejection maneuvering
+ends. Escape pods retain their ordinary compact hull.
+
+The former seed-4 characterization is now a bounded regression test. Within
+4,000 ticks Player 2 captures planet 3, reaches the evaluator's 90-unit safe
+clearance within one 300-tick trace heartbeat, and has no unfinished capture
+departure at episode end. The complete six-seed `navigation-v1` run records 36
+captures and 36 safe capture departures; neither previously observed deadlock
+remains.
 
 ## Next slices
 
-1. Turn the seed-4/Player-2 departure into a regression test, then test removing
-   the pre-launch brake while retaining the spaceport's existing positional
-   damping. Confirm the seed-2 failure and the complete `navigation-v1` suite.
-2. Add a slower strategic state machine for capture, repair, defend, and combat
+1. Add a slower strategic state machine for capture, repair, defend, and combat
    goals, including commitment and hysteresis.
-3. Compare each strategy revision against the baseline outcomes and traces.
-4. Promote additional scenario transitions to typed evaluator events when
+2. Compare each strategy revision against the baseline outcomes and traces.
+3. Promote additional scenario transitions to typed evaluator events when
    state-difference metrics are no longer expressive enough.
-5. Add policy adapters and batched observation storage only after the rule path
+4. Add policy adapters and batched observation storage only after the rule path
    gives us stable semantics and measurable workloads.

--- a/docs/design/ship-ai.md
+++ b/docs/design/ship-ai.md
@@ -105,13 +105,75 @@ repair, defend, and attack goals against each other or use personality weights.
 Small Duel remains the clearest combat test; a normal planet world exercises
 the docking path.
 
+## Headless evaluation
+
+`engine-agent` now embeds the Spacewars scenario and runs the same
+observation/brain/intent/action loop without rendering, audio, or realtime
+pacing. An episode explicitly records its world preset, seed, tick limit, and
+versioned controller identity. Batches walk a configurable seed sequence and
+can install an idle or rule controller independently in each player seat.
+The `standard-no-asteroids` preset changes only the standard configuration's
+asteroid spawn rate, providing a controlled navigation baseline without
+redefining normal gameplay.
+
+The named `navigation-v1` suite turns that baseline into a reproducible
+contract: seeds 0 through 5, rule-brain self-play, a 36,000-tick ceiling, no
+random asteroids, and deliberately high ship health. Collisions and docking
+physics remain active. This keeps accidental destruction from truncating the
+experiment while preserving the contacts that navigation guidance must avoid.
+
+The evaluator is allowed to read authoritative state to measure captures,
+ship losses, rebuilds, eliminations, collision incidents, docking, departures,
+and outcomes. Body and ship collision incidents re-arm after 30 contact-free
+ticks, preventing a sustained or briefly flickering scrape from dominating the
+count; debris and laser hits are already discrete events. A docking session
+records whether capture or rebuilding happened there, and counts successful
+departure only after the craft reaches 90 world units of surface clearance
+beyond its collision hull. This does not widen the controller boundary: each
+rule brain still receives only `ShipObservationV1`, and every intent still
+passes through `ShipIntentEncoder` and ordinary scenario actions before
+`Scenario::step()`.
+
+Each deterministic episode summary includes its action stream and selected
+outcome-relevant terminal state in a SHA-256 trace fingerprint. Wall-clock
+throughput is reported only at the batch layer and is intentionally excluded
+from deterministic comparisons. Versioned JSON output provides the first
+artifact format for regression suites and later training experiments.
+
+An opt-in per-player navigation trace sits on the evaluator side of the same
+boundary. It samples semantic brain and docking transitions immediately, then
+adds a heartbeat every 300 ticks while a post-capture departure is unfinished.
+The sample combines `BrainTelemetry`, the emitted `ShipIntent`, dock/contact
+state, planet surface clearance, and outward velocity. Collecting it does not
+alter controller actions or the deterministic episode fingerprint, and normal
+untraced batches do not pay its extra observation cost.
+
+The first traced baseline isolated two unfinished departures. In seed 4,
+Player 2 captures planet 3 at tick 2,714 and remains docked through tick 36,000;
+seed 2 leaves Player 1 similarly docked after its fourth capture. Both brains
+remain in `Depart`, continuously request a turn plus brake, never request
+thrust, and stay roughly 45–50 units inside the surface. Their measured hull
+rotation repeatedly reverses while the turn command does not. The evidence
+points to a dock-bay rotation deadlock: solid contact opposes the attempted
+alignment, while the general brake removes angular authority along with linear
+motion.
+
+A bounded characterization test now reproduces the seed-4 failure at tick
+4,000. It pins the capture at tick 2,714 and verifies that Player 2 remains
+docked on planet 3 for the next 1,286 ticks with negative surface clearance,
+full turn, full brake, and no thrust. This assertion is intentionally a
+temporary bug contract; the departure repair should invert it to require safe
+clearance within the same budget.
+
 ## Next slices
 
-1. Add a slower strategic state machine for capture, repair, defend, and combat
+1. Turn the seed-4/Player-2 departure into a regression test, then test removing
+   the pre-launch brake while retaining the spaceport's existing positional
+   damping. Confirm the seed-2 failure and the complete `navigation-v1` suite.
+2. Add a slower strategic state machine for capture, repair, defend, and combat
    goals, including commitment and hysteresis.
-2. Add deterministic repair and full escape-pod rebuild episodes around the
-   moving-spaceport fixture.
-3. Surface brain telemetry in developer HUD/IPC tooling.
-4. Let `engine-agent` run the same observation/brain/action loop headlessly.
+3. Compare each strategy revision against the baseline outcomes and traces.
+4. Promote additional scenario transitions to typed evaluator events when
+   state-difference metrics are no longer expressive enough.
 5. Add policy adapters and batched observation storage only after the rule path
    gives us stable semantics and measurable workloads.

--- a/docs/design/ship-ai.md
+++ b/docs/design/ship-ai.md
@@ -62,8 +62,9 @@ version.
 
 - `reset(BrainReset)` installs an actor and episode seed;
 - `intent(&ShipObservationV1)` produces one normalized controller intent;
-- `telemetry()` reports the current goal, target, hazard, range, and heading
-  error without granting state access.
+- `telemetry()` reports the current goal, target, hazard, avoided celestial
+  body and surface clearance, range, and heading error without granting state
+  access.
 
 When a host changes between human, rule-bot, or benchmark control, it forwards
 one neutral intent before the new source. This releases held thrust and weapons
@@ -87,6 +88,9 @@ The first deterministic bot is selectable for Player 2 in the launcher. It:
 - treats a sensed docking contact as authoritative over its planned target,
   capturing an unexpected unowned port or relaunching from an owned one;
 - seeks an owned spaceport for rebuilding when reduced to an escape pod;
+- preserves pod steering authority during avoidance, rebuild navigation, and
+  fallback survival turns instead of combining those turns with angular
+  braking;
 - uses fast wings only for long, aligned pursuit;
 - fires laser/cannon only inside configured alignment and range windows;
 - falls back to simple escape behavior when a pod has no accessible port.
@@ -160,7 +164,8 @@ motion, and the broad asymmetric ship hull could bridge the inner planet and a
 spaceport wall while trying to turn.
 
 The departure repair is intentionally split at the controller/physics
-boundary. Rule policy `rule_ship_v2` does not apply the omnidirectional brake
+boundary. Rule policy `rule_ship_v2` introduced a departure maneuver that does
+not apply the omnidirectional brake
 while aligning for launch; spaceport contact already damps and centers linear
 motion. A docked full ship that is actively maneuvering to leave keeps its
 ordinary collision groups and mass but temporarily uses a body-sized circular
@@ -169,6 +174,30 @@ zero-mass copy of the normal hull preserves the established spaceport sensor
 footprint during that maneuver. The full physical hull remains in use while
 landing and capturing, and is restored when departure/ejection maneuvering
 ends. Escape pods retain their ordinary compact hull.
+
+Rule policy `rule_ship_v3` accounts for the pod actuator's different meaning:
+releasing its brake provides automatic forward cruise, while applying the
+brake damps angular as well as linear velocity. A pod therefore suppresses a
+requested brake while it has a meaningful heading correction during body or
+hazard avoidance, rebuild-port navigation, and fallback survival. Unlike a
+ship, it cannot hover while matching a moving staging ring's velocity. Pod
+rendezvous and approach transitions are therefore position-driven geometric
+waypoints; ingress still has to establish a real, ownership-approved spaceport
+contact. If that contact is lost before the eight-second rebuild completes,
+the remembered `Docked` phase returns to `Ingress` and actively reacquires the
+port. Full-ship staging and capture behavior retain their position-and-velocity
+requirements. Body-avoidance telemetry records whether the active obstacle is
+the sun or a stable planet ID together with signed hull-to-surface clearance,
+and the interactive control-socket status also includes the episode seed so a
+live failure can be reproduced exactly.
+
+The pod rebuild regression runs seeds 0 through 5 in 10,000-radius generated
+worlds, targets outer `PlanetId(9)`, and starts with the tangential fixed-speed
+flyby that previously produced a permanent orbit. Every run must observe
+approach, ingress, physical docking, at least 480 docked ticks, restoration to
+a full ship, departure, and 90 units of safe surface clearance. A focused
+contact-loss test separately verifies that an incomplete rebuild returns to
+ingress instead of remaining logically docked in empty space.
 
 The former seed-4 characterization is now a bounded regression test. Within
 4,000 ticks Player 2 captures planet 3, reaches the evaluator's 90-unit safe

--- a/scenarios/spacewars/src/physics.rs
+++ b/scenarios/spacewars/src/physics.rs
@@ -53,6 +53,10 @@ const GROUP_ALL_SOLIDS: u32 =
 
 const PLANET_SURFACE_SEGMENTS: usize = 24;
 const WORLD_SURFACE_SEGMENTS: usize = 192;
+// The full ship silhouette is intentionally broad, but that shape can bridge
+// the inner planet and a spaceport wall while the craft turns in the bay. Use
+// a body-sized, rotation-invariant contact shape during active port maneuvers.
+const DOCKED_SHIP_COLLIDER_RADIUS: f32 = 2.5;
 
 pub(super) fn spacewars_rover_spec() -> RoverSpec {
     RoverSpec {
@@ -116,6 +120,7 @@ struct ShipColliderKey {
     form: ShipForm,
     wing_theta: u32,
     docked: bool,
+    compact: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -196,7 +201,7 @@ impl SpacewarsPhysics {
             let _ = physics.insert_planet(index, planet);
         }
         for (index, ship) in ships.iter().enumerate() {
-            let _ = physics.insert_ship(index, ship, false);
+            let _ = physics.insert_ship(index, ship, false, false);
         }
         physics
     }
@@ -255,14 +260,24 @@ impl SpacewarsPhysics {
         }
 
         for (index, ship) in ships.iter().enumerate() {
+            let sensor_docked = docked_ships[index];
+            let docked = sensor_docked || ship.spaceport_ejection.is_some();
+            // Preserve normal arrival/capture mechanics until the controls
+            // indicate an intentional departure maneuver.
+            let compact = ship.spaceport_ejection.is_some()
+                || (sensor_docked
+                    && ship.brake <= 0.0
+                    && (ship.turn.abs() > f32::EPSILON || ship.thrust.abs() > f32::EPSILON));
             let key = ShipColliderKey {
                 form: ship.form,
                 wing_theta: ship.wing_theta.to_bits(),
-                docked: docked_ships[index] || ship.spaceport_ejection.is_some(),
+                docked,
+                compact,
             };
             if self.ship_keys[index] != Some(key) {
                 lifecycle.removed += usize::from(self.world.remove_entity(ship_entity(index)));
-                lifecycle.added += usize::from(self.insert_ship(index, ship, key.docked));
+                lifecycle.added +=
+                    usize::from(self.insert_ship(index, ship, key.docked, key.compact));
             } else {
                 synchronize_ship_to_physics(&mut self.world, index, ship);
             }
@@ -674,9 +689,9 @@ impl SpacewarsPhysics {
         inserted
     }
 
-    fn insert_ship(&mut self, index: usize, ship: &ShipState, docked: bool) -> bool {
+    fn insert_ship(&mut self, index: usize, ship: &ShipState, docked: bool, compact: bool) -> bool {
         let entity = ship_entity(index);
-        let collider = ship_collider(entity, ship, docked);
+        let colliders = ship_colliders(entity, ship, docked, compact);
         let inserted = self.world.insert_body(
             primary_body(entity),
             BodySpec {
@@ -691,13 +706,14 @@ impl SpacewarsPhysics {
                 additional_solver_iterations: 2,
                 ..BodySpec::default()
             },
-            &[collider],
+            &colliders,
         );
         debug_assert!(inserted);
         self.ship_keys[index] = Some(ShipColliderKey {
             form: ship.form,
             wing_theta: ship.wing_theta.to_bits(),
             docked,
+            compact,
         });
         inserted
     }
@@ -886,17 +902,46 @@ fn ship_local_triangles(ship: &ShipState) -> Vec<[Vec2; 3]> {
     ]
 }
 
-fn ship_collider(entity: PhysicsId, ship: &ShipState, docked: bool) -> ColliderSpec {
-    let hull = ship_collision_hull(ship);
-    let density = ship.mass() / polygon_area(&hull).max(f32::EPSILON);
+fn ship_colliders(
+    entity: PhysicsId,
+    ship: &ShipState,
+    docked: bool,
+    compact: bool,
+) -> Vec<ColliderSpec> {
+    debug_assert!(!compact || docked);
     let groups = ship_collision_groups(ship, docked);
-    let mut collider = ColliderSpec::convex_polygon(collider_id(entity, SHIP_HULL_ROLE, 0), hull);
-    collider.density = density;
+    let primary_id = collider_id(entity, SHIP_HULL_ROLE, 0);
+    let compact_while_docked = compact && ship.form == ShipForm::Ship;
+    let hull = ship_collision_hull(ship);
+    let (mut collider, area) = if compact_while_docked {
+        (
+            ColliderSpec::ball(primary_id, DOCKED_SHIP_COLLIDER_RADIUS),
+            core::f32::consts::PI * DOCKED_SHIP_COLLIDER_RADIUS.powi(2),
+        )
+    } else {
+        let area = polygon_area(&hull);
+        (ColliderSpec::convex_polygon(primary_id, hull.clone()), area)
+    };
+    collider.density = ship.mass() / area.max(f32::EPSILON);
     collider.friction = 0.0;
     collider.restitution = DEFAULT_ELASTICITY;
     collider.collision_groups = groups;
     collider.solver_groups = groups;
-    collider
+    let mut colliders = vec![collider];
+
+    if compact_while_docked {
+        // Retain the normal hull exclusively as a sensor probe. This keeps the
+        // established landing/capture footprint stable when the physical hull
+        // becomes compact, preventing shallow contacts from flickering.
+        let mut probe = ColliderSpec::convex_polygon(collider_id(entity, SHIP_HULL_ROLE, 1), hull);
+        probe.density = 0.0;
+        probe.sensor = true;
+        probe.collision_groups = CollisionGroups::new(groups.memberships, GROUP_SPACEPORT_SENSOR);
+        probe.solver_groups = CollisionGroups::NONE;
+        colliders.push(probe);
+    }
+
+    colliders
 }
 
 /// Build one stable convex collision silhouette from the independently rendered
@@ -1216,7 +1261,9 @@ mod tests {
                 }
             }
 
-            let collider = ship_collider(ship_entity(0), ship, false);
+            let mut colliders = ship_colliders(ship_entity(0), ship, false, false);
+            assert_eq!(colliders.len(), 1);
+            let collider = colliders.pop().unwrap();
             let engine_rapier::world::ColliderShape::ConvexPolygon { vertices } = collider.shape
             else {
                 panic!("ship should use one convex polygon");
@@ -1231,6 +1278,48 @@ mod tests {
             ship_collision_hull(&ship),
             ship_collision_hull(&closed_ship)
         );
+    }
+
+    #[test]
+    fn docked_ship_uses_a_compact_rotation_invariant_collider() {
+        let mut ship =
+            ShipState::new_with_default_life(0, Vec2::ZERO, engine_core::Color::WHITE, 1.0 / 60.0);
+        let open_hull = ship_collision_hull(&ship);
+        let open = ship_colliders(ship_entity(0), &ship, true, true);
+        ship.wing_theta = super::super::MAX_WING_THETA;
+        let closed = ship_colliders(ship_entity(0), &ship, true, true);
+
+        assert_eq!(open.len(), 2);
+        assert_eq!(closed.len(), 2);
+        let engine_rapier::world::ColliderShape::Ball { radius } = open[0].shape else {
+            panic!("docked ship should use one circular collider");
+        };
+        assert_eq!(radius, DOCKED_SHIP_COLLIDER_RADIUS);
+        assert_eq!(
+            closed[0].shape,
+            engine_rapier::world::ColliderShape::Ball { radius }
+        );
+        assert!(
+            (open[0].density * core::f32::consts::PI * radius.powi(2) - ship.mass()).abs() < 1.0e-4
+        );
+        assert!(open[1].sensor);
+        assert_eq!(open[1].density, 0.0);
+        assert_eq!(open[1].solver_groups, CollisionGroups::NONE);
+        assert_eq!(
+            open[1].shape,
+            engine_rapier::world::ColliderShape::ConvexPolygon {
+                vertices: open_hull
+            }
+        );
+
+        assert!(matches!(
+            ship_colliders(ship_entity(0), &ship, false, false)[0].shape,
+            engine_rapier::world::ColliderShape::ConvexPolygon { .. }
+        ));
+        assert!(matches!(
+            ship_colliders(ship_entity(0), &ship, true, false)[0].shape,
+            engine_rapier::world::ColliderShape::ConvexPolygon { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a deterministic headless `engine-agent` runner with explicit presets, controller assignments, seed batches, versioned JSON reports, action fingerprints, transition metrics, and opt-in navigation traces
- add the fixed `navigation-v1` evaluation contract for repeatable rule-bot capture and departure testing without random asteroids
- repair spaceport departures by preserving steering authority and using a compact docked maneuver collider while retaining the normal sensor footprint
- make escape-pod avoidance and rebuild navigation respect the pod's fixed-speed actuator, including position-driven staging and port reacquisition after incomplete contact
- expose the avoided celestial body, signed surface clearance, seed, phase, and intent through live rule-bot diagnostics
- document the controller boundary, evaluator model, telemetry, and regression contracts

## Pod recovery coverage

The end-to-end pod regression runs seeds 0 through 5 in 10,000-radius generated worlds against outer `PlanetId(9)`. Each run must observe:

1. port approach and ingress
2. real ownership-approved spaceport contact
3. at least 480 docked ticks for the rebuild timer
4. escape-pod restoration to a full ship
5. departure and 90 units of safe surface clearance

A separate regression verifies that a pod which briefly loses rebuild contact returns to ingress instead of remaining logically docked in empty space.

## Validation

- `cargo +1.89.0 test --workspace`
- `cargo +1.89.0 clippy -p spacewars-ai --all-targets --no-deps -- -D warnings`
- `cargo +1.89.0 run --release -p engine-agent -- --suite navigation-v1`
  - 36 captures
  - 36 safe capture departures
  - no ship losses
  - unchanged six-seed navigation fingerprints after scoping the pod changes
- `cargo +1.89.0 build --release -p engine-client`
- manual playtesting confirmed a rule-bot pod can escape a planet, dock at its owned spaceport, and rebuild into a ship
