### PR TITLE
Add versioned UI state snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,7 @@ dependencies = [
  "slint",
  "slint-build",
  "spacewars-ai",
+ "spacewars-control",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -5064,6 +5065,15 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "engine-common",
+ "spacewars-control",
+]
+
+[[package]]
+name = "spacewars-control"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/engine-rapier",
     "crates/spacewars-ai",
     "crates/engine-client",
+    "crates/spacewars-control",
     "crates/spacewars-cli",
     "crates/engine-agent",
     "crates/engine-os-manager",
@@ -63,6 +64,7 @@ engine-gravity = { path = "crates/engine-gravity" }
 engine-nes = { path = "crates/engine-nes" }
 engine-rapier = { path = "crates/engine-rapier" }
 spacewars-ai = { path = "crates/spacewars-ai" }
+spacewars-control = { path = "crates/spacewars-control" }
 scenario-falling = { path = "scenarios/falling" }
 scenario-nes = { path = "scenarios/nes" }
 scenario-null = { path = "scenarios/null" }

--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ body avoidance it identifies the sun or planet being avoided and reports the
 craft's signed surface clearance. This keeps diagnostic formatting out of the
 simulation hot path.
 
+Inspect the visible UI screen and its selected and active scenarios separately:
+
+```sh
+spacewars-cli ui state
+spacewars-cli ui state --json
+```
+
+The JSON form is a versioned automation contract. It reports the exact launcher,
+gameplay, pause, controls, touch-test, or game-over screen; a monotonic UI
+revision; the active scenario instance revision; and pause and benchmark state.
+Returning to the launcher clears active-scenario state while preserving the
+launcher selection. The existing `status` command remains the detailed
+performance and scenario diagnostics interface.
+
 Start or restart the selected scenario's visual benchmark and wait until the
 host confirms a new scenario instance:
 

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -15,6 +15,7 @@ engine-common = { workspace = true }
 engine-core = { workspace = true }
 engine-nes = { workspace = true }
 spacewars-ai = { workspace = true }
+spacewars-control = { workspace = true }
 scenario-falling = { workspace = true }
 scenario-nes = { workspace = true }
 scenario-null = { workspace = true }

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -16,6 +16,11 @@ use engine_common::DEFAULT_CONTROL_SOCKET;
 use slint::Timer;
 #[cfg(unix)]
 use slint::{ComponentHandle, Rgba8Pixel, SharedPixelBuffer, TimerMode};
+#[cfg(unix)]
+use spacewars_control::{
+    ProtocolError, RuntimeStatus, UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiScreen, UiState,
+    parse_runtime_status,
+};
 
 use crate::MainWindow;
 
@@ -31,7 +36,59 @@ struct ControlRequest {
 enum ControlCommand {
     Screenshot { output: PathBuf },
     Status,
+    UiState,
     HostBenchmark,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ScreenVisibility {
+    launcher: bool,
+    launcher_controls: bool,
+    launcher_settings: bool,
+    touch_test: bool,
+    ingame_menu: bool,
+    ingame_controls: bool,
+    game_over: bool,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UiStateObservation {
+    screen: UiScreen,
+    active_scenario: Option<String>,
+    selected_scenario: String,
+    scenario_revision: Option<u64>,
+    paused: bool,
+    benchmark_active: bool,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Default)]
+struct UiStateTracker {
+    revision: u64,
+    last_observation: Option<UiStateObservation>,
+}
+
+#[cfg(unix)]
+impl UiStateTracker {
+    fn observe(&mut self, observation: UiStateObservation) -> UiState {
+        if self.last_observation.as_ref() != Some(&observation) {
+            self.revision = self.revision.saturating_add(1);
+            self.last_observation = Some(observation.clone());
+        }
+
+        UiState {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            revision: self.revision,
+            screen: observation.screen,
+            active_scenario: observation.active_scenario,
+            selected_scenario: observation.selected_scenario,
+            scenario_revision: observation.scenario_revision,
+            paused: observation.paused,
+            benchmark_active: observation.benchmark_active,
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -71,13 +128,14 @@ pub fn start_control_server(window: &MainWindow, socket_path: PathBuf) -> Option
 
     let timer = Timer::default();
     let weak_window = window.as_weak();
+    let mut ui_state_tracker = UiStateTracker::default();
     timer.start(TimerMode::Repeated, Duration::from_millis(50), move || {
         let Some(window) = weak_window.upgrade() else {
             return;
         };
 
         while let Ok(request) = rx.try_recv() {
-            handle_request(&window, request);
+            handle_request(&window, request, &mut ui_state_tracker);
         }
     });
 
@@ -170,6 +228,12 @@ fn parse_command(body: &str) -> Result<ControlCommand, String> {
             }
             Ok(ControlCommand::Status)
         }
+        Some(UI_STATE_COMMAND) => {
+            if lines.next().is_some() {
+                return Err("too many command lines".into());
+            }
+            Ok(ControlCommand::UiState)
+        }
         Some("host benchmark") => {
             if lines.next().is_some() {
                 return Err("too many command lines".into());
@@ -182,7 +246,11 @@ fn parse_command(body: &str) -> Result<ControlCommand, String> {
 }
 
 #[cfg(unix)]
-fn handle_request(window: &MainWindow, request: ControlRequest) {
+fn handle_request(
+    window: &MainWindow,
+    request: ControlRequest,
+    ui_state_tracker: &mut UiStateTracker,
+) {
     match request.command {
         ControlCommand::Screenshot { output } => match write_window_screenshot(window, &output) {
             Ok(()) => request
@@ -191,6 +259,12 @@ fn handle_request(window: &MainWindow, request: ControlRequest) {
             Err(err) => request.response.error(err.to_string()),
         },
         ControlCommand::Status => request.response.ok(window.get_runtime_diagnostics()),
+        ControlCommand::UiState => {
+            match ui_state(window, ui_state_tracker).and_then(|state| state.to_json()) {
+                Ok(json) => request.response.ok(json),
+                Err(error) => request.response.error(error.to_string()),
+            }
+        }
         ControlCommand::HostBenchmark => {
             if !window.get_scenario_benchmark_available() {
                 request
@@ -215,6 +289,64 @@ fn handle_request(window: &MainWindow, request: ControlRequest) {
                 request.response.ok("benchmark requested");
             }
         }
+    }
+}
+
+#[cfg(unix)]
+fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState, ProtocolError> {
+    let screen = classify_screen(ScreenVisibility {
+        launcher: window.get_launcher_visible(),
+        launcher_controls: window.get_launcher_controls_visible(),
+        launcher_settings: window.get_launcher_settings_visible(),
+        touch_test: window.get_touch_test_visible(),
+        ingame_menu: window.get_ingame_menu_visible(),
+        ingame_controls: window.get_ingame_controls_visible(),
+        game_over: window.get_game_over_visible(),
+    });
+    let runtime = runtime_status_for_screen(screen, window.get_runtime_diagnostics().as_str())?;
+
+    Ok(tracker.observe(UiStateObservation {
+        screen,
+        active_scenario: runtime.active_scenario,
+        selected_scenario: window.get_launcher_scenario().into(),
+        scenario_revision: runtime.scenario_revision,
+        paused: runtime.paused,
+        benchmark_active: runtime.benchmark_active,
+    }))
+}
+
+#[cfg(unix)]
+fn runtime_status_for_screen(
+    screen: UiScreen,
+    diagnostics: &str,
+) -> Result<RuntimeStatus, ProtocolError> {
+    if screen.is_launcher() {
+        Ok(RuntimeStatus::inactive())
+    } else {
+        parse_runtime_status(diagnostics)
+    }
+}
+
+#[cfg(unix)]
+fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
+    if visibility.touch_test {
+        UiScreen::LauncherTouchTest
+    } else if visibility.launcher {
+        if visibility.launcher_controls {
+            UiScreen::LauncherControls
+        } else if visibility.launcher_settings {
+            UiScreen::LauncherSettings
+        } else {
+            UiScreen::LauncherMain
+        }
+    } else if visibility.game_over {
+        UiScreen::GameOver
+    } else if visibility.ingame_controls {
+        UiScreen::PauseControls
+    } else if visibility.ingame_menu {
+        UiScreen::PauseMain
+    } else {
+        UiScreen::Gameplay
     }
 }
 
@@ -260,7 +392,7 @@ mod tests {
             ControlCommand::Screenshot { output } => {
                 assert_eq!(output, PathBuf::from("/tmp/shot.png"));
             }
-            ControlCommand::Status | ControlCommand::HostBenchmark => {
+            ControlCommand::Status | ControlCommand::UiState | ControlCommand::HostBenchmark => {
                 panic!("expected screenshot command")
             }
         }
@@ -281,11 +413,159 @@ mod tests {
     }
 
     #[test]
+    fn parse_ui_state_command() {
+        assert!(matches!(
+            parse_command("ui state\n"),
+            Ok(ControlCommand::UiState)
+        ));
+        assert!(parse_command("ui state\nextra\n").is_err());
+    }
+
+    #[test]
     fn parse_host_benchmark_command() {
         assert!(matches!(
             parse_command("host benchmark\n"),
             Ok(ControlCommand::HostBenchmark)
         ));
         assert!(parse_command("host benchmark\nextra\n").is_err());
+    }
+
+    #[test]
+    fn classifies_all_ui_screens() {
+        let cases = [
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherMain,
+            ),
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    launcher_settings: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherSettings,
+            ),
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    launcher_controls: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherControls,
+            ),
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    touch_test: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherTouchTest,
+            ),
+            (ScreenVisibility::default(), UiScreen::Gameplay),
+            (
+                ScreenVisibility {
+                    ingame_menu: true,
+                    ..Default::default()
+                },
+                UiScreen::PauseMain,
+            ),
+            (
+                ScreenVisibility {
+                    ingame_menu: true,
+                    ingame_controls: true,
+                    ..Default::default()
+                },
+                UiScreen::PauseControls,
+            ),
+            (
+                ScreenVisibility {
+                    game_over: true,
+                    ..Default::default()
+                },
+                UiScreen::GameOver,
+            ),
+        ];
+
+        for (visibility, expected) in cases {
+            assert_eq!(classify_screen(visibility), expected);
+        }
+    }
+
+    #[test]
+    fn classifies_the_topmost_visible_screen() {
+        assert_eq!(
+            classify_screen(ScreenVisibility {
+                launcher: true,
+                launcher_controls: true,
+                launcher_settings: true,
+                touch_test: true,
+                ingame_menu: true,
+                ingame_controls: true,
+                game_over: true,
+            }),
+            UiScreen::LauncherTouchTest
+        );
+        assert_eq!(
+            classify_screen(ScreenVisibility {
+                launcher: true,
+                launcher_controls: true,
+                launcher_settings: true,
+                game_over: true,
+                ..Default::default()
+            }),
+            UiScreen::LauncherControls
+        );
+        assert_eq!(
+            classify_screen(ScreenVisibility {
+                ingame_menu: true,
+                ingame_controls: true,
+                game_over: true,
+                ..Default::default()
+            }),
+            UiScreen::GameOver
+        );
+    }
+
+    #[test]
+    fn ui_revision_changes_only_with_observed_state() {
+        let observation = UiStateObservation {
+            screen: UiScreen::Gameplay,
+            active_scenario: Some("pizza".into()),
+            selected_scenario: "pizza".into(),
+            scenario_revision: Some(7),
+            paused: false,
+            benchmark_active: false,
+        };
+        let mut tracker = UiStateTracker::default();
+
+        let first = tracker.observe(observation.clone());
+        let unchanged = tracker.observe(observation.clone());
+        let mut changed_observation = observation;
+        changed_observation.paused = true;
+        let changed = tracker.observe(changed_observation);
+
+        assert_eq!(first.revision, 1);
+        assert_eq!(unchanged.revision, first.revision);
+        assert_eq!(changed.revision, first.revision + 1);
+    }
+
+    #[test]
+    fn launcher_state_ignores_stale_runtime_diagnostics() {
+        let stale = "scenario=pizza\nscenario_revision=7\npaused=false\nbenchmark_active=true";
+
+        assert_eq!(
+            runtime_status_for_screen(UiScreen::LauncherMain, stale).unwrap(),
+            RuntimeStatus::inactive()
+        );
+        assert_eq!(
+            runtime_status_for_screen(UiScreen::Gameplay, stale)
+                .unwrap()
+                .active_scenario
+                .as_deref(),
+            Some("pizza")
+        );
     }
 }

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -40,6 +40,7 @@ use scenario_pizza::{
 };
 use settings::LoadStatus;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, Timer, VecModel};
+use spacewars_control::NO_ACTIVE_SCENARIO_DIAGNOSTICS;
 use tracing_subscriber::EnvFilter;
 use ui_navigation::UiAction;
 
@@ -549,6 +550,7 @@ fn show_launcher(
     window.set_ingame_controls_visible(false);
     window.set_game_over_visible(false);
     window.set_scenario_error_text(SharedString::from(""));
+    clear_runtime_diagnostics(window);
     let scenario_names = host::launcher_scenario_names()
         .into_iter()
         .map(SharedString::from)
@@ -1397,9 +1399,14 @@ fn handle_launcher_start(
             hide_launcher_surfaces(&window);
         }
         Err(err) => {
+            clear_runtime_diagnostics(&window);
             window.set_launcher_error_text(SharedString::from(err.to_string()));
         }
     }
+}
+
+fn clear_runtime_diagnostics(window: &MainWindow) {
+    window.set_runtime_diagnostics(SharedString::from(NO_ACTIVE_SCENARIO_DIAGNOSTICS));
 }
 
 fn hide_launcher_surfaces(window: &MainWindow) {
@@ -1831,6 +1838,7 @@ fn start_scenario_from_launch(
     asset: client_scenarios::ScenarioAsset,
 ) -> Result<Timer, host::HostError> {
     controls.borrow_mut().clear();
+    window.set_launcher_scenario(SharedString::from(launch.scenario.clone()));
     apply_scenario_metadata(window, launch.scenario.as_str());
     host::start_scenario_loop(
         window,
@@ -2324,6 +2332,9 @@ mod tests {
         window.set_ingame_menu_visible(true);
         window.set_ingame_controls_visible(true);
         window.set_game_over_visible(true);
+        window.set_runtime_diagnostics(SharedString::from(
+            "scenario=pizza\nscenario_revision=3\npaused=false\nbenchmark_active=false",
+        ));
 
         hide_launcher_surfaces(&window);
 
@@ -2334,6 +2345,12 @@ mod tests {
         assert!(!window.get_ingame_menu_visible());
         assert!(!window.get_ingame_controls_visible());
         assert!(!window.get_game_over_visible());
+
+        clear_runtime_diagnostics(&window);
+        assert_eq!(
+            window.get_runtime_diagnostics().as_str(),
+            NO_ACTIVE_SCENARIO_DIAGNOSTICS
+        );
     }
 
     #[test]

--- a/crates/spacewars-cli/Cargo.toml
+++ b/crates/spacewars-cli/Cargo.toml
@@ -13,3 +13,4 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 engine-common = { workspace = true }
+spacewars-control = { workspace = true }

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -4,6 +4,9 @@ use std::time::{Duration, Instant};
 
 use clap::{Parser, Subcommand};
 use engine_common::DEFAULT_CONTROL_SOCKET;
+#[cfg(test)]
+use spacewars_control::UI_STATE_SCHEMA_VERSION;
+use spacewars_control::{UI_STATE_COMMAND, UiState, parse_runtime_status};
 
 #[derive(Debug, Parser)]
 #[command(name = "spacewars-cli", about = "Space-Wars runtime control helper")]
@@ -27,10 +30,26 @@ enum Command {
         output: PathBuf,
     },
 
+    /// Inspect or control the visible UI.
+    Ui {
+        #[command(subcommand)]
+        command: UiCommand,
+    },
+
     /// Control the lifecycle of the selected or active scenario.
     Host {
         #[command(subcommand)]
         command: HostCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum UiCommand {
+    /// Print the current screen and scenario state.
+    State {
+        /// Emit the versioned state object as JSON.
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -54,6 +73,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match args.command {
         Command::Status => request_status(&socket)?,
         Command::Screenshot { output } => request_screenshot(&socket, output)?,
+        Command::Ui {
+            command: UiCommand::State { json },
+        } => request_ui_state(&socket, json)?,
         Command::Host {
             command: HostCommand::Benchmark { timeout },
         } => request_benchmark(&socket, timeout)?,
@@ -80,6 +102,17 @@ fn request_screenshot(socket: &Path, output: PathBuf) -> Result<(), Box<dyn std:
 fn request_status(socket: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let message = fetch_status(socket)?;
     println!("{message}");
+    Ok(())
+}
+
+#[cfg(unix)]
+fn request_ui_state(socket: &Path, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let state = UiState::from_json(&send_request(socket, &format!("{UI_STATE_COMMAND}\n"))?)?;
+    if json {
+        println!("{}", state.to_pretty_json()?);
+    } else {
+        println!("{}", format_ui_state(&state));
+    }
     Ok(())
 }
 
@@ -194,44 +227,18 @@ fn parse_response(response: &str) -> Result<&str, String> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct RuntimeStatus {
-    scenario_revision: Option<u64>,
-    benchmark_active: bool,
-}
-
-fn parse_runtime_status(status: &str) -> Result<RuntimeStatus, String> {
-    let scenario_revision = status_value(status, "scenario_revision")
-        .map(|value| {
-            value
-                .parse()
-                .map_err(|_| "status has an invalid scenario_revision".to_string())
-        })
-        .transpose()?;
-    let benchmark_active = status_value(status, "benchmark_active")
-        .map(|value| {
-            value
-                .parse()
-                .map_err(|_| "status has an invalid benchmark_active".to_string())
-        })
-        .transpose()?;
-
-    let benchmark_active = match (scenario_revision, benchmark_active) {
-        (Some(_), Some(benchmark_active)) => benchmark_active,
-        (None, None) if status.trim() == "No active scenario diagnostics." => false,
-        _ => return Err("status has incomplete scenario diagnostics".into()),
-    };
-
-    Ok(RuntimeStatus {
-        scenario_revision,
-        benchmark_active,
-    })
-}
-
-fn status_value<'a>(status: &'a str, key: &str) -> Option<&'a str> {
-    status
-        .lines()
-        .find_map(|line| line.strip_prefix(key)?.strip_prefix('='))
+fn format_ui_state(state: &UiState) -> String {
+    format!(
+        "schema_version={}\nrevision={}\nscreen={}\nactive_scenario={}\nselected_scenario={}\nscenario_revision={}\npaused={}\nbenchmark_active={}",
+        state.schema_version,
+        state.revision,
+        state.screen,
+        state.active_scenario.as_deref().unwrap_or("none"),
+        state.selected_scenario,
+        format_scenario_revision(state.scenario_revision),
+        state.paused,
+        state.benchmark_active,
+    )
 }
 
 fn format_scenario_revision(revision: Option<u64>) -> String {
@@ -280,6 +287,11 @@ fn request_status(_socket: &Path) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(not(unix))]
+fn request_ui_state(_socket: &Path, _json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    Err("spacewars-cli ui state requires Unix domain sockets".into())
+}
+
+#[cfg(not(unix))]
 fn request_benchmark(_socket: &Path, _timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
     Err("spacewars-cli host benchmark requires Unix domain sockets".into())
 }
@@ -309,6 +321,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_ui_state_json_subcommand() {
+        let args = Args::try_parse_from(["spacewars-cli", "ui", "state", "--json"]).unwrap();
+
+        assert!(matches!(
+            args.command,
+            Command::Ui {
+                command: UiCommand::State { json: true }
+            }
+        ));
+    }
+
+    #[test]
     fn accepts_multiline_success_response() {
         assert_eq!(
             parse_response("ok scenario=pizza\nfps=59.8\nframes_total=123\n").unwrap(),
@@ -329,25 +353,22 @@ mod tests {
     }
 
     #[test]
-    fn parses_runtime_status_needed_for_benchmark_wait() {
+    fn formats_human_readable_ui_state() {
+        let state = UiState {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            revision: 8,
+            screen: spacewars_control::UiScreen::PauseMain,
+            active_scenario: Some("pizza".into()),
+            selected_scenario: "pizza".into(),
+            scenario_revision: Some(3),
+            paused: true,
+            benchmark_active: false,
+        };
+
         assert_eq!(
-            parse_runtime_status(
-                "scenario=spacewars\nscenario_revision=9\nbenchmark_active=true\nfps=60.0\n"
-            )
-            .unwrap(),
-            RuntimeStatus {
-                scenario_revision: Some(9),
-                benchmark_active: true,
-            }
+            format_ui_state(&state),
+            "schema_version=1\nrevision=8\nscreen=pause.main\nactive_scenario=pizza\nselected_scenario=pizza\nscenario_revision=3\npaused=true\nbenchmark_active=false"
         );
-        assert_eq!(
-            parse_runtime_status("No active scenario diagnostics.").unwrap(),
-            RuntimeStatus {
-                scenario_revision: None,
-                benchmark_active: false,
-            }
-        );
-        assert!(parse_runtime_status("benchmark_active=true\n").is_err());
     }
 
     #[test]

--- a/crates/spacewars-control/Cargo.toml
+++ b/crates/spacewars-control/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "spacewars-control"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/spacewars-control/src/lib.rs
+++ b/crates/spacewars-control/src/lib.rs
@@ -1,0 +1,313 @@
+//! Shared protocol types for controlling a running Space-Wars client.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const UI_STATE_COMMAND: &str = "ui state";
+pub const UI_STATE_SCHEMA_VERSION: u32 = 1;
+pub const NO_ACTIVE_SCENARIO_DIAGNOSTICS: &str = "No active scenario diagnostics.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UiScreen {
+    #[serde(rename = "launcher.main")]
+    LauncherMain,
+    #[serde(rename = "launcher.settings")]
+    LauncherSettings,
+    #[serde(rename = "launcher.controls")]
+    LauncherControls,
+    #[serde(rename = "launcher.touch-test")]
+    LauncherTouchTest,
+    #[serde(rename = "gameplay")]
+    Gameplay,
+    #[serde(rename = "pause.main")]
+    PauseMain,
+    #[serde(rename = "pause.controls")]
+    PauseControls,
+    #[serde(rename = "game-over")]
+    GameOver,
+}
+
+impl UiScreen {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LauncherMain => "launcher.main",
+            Self::LauncherSettings => "launcher.settings",
+            Self::LauncherControls => "launcher.controls",
+            Self::LauncherTouchTest => "launcher.touch-test",
+            Self::Gameplay => "gameplay",
+            Self::PauseMain => "pause.main",
+            Self::PauseControls => "pause.controls",
+            Self::GameOver => "game-over",
+        }
+    }
+
+    pub const fn is_launcher(self) -> bool {
+        matches!(
+            self,
+            Self::LauncherMain
+                | Self::LauncherSettings
+                | Self::LauncherControls
+                | Self::LauncherTouchTest
+        )
+    }
+}
+
+impl fmt::Display for UiScreen {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiState {
+    pub schema_version: u32,
+    pub revision: u64,
+    pub screen: UiScreen,
+    pub active_scenario: Option<String>,
+    pub selected_scenario: String,
+    pub scenario_revision: Option<u64>,
+    pub paused: bool,
+    pub benchmark_active: bool,
+}
+
+impl UiState {
+    pub fn from_json(json: &str) -> Result<Self, ProtocolError> {
+        let state: Self = serde_json::from_str(json)?;
+        state.validate()?;
+        Ok(state)
+    }
+
+    pub fn to_json(&self) -> Result<String, ProtocolError> {
+        self.validate()?;
+        Ok(serde_json::to_string(self)?)
+    }
+
+    pub fn to_pretty_json(&self) -> Result<String, ProtocolError> {
+        self.validate()?;
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+
+    fn validate(&self) -> Result<(), ProtocolError> {
+        if self.schema_version != UI_STATE_SCHEMA_VERSION {
+            return Err(ProtocolError::UnsupportedSchemaVersion {
+                found: self.schema_version,
+                supported: UI_STATE_SCHEMA_VERSION,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeStatus {
+    pub active_scenario: Option<String>,
+    pub scenario_revision: Option<u64>,
+    pub paused: bool,
+    pub benchmark_active: bool,
+}
+
+impl RuntimeStatus {
+    pub fn inactive() -> Self {
+        Self {
+            active_scenario: None,
+            scenario_revision: None,
+            paused: false,
+            benchmark_active: false,
+        }
+    }
+}
+
+pub fn parse_runtime_status(status: &str) -> Result<RuntimeStatus, ProtocolError> {
+    if status.trim() == NO_ACTIVE_SCENARIO_DIAGNOSTICS {
+        return Ok(RuntimeStatus::inactive());
+    }
+
+    let scenario = required_status_value(status, "scenario")?;
+    if scenario.is_empty() {
+        return Err(ProtocolError::InvalidRuntimeField {
+            field: "scenario",
+            value: scenario.into(),
+        });
+    }
+
+    Ok(RuntimeStatus {
+        active_scenario: Some(scenario.into()),
+        scenario_revision: Some(parse_status_value(status, "scenario_revision")?),
+        paused: parse_status_value(status, "paused")?,
+        benchmark_active: parse_status_value(status, "benchmark_active")?,
+    })
+}
+
+fn parse_status_value<T>(status: &str, field: &'static str) -> Result<T, ProtocolError>
+where
+    T: std::str::FromStr,
+{
+    let value = required_status_value(status, field)?;
+    value
+        .parse()
+        .map_err(|_| ProtocolError::InvalidRuntimeField {
+            field,
+            value: value.into(),
+        })
+}
+
+fn required_status_value<'a>(
+    status: &'a str,
+    field: &'static str,
+) -> Result<&'a str, ProtocolError> {
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix(field)?.strip_prefix('='))
+        .ok_or(ProtocolError::MissingRuntimeField(field))
+}
+
+#[derive(Debug)]
+pub enum ProtocolError {
+    Json(serde_json::Error),
+    UnsupportedSchemaVersion { found: u32, supported: u32 },
+    MissingRuntimeField(&'static str),
+    InvalidRuntimeField { field: &'static str, value: String },
+}
+
+impl fmt::Display for ProtocolError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Json(error) => write!(formatter, "invalid UI state JSON: {error}"),
+            Self::UnsupportedSchemaVersion { found, supported } => write!(
+                formatter,
+                "unsupported UI state schema version {found}; this client supports version {supported}"
+            ),
+            Self::MissingRuntimeField(field) => {
+                write!(formatter, "runtime diagnostics are missing {field}")
+            }
+            Self::InvalidRuntimeField { field, value } => {
+                write!(
+                    formatter,
+                    "runtime diagnostics have invalid {field} {value:?}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Json(error) => Some(error),
+            Self::UnsupportedSchemaVersion { .. }
+            | Self::MissingRuntimeField(_)
+            | Self::InvalidRuntimeField { .. } => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for ProtocolError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_state() -> UiState {
+        UiState {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            revision: 42,
+            screen: UiScreen::LauncherMain,
+            active_scenario: None,
+            selected_scenario: "spacewars".into(),
+            scenario_revision: None,
+            paused: false,
+            benchmark_active: false,
+        }
+    }
+
+    #[test]
+    fn screen_names_are_stable_and_round_trip() {
+        let cases = [
+            (UiScreen::LauncherMain, "launcher.main"),
+            (UiScreen::LauncherSettings, "launcher.settings"),
+            (UiScreen::LauncherControls, "launcher.controls"),
+            (UiScreen::LauncherTouchTest, "launcher.touch-test"),
+            (UiScreen::Gameplay, "gameplay"),
+            (UiScreen::PauseMain, "pause.main"),
+            (UiScreen::PauseControls, "pause.controls"),
+            (UiScreen::GameOver, "game-over"),
+        ];
+
+        for (screen, name) in cases {
+            assert_eq!(screen.as_str(), name);
+            assert_eq!(screen.to_string(), name);
+            assert_eq!(
+                serde_json::to_string(&screen).unwrap(),
+                format!("\"{name}\"")
+            );
+            assert_eq!(
+                serde_json::from_str::<UiScreen>(&format!("\"{name}\"")).unwrap(),
+                screen
+            );
+        }
+    }
+
+    #[test]
+    fn ui_state_json_round_trips_and_rejects_other_versions() {
+        let state = sample_state();
+        let json = state.to_json().unwrap();
+        assert_eq!(UiState::from_json(&json).unwrap(), state);
+
+        let mut unsupported = sample_state();
+        unsupported.schema_version += 1;
+        assert!(matches!(
+            unsupported.to_json(),
+            Err(ProtocolError::UnsupportedSchemaVersion { .. })
+        ));
+        assert!(matches!(
+            UiState::from_json(&serde_json::to_string(&unsupported).unwrap()),
+            Err(ProtocolError::UnsupportedSchemaVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn parses_active_runtime_diagnostics_and_ignores_extra_fields() {
+        assert_eq!(
+            parse_runtime_status(
+                "scenario=pizza\nscenario_revision=9\npaused=true\nbenchmark_active=false\nfps=59.8\n"
+            )
+            .unwrap(),
+            RuntimeStatus {
+                active_scenario: Some("pizza".into()),
+                scenario_revision: Some(9),
+                paused: true,
+                benchmark_active: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_inactive_runtime_diagnostics() {
+        assert_eq!(
+            parse_runtime_status(NO_ACTIVE_SCENARIO_DIAGNOSTICS).unwrap(),
+            RuntimeStatus::inactive()
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_or_invalid_runtime_diagnostics() {
+        assert!(matches!(
+            parse_runtime_status("scenario=spacewars\npaused=false\nbenchmark_active=false\n"),
+            Err(ProtocolError::MissingRuntimeField("scenario_revision"))
+        ));
+        assert!(matches!(
+            parse_runtime_status(
+                "scenario=spacewars\nscenario_revision=abc\npaused=false\nbenchmark_active=false\n"
+            ),
+            Err(ProtocolError::InvalidRuntimeField {
+                field: "scenario_revision",
+                ..
+            })
+        ));
+    }
+}

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -165,6 +165,20 @@ Query the active scenario without interrupting the kiosk UI:
 spacewars-cli status
 ```
 
+Query the visible screen and distinguish the launcher selection from the active
+scenario:
+
+```sh
+spacewars-cli ui state
+spacewars-cli ui state --json
+```
+
+The versioned JSON snapshot includes the UI revision, exact screen, selected and
+active scenario IDs, scenario instance revision, and pause/benchmark state. A
+launcher snapshot always has no active scenario, including after returning from
+gameplay. `status` remains available for detailed performance and
+scenario-specific diagnostics.
+
 Synchronize a sampler or screenshot with the start of a fresh visual benchmark:
 
 ```sh


### PR DESCRIPTION
## Summary

- add a shared `spacewars-control` crate with schema-versioned UI state and runtime-diagnostics protocol types
- expose `ui state` over the existing user-only control socket with exact screen classification and meaningful monotonic revisions
- add human-readable and JSON output through `spacewars-cli ui state [--json]`
- distinguish the selected launcher scenario from the active scenario and clear stale runtime diagnostics on launcher return
- document the new read-only interface and add focused parser, classification, revision, and stale-state tests

## Verification

- `cargo +1.89 test --workspace --all-targets`
- `cargo clippy -p spacewars-control -p spacewars-cli --all-targets --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Scope

This is the initial read-only state-snapshot slice of #31. Control inventory and selection, mutating UI actions, transition waits, and the black-box functional harness remain follow-up work.