### PR TITLE
Add structured UI controls and black-box functional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.89.0
       - name: Install native client dependencies
-        run: sudo apt-get update && sudo apt-get install --yes libasound2-dev libdrm-dev libinput-dev libudev-dev libxkbcommon-dev xauth xvfb
+        run: sudo apt-get update && sudo apt-get install --yes libasound2-dev libdrm-dev libinput-dev libudev-dev libxkbcommon-dev libxkbcommon-x11-0 xauth xvfb
       - run: cargo test --locked --workspace --all-targets
       - name: Run black-box UI functional tests
         run: xvfb-run -a -s "-screen 0 1280x1024x24" cargo test --locked -p engine-client --test ui_control_functional -- --ignored --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,17 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.89.0
       - name: Install native client dependencies
-        run: sudo apt-get update && sudo apt-get install --yes libasound2-dev libdrm-dev libinput-dev libudev-dev libxkbcommon-dev
+        run: sudo apt-get update && sudo apt-get install --yes libasound2-dev libdrm-dev libinput-dev libudev-dev libxkbcommon-dev xauth xvfb
       - run: cargo test --locked --workspace --all-targets
+      - name: Run black-box UI functional tests
+        run: xvfb-run -a -s "-screen 0 1280x1024x24" cargo test --locked -p engine-client --test ui_control_functional -- --ignored --test-threads=1
+      - name: Upload functional-test failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-functional-test-artifacts
+          path: target/functional-test-artifacts
+          if-no-files-found: ignore
       - name: Test vendored LinuxKMS touch transforms
         run: cargo test --locked --manifest-path vendor/i-slint-backend-linuxkms/Cargo.toml --features renderer-software --lib
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,8 @@ dependencies = [
  "scenario-pizza",
  "scenario-rover-lab",
  "scenario-spacewars",
+ "serde",
+ "serde_json",
  "sha2",
  "slint",
  "slint-build",

--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ The dedicated CI step runs these tests under the software renderer. See
 [Functional UI tests](docs/functional-tests.md) for local display options,
 current workflow coverage, and failure artifacts.
 
+Pause active gameplay and wait until the pause menu is observable:
+
+```sh
+spacewars-cli host pause --timeout 3s
+```
+
+The command observes the current UI revision, submits a guarded host request,
+and polls with the same overall deadline. From Spacewars, the visible Benchmark
+menu item can then be activated by ID:
+
+```sh
+spacewars-cli ui activate pause.benchmark --expect-screen pause.main
+```
+
 Start or restart the selected scenario's visual benchmark and wait until the
 host confirms a new scenario instance:
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,18 @@ Multiple conditions are combined. Waiting happens in the CLI by polling with a
 deadline, so it never blocks the Slint event loop; a timeout includes the last
 observed state.
 
+The public control API is exercised by black-box integration tests that launch
+the real client with isolated settings and socket paths:
+
+```sh
+xvfb-run -a cargo test -p engine-client --test ui_control_functional -- \
+  --ignored --test-threads=1
+```
+
+The dedicated CI step runs these tests under the software renderer. See
+[Functional UI tests](docs/functional-tests.md) for local display options,
+current workflow coverage, and failure artifacts.
+
 Start or restart the selected scenario's visual benchmark and wait until the
 host confirms a new scenario instance:
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ for a structured success or failure. `spacewars-cli ui press --help` lists all
 action and screen values, while `ui state` lists the actions accepted by the
 current screen.
 
+Activate a visible control directly by the stable ID reported by `ui state`:
+
+```sh
+spacewars-cli ui activate launcher.settings \
+  --expect-screen launcher.main --expect-revision 12
+spacewars-cli ui activate launcher.settings.renderer.next --json
+```
+
+Semantic activation uses the same menu-action and host callback paths as the
+visible controls without depending on focus order. Unknown, hidden, or disabled
+controls return structured failures with the current state; screen and revision
+guards behave the same as `ui press`.
+
 Wait for one or more state conditions without guessing at a delay:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ menu item can then be activated by ID:
 spacewars-cli ui activate pause.benchmark --expect-screen pause.main
 ```
 
+The other pause-menu lifecycle choices use the same semantic API. Restart is an
+asynchronous host transition, so scripts can wait for gameplay before taking
+their next action:
+
+```sh
+spacewars-cli host pause --timeout 3s
+spacewars-cli ui activate pause.restart --expect-screen pause.main
+spacewars-cli ui wait --screen gameplay --scenario spacewars --timeout 3s
+
+spacewars-cli host pause --timeout 3s
+spacewars-cli ui activate pause.return-to-launcher --expect-screen pause.main
+spacewars-cli ui wait --screen launcher.main --timeout 3s
+```
+
 Start or restart the selected scenario's visual benchmark and wait until the
 host confirms a new scenario instance:
 

--- a/README.md
+++ b/README.md
@@ -139,12 +139,40 @@ spacewars-cli ui state --json
 The JSON form is a versioned automation contract. It reports the exact launcher,
 gameplay, pause, controls, touch-test, or game-over screen; a monotonic UI
 revision; the active scenario instance revision; and pause and benchmark state.
-Each screen also reports its selected control, visible controls with stable IDs,
-labels and enabled state, and any visible error. Choice arrows include their
-current displayed value so settings changes advance the UI revision.
+Each screen also reports its accepted menu actions, selected control, visible
+controls with stable IDs, labels and enabled state, and any visible error. Choice
+arrows include their current displayed value so settings changes advance the UI
+revision.
 Returning to the launcher clears active-scenario state while preserving the
 launcher selection. The existing `status` command remains the detailed
 performance and scenario diagnostics interface.
+
+Route the same actions used by keyboards and gamepads through the visible menu:
+
+```sh
+spacewars-cli ui press down --expect-screen launcher.main
+spacewars-cli ui press confirm --expect-screen launcher.main --expect-revision 12
+```
+
+Every successful press prints the resulting UI state. Screen and revision
+preconditions make an observe-then-act sequence fail safely if the UI changed in
+between. A rejected action reports the current state and distinguishes a wrong
+screen, stale revision, and an action unavailable on that screen. Add `--json`
+for a structured success or failure. `spacewars-cli ui press --help` lists all
+action and screen values, while `ui state` lists the actions accepted by the
+current screen.
+
+Wait for one or more state conditions without guessing at a delay:
+
+```sh
+spacewars-cli ui wait --screen launcher.settings --timeout 2s
+spacewars-cli ui wait --screen gameplay --scenario spacewars \
+  --revision-after 12 --timeout 10s --json
+```
+
+Multiple conditions are combined. Waiting happens in the CLI by polling with a
+deadline, so it never blocks the Slint event loop; a timeout includes the last
+observed state.
 
 Start or restart the selected scenario's visual benchmark and wait until the
 host confirms a new scenario instance:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ spacewars-cli ui state --json
 The JSON form is a versioned automation contract. It reports the exact launcher,
 gameplay, pause, controls, touch-test, or game-over screen; a monotonic UI
 revision; the active scenario instance revision; and pause and benchmark state.
+Each screen also reports its selected control, visible controls with stable IDs,
+labels and enabled state, and any visible error. Choice arrows include their
+current displayed value so settings changes advance the UI revision.
 Returning to the launcher clears active-scenario state while preserving the
 launcher selection. The existing `status` command remains the detailed
 performance and scenario diagnostics interface.

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -37,6 +37,10 @@ tracing-subscriber = { workspace = true }
 [build-dependencies]
 slint-build = { workspace = true }
 
+[dev-dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+
 [features]
 default = ["desktop"]
 desktop = [

--- a/crates/engine-client/src/gamepad.rs
+++ b/crates/engine-client/src/gamepad.rs
@@ -5,10 +5,10 @@ use std::time::{Duration, Instant};
 
 use gilrs::{Axis, Button, EventType, Gamepad, GamepadId, Gilrs, Mapping};
 use slint::{ComponentHandle, SharedString, Timer, TimerMode};
+use spacewars_control::UiAction;
 
 use crate::MainWindow;
 use crate::input::{self, GameKey, GamepadSeatInput, SharedGamepadInput, SharedInput};
-use crate::ui_navigation::UiAction;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(16);
 const UI_REPEAT_DELAY: Duration = Duration::from_millis(350);

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -75,6 +75,7 @@ pub struct ScenarioControls {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ScenarioControlRequest {
+    Pause,
     Resume,
     Restart,
     Benchmark,
@@ -87,6 +88,10 @@ pub fn new_scenario_controls() -> SharedScenarioControls {
 }
 
 impl ScenarioControls {
+    pub fn request_pause(&mut self) {
+        self.request = Some(ScenarioControlRequest::Pause);
+    }
+
     pub fn request_resume(&mut self) {
         self.request = Some(ScenarioControlRequest::Resume);
     }
@@ -810,6 +815,16 @@ fn step_scenario_inner(
 
     if let Some(request) = controls.take_request() {
         match request {
+            ScenarioControlRequest::Pause => {
+                if !scenario.is_game_over() {
+                    *paused = true;
+                    *accumulator = Duration::ZERO;
+                    deliver_pointer_cancellation(scenario, input, input_projections);
+                    input.clear();
+                    tracing::info!(benchmark = *benchmark_active, "paused by host control.");
+                }
+                return HostStepResult::default();
+            }
             ScenarioControlRequest::Resume => {
                 *paused = false;
                 *accumulator = Duration::ZERO;
@@ -3226,13 +3241,34 @@ mod tests {
     }
 
     #[test]
-    fn scenario_controls_resume_restart_and_start_benchmark() {
+    fn scenario_controls_pause_resume_restart_and_start_benchmark() {
         let mut scenario = hosted_scenario("spacewars", 42).unwrap();
         let mut input = ClientInput::default();
         let mut accumulator = Duration::from_secs(1);
         let mut controls = ScenarioControls::default();
-        let mut paused = true;
+        let mut paused = false;
         let mut benchmark_active = false;
+
+        controls.request_pause();
+        step_scenario(
+            &mut scenario,
+            "spacewars",
+            42,
+            TickModel::FixedTimestep { hz: 60 },
+            Some(Duration::from_secs_f64(1.0 / 60.0)),
+            Duration::ZERO,
+            &mut accumulator,
+            &mut input,
+            &mut controls,
+            &mut paused,
+            &mut benchmark_active,
+            false,
+            &Settings::default(),
+            TEST_VIEWPORT,
+            &[],
+        );
+        assert!(paused);
+        assert_eq!(accumulator, Duration::ZERO);
 
         controls.request_resume();
         step_scenario(

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -1136,6 +1136,11 @@ fn start_benchmark_scenario(
 
 fn set_ingame_menu(window: &MainWindow, paused: bool) {
     let visible = paused && !window.get_launcher_visible();
+    if visible && !window.get_ingame_menu_visible() {
+        // Reset focus before exposing the menu so external state observers do
+        // not see a transient selection carried over from the previous pause.
+        window.set_ingame_menu_focus_index(0);
+    }
     window.set_ingame_menu_visible(visible);
     if !visible {
         window.set_ingame_controls_visible(false);

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -18,11 +18,15 @@ use slint::Timer;
 use slint::{ComponentHandle, Rgba8Pixel, SharedPixelBuffer, TimerMode};
 #[cfg(unix)]
 use spacewars_control::{
-    ProtocolError, RuntimeStatus, UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiScreen, UiState,
-    parse_runtime_status,
+    ProtocolError, RuntimeStatus, UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiControl, UiScreen,
+    UiState, parse_runtime_status,
 };
 
 use crate::MainWindow;
+#[cfg(unix)]
+use crate::ui_inventory::{
+    ScreenVisibility, UiInventoryContext, classify_screen, inventory_for_screen,
+};
 
 #[cfg(unix)]
 #[derive(Debug)]
@@ -41,26 +45,17 @@ enum ControlCommand {
 }
 
 #[cfg(unix)]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct ScreenVisibility {
-    launcher: bool,
-    launcher_controls: bool,
-    launcher_settings: bool,
-    touch_test: bool,
-    ingame_menu: bool,
-    ingame_controls: bool,
-    game_over: bool,
-}
-
-#[cfg(unix)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct UiStateObservation {
     screen: UiScreen,
     active_scenario: Option<String>,
     selected_scenario: String,
+    selected_control: Option<String>,
+    controls: Vec<UiControl>,
     scenario_revision: Option<u64>,
     paused: bool,
     benchmark_active: bool,
+    error: Option<String>,
 }
 
 #[cfg(unix)]
@@ -84,9 +79,12 @@ impl UiStateTracker {
             screen: observation.screen,
             active_scenario: observation.active_scenario,
             selected_scenario: observation.selected_scenario,
+            selected_control: observation.selected_control,
+            controls: observation.controls,
             scenario_revision: observation.scenario_revision,
             paused: observation.paused,
             benchmark_active: observation.benchmark_active,
+            error: observation.error,
         }
     }
 }
@@ -304,15 +302,49 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
         game_over: window.get_game_over_visible(),
     });
     let runtime = runtime_status_for_screen(screen, window.get_runtime_diagnostics().as_str())?;
+    let selected_scenario = window.get_launcher_scenario().to_string();
+    let inventory = inventory_for_screen(
+        screen,
+        &UiInventoryContext {
+            selected_scenario: selected_scenario.clone(),
+            launcher_focus_index: window.get_launcher_focus_index(),
+            launcher_settings_focus_index: window.get_launcher_settings_focus_index(),
+            launcher_controls_focus_index: window.get_launcher_controls_focus_index(),
+            ingame_menu_focus_index: window.get_ingame_menu_focus_index(),
+            game_over_focus_index: window.get_game_over_focus_index(),
+            benchmark_available: window.get_scenario_benchmark_available(),
+            launch_available: selected_scenario != "nes" || window.get_launcher_nes_rom_supported(),
+            launcher_error: non_empty(window.get_launcher_error_text().as_str()),
+            scenario_error: non_empty(window.get_scenario_error_text().as_str()),
+            renderer: window.get_launcher_renderer().to_string(),
+            raster_scale: window.get_launcher_raster_scale_text().to_string(),
+            spacewars_preset: window.get_launcher_spacewars_preset().to_string(),
+            spacewars_planets: window.get_launcher_use_planets().to_string(),
+            spacewars_asteroids: window.get_launcher_asteroids_enabled().to_string(),
+            spacewars_player_health: window.get_launcher_player_health_text().to_string(),
+            spacewars_player_2: window.get_launcher_p2_controller().to_string(),
+            pizza_desired_balls: window.get_launcher_pizza_desired_balls_text().to_string(),
+            pizza_spawn_rate: window.get_launcher_pizza_spawn_rate_text().to_string(),
+            nes_cartridge_name: window.get_launcher_nes_rom_name().to_string(),
+        },
+    );
 
     Ok(tracker.observe(UiStateObservation {
         screen,
         active_scenario: runtime.active_scenario,
-        selected_scenario: window.get_launcher_scenario().into(),
+        selected_scenario,
+        selected_control: inventory.selected_control,
+        controls: inventory.controls,
         scenario_revision: runtime.scenario_revision,
         paused: runtime.paused,
         benchmark_active: runtime.benchmark_active,
+        error: inventory.error,
     }))
+}
+
+#[cfg(unix)]
+fn non_empty(text: &str) -> Option<String> {
+    (!text.is_empty()).then(|| text.into())
 }
 
 #[cfg(unix)]
@@ -324,29 +356,6 @@ fn runtime_status_for_screen(
         Ok(RuntimeStatus::inactive())
     } else {
         parse_runtime_status(diagnostics)
-    }
-}
-
-#[cfg(unix)]
-fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
-    if visibility.touch_test {
-        UiScreen::LauncherTouchTest
-    } else if visibility.launcher {
-        if visibility.launcher_controls {
-            UiScreen::LauncherControls
-        } else if visibility.launcher_settings {
-            UiScreen::LauncherSettings
-        } else {
-            UiScreen::LauncherMain
-        }
-    } else if visibility.game_over {
-        UiScreen::GameOver
-    } else if visibility.ingame_controls {
-        UiScreen::PauseControls
-    } else if visibility.ingame_menu {
-        UiScreen::PauseMain
-    } else {
-        UiScreen::Gameplay
     }
 }
 
@@ -431,113 +440,17 @@ mod tests {
     }
 
     #[test]
-    fn classifies_all_ui_screens() {
-        let cases = [
-            (
-                ScreenVisibility {
-                    launcher: true,
-                    ..Default::default()
-                },
-                UiScreen::LauncherMain,
-            ),
-            (
-                ScreenVisibility {
-                    launcher: true,
-                    launcher_settings: true,
-                    ..Default::default()
-                },
-                UiScreen::LauncherSettings,
-            ),
-            (
-                ScreenVisibility {
-                    launcher: true,
-                    launcher_controls: true,
-                    ..Default::default()
-                },
-                UiScreen::LauncherControls,
-            ),
-            (
-                ScreenVisibility {
-                    launcher: true,
-                    touch_test: true,
-                    ..Default::default()
-                },
-                UiScreen::LauncherTouchTest,
-            ),
-            (ScreenVisibility::default(), UiScreen::Gameplay),
-            (
-                ScreenVisibility {
-                    ingame_menu: true,
-                    ..Default::default()
-                },
-                UiScreen::PauseMain,
-            ),
-            (
-                ScreenVisibility {
-                    ingame_menu: true,
-                    ingame_controls: true,
-                    ..Default::default()
-                },
-                UiScreen::PauseControls,
-            ),
-            (
-                ScreenVisibility {
-                    game_over: true,
-                    ..Default::default()
-                },
-                UiScreen::GameOver,
-            ),
-        ];
-
-        for (visibility, expected) in cases {
-            assert_eq!(classify_screen(visibility), expected);
-        }
-    }
-
-    #[test]
-    fn classifies_the_topmost_visible_screen() {
-        assert_eq!(
-            classify_screen(ScreenVisibility {
-                launcher: true,
-                launcher_controls: true,
-                launcher_settings: true,
-                touch_test: true,
-                ingame_menu: true,
-                ingame_controls: true,
-                game_over: true,
-            }),
-            UiScreen::LauncherTouchTest
-        );
-        assert_eq!(
-            classify_screen(ScreenVisibility {
-                launcher: true,
-                launcher_controls: true,
-                launcher_settings: true,
-                game_over: true,
-                ..Default::default()
-            }),
-            UiScreen::LauncherControls
-        );
-        assert_eq!(
-            classify_screen(ScreenVisibility {
-                ingame_menu: true,
-                ingame_controls: true,
-                game_over: true,
-                ..Default::default()
-            }),
-            UiScreen::GameOver
-        );
-    }
-
-    #[test]
     fn ui_revision_changes_only_with_observed_state() {
         let observation = UiStateObservation {
             screen: UiScreen::Gameplay,
             active_scenario: Some("pizza".into()),
             selected_scenario: "pizza".into(),
+            selected_control: None,
+            controls: Vec::new(),
             scenario_revision: Some(7),
             paused: false,
             benchmark_active: false,
+            error: None,
         };
         let mut tracker = UiStateTracker::default();
 
@@ -550,6 +463,31 @@ mod tests {
         assert_eq!(first.revision, 1);
         assert_eq!(unchanged.revision, first.revision);
         assert_eq!(changed.revision, first.revision + 1);
+    }
+
+    #[test]
+    fn ui_revision_changes_with_inventory_state() {
+        let mut observation = UiStateObservation {
+            screen: UiScreen::LauncherMain,
+            active_scenario: None,
+            selected_scenario: "pizza".into(),
+            selected_control: Some("launcher.start".into()),
+            controls: vec![UiControl::new("launcher.start", "Start Game", true)],
+            scenario_revision: None,
+            paused: false,
+            benchmark_active: false,
+            error: None,
+        };
+        let mut tracker = UiStateTracker::default();
+        let first = tracker.observe(observation.clone());
+
+        observation.controls[0].value = Some("ready".into());
+        let value_changed = tracker.observe(observation.clone());
+        observation.error = Some("Could not start".into());
+        let error_changed = tracker.observe(observation);
+
+        assert_eq!(value_changed.revision, first.revision + 1);
+        assert_eq!(error_changed.revision, value_changed.revision + 1);
     }
 
     #[test]

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -18,7 +18,8 @@ use slint::Timer;
 use slint::{ComponentHandle, Rgba8Pixel, SharedPixelBuffer, TimerMode};
 #[cfg(unix)]
 use spacewars_control::{
-    ProtocolError, RuntimeStatus, UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiControl, UiScreen,
+    ControlFailure, ControlFailureCode, ProtocolError, RuntimeStatus, UI_PRESS_COMMAND,
+    UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiAction, UiControl, UiPressRequest, UiScreen,
     UiState, parse_runtime_status,
 };
 
@@ -41,7 +42,15 @@ enum ControlCommand {
     Screenshot { output: PathBuf },
     Status,
     UiState,
+    UiPress(UiPressRequest),
     HostBenchmark,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+enum CommandParseError {
+    Legacy(String),
+    Structured(Box<ControlFailure>),
 }
 
 #[cfg(unix)]
@@ -52,6 +61,7 @@ struct UiStateObservation {
     selected_scenario: String,
     selected_control: Option<String>,
     controls: Vec<UiControl>,
+    actions: Vec<UiAction>,
     scenario_revision: Option<u64>,
     paused: bool,
     benchmark_active: bool,
@@ -81,6 +91,7 @@ impl UiStateTracker {
             selected_scenario: observation.selected_scenario,
             selected_control: observation.selected_control,
             controls: observation.controls,
+            actions: observation.actions,
             scenario_revision: observation.scenario_revision,
             paused: observation.paused,
             benchmark_active: observation.benchmark_active,
@@ -103,6 +114,13 @@ impl ResponseWriter {
 
     fn error(mut self, message: impl AsRef<str>) {
         let _ = writeln!(self.stream, "error {}", message.as_ref());
+    }
+
+    fn control_failure(self, failure: ControlFailure) {
+        match failure.to_json() {
+            Ok(json) => self.error(json),
+            Err(error) => self.error(error.to_string()),
+        }
     }
 }
 
@@ -188,8 +206,12 @@ fn handle_stream(mut stream: std::os::unix::net::UnixStream, tx: &mpsc::Sender<C
     let response = ResponseWriter { stream };
     let command = match parse_command(&body) {
         Ok(command) => command,
-        Err(message) => {
+        Err(CommandParseError::Legacy(message)) => {
             response.error(message);
+            return;
+        }
+        Err(CommandParseError::Structured(failure)) => {
+            response.control_failure(*failure);
             return;
         }
     };
@@ -203,18 +225,22 @@ fn handle_stream(mut stream: std::os::unix::net::UnixStream, tx: &mpsc::Sender<C
 }
 
 #[cfg(unix)]
-fn parse_command(body: &str) -> Result<ControlCommand, String> {
+fn parse_command(body: &str) -> Result<ControlCommand, CommandParseError> {
     let mut lines = body.lines();
     match lines.next() {
         Some("screenshot") => {
             let Some(output) = lines.next() else {
-                return Err("missing screenshot output path".into());
+                return Err(CommandParseError::Legacy(
+                    "missing screenshot output path".into(),
+                ));
             };
             if output.is_empty() {
-                return Err("screenshot output path must not be empty".into());
+                return Err(CommandParseError::Legacy(
+                    "screenshot output path must not be empty".into(),
+                ));
             }
             if lines.next().is_some() {
-                return Err("too many command lines".into());
+                return Err(CommandParseError::Legacy("too many command lines".into()));
             }
             Ok(ControlCommand::Screenshot {
                 output: PathBuf::from(output),
@@ -222,25 +248,49 @@ fn parse_command(body: &str) -> Result<ControlCommand, String> {
         }
         Some("status") => {
             if lines.next().is_some() {
-                return Err("too many command lines".into());
+                return Err(CommandParseError::Legacy("too many command lines".into()));
             }
             Ok(ControlCommand::Status)
         }
         Some(UI_STATE_COMMAND) => {
             if lines.next().is_some() {
-                return Err("too many command lines".into());
+                return Err(CommandParseError::Legacy("too many command lines".into()));
             }
             Ok(ControlCommand::UiState)
         }
+        Some(UI_PRESS_COMMAND) => {
+            let payload = lines.next().ok_or_else(|| {
+                invalid_press_request("ui press requires a JSON request on the second line")
+            })?;
+            if lines.next().is_some() {
+                return Err(invalid_press_request(
+                    "ui press accepts exactly one JSON request line",
+                ));
+            }
+            UiPressRequest::from_json(payload)
+                .map(ControlCommand::UiPress)
+                .map_err(|error| invalid_press_request(error.to_string()))
+        }
         Some("host benchmark") => {
             if lines.next().is_some() {
-                return Err("too many command lines".into());
+                return Err(CommandParseError::Legacy("too many command lines".into()));
             }
             Ok(ControlCommand::HostBenchmark)
         }
-        Some(command) => Err(format!("unknown command {command:?}")),
-        None => Err("empty command".into()),
+        Some(command) => Err(CommandParseError::Legacy(format!(
+            "unknown command {command:?}"
+        ))),
+        None => Err(CommandParseError::Legacy("empty command".into())),
     }
+}
+
+#[cfg(unix)]
+fn invalid_press_request(message: impl Into<String>) -> CommandParseError {
+    CommandParseError::Structured(Box::new(ControlFailure::new(
+        ControlFailureCode::InvalidRequest,
+        message,
+        None,
+    )))
 }
 
 #[cfg(unix)]
@@ -262,6 +312,9 @@ fn handle_request(
                 Ok(json) => request.response.ok(json),
                 Err(error) => request.response.error(error.to_string()),
             }
+        }
+        ControlCommand::UiPress(press) => {
+            handle_ui_press(window, press, request.response, ui_state_tracker);
         }
         ControlCommand::HostBenchmark => {
             if !window.get_scenario_benchmark_available() {
@@ -288,6 +341,85 @@ fn handle_request(
             }
         }
     }
+}
+
+#[cfg(unix)]
+fn handle_ui_press(
+    window: &MainWindow,
+    request: UiPressRequest,
+    response: ResponseWriter,
+    ui_state_tracker: &mut UiStateTracker,
+) {
+    let state = match ui_state(window, ui_state_tracker) {
+        Ok(state) => state,
+        Err(error) => {
+            response.error(error.to_string());
+            return;
+        }
+    };
+
+    if let Err(failure) = validate_ui_press(&request, &state) {
+        response.control_failure(*failure);
+        return;
+    }
+
+    window.invoke_ui_action(request.action.code());
+    match ui_state(window, ui_state_tracker).and_then(|state| state.to_json()) {
+        Ok(json) => response.ok(json),
+        Err(error) => response.error(error.to_string()),
+    }
+}
+
+#[cfg(unix)]
+fn validate_ui_press(request: &UiPressRequest, state: &UiState) -> Result<(), Box<ControlFailure>> {
+    if let Some(expected) = request.expected_screen
+        && state.screen != expected
+    {
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::WrongScreen,
+            format!(
+                "expected screen {expected}, but current screen is {}; inspect `spacewars-cli ui state` and retry",
+                state.screen
+            ),
+            Some(state.clone()),
+        )));
+    }
+
+    if let Some(expected) = request.expected_revision
+        && state.revision != expected
+    {
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::StaleRevision,
+            format!(
+                "expected UI revision {expected}, but current revision is {}; inspect `spacewars-cli ui state` and retry",
+                state.revision
+            ),
+            Some(state.clone()),
+        )));
+    }
+
+    if !state.actions.contains(&request.action) {
+        let available = if state.actions.is_empty() {
+            "none".into()
+        } else {
+            state
+                .actions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::ActionUnavailable,
+            format!(
+                "action {} is unavailable on {}; available actions: {available}",
+                request.action, state.screen
+            ),
+            Some(state.clone()),
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -335,6 +467,7 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
         selected_scenario,
         selected_control: inventory.selected_control,
         controls: inventory.controls,
+        actions: inventory.actions,
         scenario_revision: runtime.scenario_revision,
         paused: runtime.paused,
         benchmark_active: runtime.benchmark_active,
@@ -401,7 +534,10 @@ mod tests {
             ControlCommand::Screenshot { output } => {
                 assert_eq!(output, PathBuf::from("/tmp/shot.png"));
             }
-            ControlCommand::Status | ControlCommand::UiState | ControlCommand::HostBenchmark => {
+            ControlCommand::Status
+            | ControlCommand::UiState
+            | ControlCommand::UiPress(_)
+            | ControlCommand::HostBenchmark => {
                 panic!("expected screenshot command")
             }
         }
@@ -431,6 +567,33 @@ mod tests {
     }
 
     #[test]
+    fn parse_ui_press_command_and_reject_invalid_payloads_structurally() {
+        let request = UiPressRequest {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            action: UiAction::Confirm,
+            expected_screen: Some(UiScreen::LauncherMain),
+            expected_revision: Some(12),
+        };
+        let body = format!("ui press\n{}\n", request.to_json().unwrap());
+        assert!(matches!(
+            parse_command(&body),
+            Ok(ControlCommand::UiPress(parsed)) if parsed == request
+        ));
+
+        for body in [
+            "ui press\n",
+            "ui press\nnot-json\n",
+            "ui press\n{}\nextra\n",
+        ] {
+            assert!(matches!(
+                parse_command(body),
+                Err(CommandParseError::Structured(failure))
+                    if failure.code == ControlFailureCode::InvalidRequest
+            ));
+        }
+    }
+
+    #[test]
     fn parse_host_benchmark_command() {
         assert!(matches!(
             parse_command("host benchmark\n"),
@@ -447,6 +610,7 @@ mod tests {
             selected_scenario: "pizza".into(),
             selected_control: None,
             controls: Vec::new(),
+            actions: Vec::new(),
             scenario_revision: Some(7),
             paused: false,
             benchmark_active: false,
@@ -473,6 +637,7 @@ mod tests {
             selected_scenario: "pizza".into(),
             selected_control: Some("launcher.start".into()),
             controls: vec![UiControl::new("launcher.start", "Start Game", true)],
+            actions: vec![UiAction::Confirm],
             scenario_revision: None,
             paused: false,
             benchmark_active: false,
@@ -488,6 +653,46 @@ mod tests {
 
         assert_eq!(value_changed.revision, first.revision + 1);
         assert_eq!(error_changed.revision, value_changed.revision + 1);
+    }
+
+    #[test]
+    fn ui_press_validation_checks_screen_revision_and_available_action() {
+        let state = UiState {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            revision: 7,
+            screen: UiScreen::LauncherMain,
+            active_scenario: None,
+            selected_scenario: "spacewars".into(),
+            selected_control: Some("launcher.start".into()),
+            controls: vec![UiControl::new("launcher.start", "Start Game", true)],
+            actions: vec![UiAction::Confirm, UiAction::Start],
+            scenario_revision: None,
+            paused: false,
+            benchmark_active: false,
+            error: None,
+        };
+        let mut request = UiPressRequest::new(UiAction::Confirm);
+        request.expected_screen = Some(UiScreen::LauncherSettings);
+        request.expected_revision = Some(6);
+        assert_eq!(
+            validate_ui_press(&request, &state).unwrap_err().code,
+            ControlFailureCode::WrongScreen
+        );
+
+        request.expected_screen = Some(UiScreen::LauncherMain);
+        assert_eq!(
+            validate_ui_press(&request, &state).unwrap_err().code,
+            ControlFailureCode::StaleRevision
+        );
+
+        request.expected_revision = Some(7);
+        request.action = UiAction::Back;
+        let unavailable = validate_ui_press(&request, &state).unwrap_err();
+        assert_eq!(unavailable.code, ControlFailureCode::ActionUnavailable);
+        assert_eq!(unavailable.current_state, Some(state.clone()));
+
+        request.action = UiAction::Start;
+        assert_eq!(validate_ui_press(&request, &state), Ok(()));
     }
 
     #[test]

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -18,9 +18,9 @@ use slint::Timer;
 use slint::{ComponentHandle, Rgba8Pixel, SharedPixelBuffer, TimerMode};
 #[cfg(unix)]
 use spacewars_control::{
-    ControlFailure, ControlFailureCode, ProtocolError, RuntimeStatus, UI_PRESS_COMMAND,
-    UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiAction, UiControl, UiPressRequest, UiScreen,
-    UiState, parse_runtime_status,
+    ControlFailure, ControlFailureCode, ProtocolError, RuntimeStatus, UI_ACTIVATE_COMMAND,
+    UI_PRESS_COMMAND, UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiAction, UiActivateRequest,
+    UiControl, UiPressRequest, UiScreen, UiState, parse_runtime_status,
 };
 
 use crate::MainWindow;
@@ -43,6 +43,7 @@ enum ControlCommand {
     Status,
     UiState,
     UiPress(UiPressRequest),
+    UiActivate(UiActivateRequest),
     HostBenchmark,
 }
 
@@ -260,16 +261,29 @@ fn parse_command(body: &str) -> Result<ControlCommand, CommandParseError> {
         }
         Some(UI_PRESS_COMMAND) => {
             let payload = lines.next().ok_or_else(|| {
-                invalid_press_request("ui press requires a JSON request on the second line")
+                invalid_mutation_request("ui press requires a JSON request on the second line")
             })?;
             if lines.next().is_some() {
-                return Err(invalid_press_request(
+                return Err(invalid_mutation_request(
                     "ui press accepts exactly one JSON request line",
                 ));
             }
             UiPressRequest::from_json(payload)
                 .map(ControlCommand::UiPress)
-                .map_err(|error| invalid_press_request(error.to_string()))
+                .map_err(|error| invalid_mutation_request(error.to_string()))
+        }
+        Some(UI_ACTIVATE_COMMAND) => {
+            let payload = lines.next().ok_or_else(|| {
+                invalid_mutation_request("ui activate requires a JSON request on the second line")
+            })?;
+            if lines.next().is_some() {
+                return Err(invalid_mutation_request(
+                    "ui activate accepts exactly one JSON request line",
+                ));
+            }
+            UiActivateRequest::from_json(payload)
+                .map(ControlCommand::UiActivate)
+                .map_err(|error| invalid_mutation_request(error.to_string()))
         }
         Some("host benchmark") => {
             if lines.next().is_some() {
@@ -285,7 +299,7 @@ fn parse_command(body: &str) -> Result<ControlCommand, CommandParseError> {
 }
 
 #[cfg(unix)]
-fn invalid_press_request(message: impl Into<String>) -> CommandParseError {
+fn invalid_mutation_request(message: impl Into<String>) -> CommandParseError {
     CommandParseError::Structured(Box::new(ControlFailure::new(
         ControlFailureCode::InvalidRequest,
         message,
@@ -315,6 +329,9 @@ fn handle_request(
         }
         ControlCommand::UiPress(press) => {
             handle_ui_press(window, press, request.response, ui_state_tracker);
+        }
+        ControlCommand::UiActivate(activation) => {
+            handle_ui_activate(window, activation, request.response, ui_state_tracker);
         }
         ControlCommand::HostBenchmark => {
             if !window.get_scenario_benchmark_available() {
@@ -371,32 +388,46 @@ fn handle_ui_press(
 }
 
 #[cfg(unix)]
-fn validate_ui_press(request: &UiPressRequest, state: &UiState) -> Result<(), Box<ControlFailure>> {
-    if let Some(expected) = request.expected_screen
-        && state.screen != expected
-    {
-        return Err(Box::new(ControlFailure::new(
-            ControlFailureCode::WrongScreen,
-            format!(
-                "expected screen {expected}, but current screen is {}; inspect `spacewars-cli ui state` and retry",
-                state.screen
-            ),
-            Some(state.clone()),
-        )));
+fn handle_ui_activate(
+    window: &MainWindow,
+    request: UiActivateRequest,
+    response: ResponseWriter,
+    ui_state_tracker: &mut UiStateTracker,
+) {
+    let state = match ui_state(window, ui_state_tracker) {
+        Ok(state) => state,
+        Err(error) => {
+            response.error(error.to_string());
+            return;
+        }
+    };
+
+    if let Err(failure) = validate_ui_activate(&request, &state) {
+        response.control_failure(*failure);
+        return;
     }
 
-    if let Some(expected) = request.expected_revision
-        && state.revision != expected
-    {
-        return Err(Box::new(ControlFailure::new(
-            ControlFailureCode::StaleRevision,
+    if !crate::ui_activation::activate(window, &request.control_id) {
+        response.control_failure(ControlFailure::new(
+            ControlFailureCode::ControlUnavailable,
             format!(
-                "expected UI revision {expected}, but current revision is {}; inspect `spacewars-cli ui state` and retry",
-                state.revision
+                "control {:?} is visible and enabled on {}, but has no semantic activation mapping",
+                request.control_id, state.screen
             ),
-            Some(state.clone()),
-        )));
+            Some(state),
+        ));
+        return;
     }
+
+    match ui_state(window, ui_state_tracker).and_then(|state| state.to_json()) {
+        Ok(json) => response.ok(json),
+        Err(error) => response.error(error.to_string()),
+    }
+}
+
+#[cfg(unix)]
+fn validate_ui_press(request: &UiPressRequest, state: &UiState) -> Result<(), Box<ControlFailure>> {
+    validate_ui_preconditions(request.expected_screen, request.expected_revision, state)?;
 
     if !state.actions.contains(&request.action) {
         let available = if state.actions.is_empty() {
@@ -414,6 +445,87 @@ fn validate_ui_press(request: &UiPressRequest, state: &UiState) -> Result<(), Bo
             format!(
                 "action {} is unavailable on {}; available actions: {available}",
                 request.action, state.screen
+            ),
+            Some(state.clone()),
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_ui_activate(
+    request: &UiActivateRequest,
+    state: &UiState,
+) -> Result<(), Box<ControlFailure>> {
+    validate_ui_preconditions(request.expected_screen, request.expected_revision, state)?;
+
+    let Some(control) = state
+        .controls
+        .iter()
+        .find(|control| control.id == request.control_id)
+    else {
+        let available = if state.controls.is_empty() {
+            "none".into()
+        } else {
+            state
+                .controls
+                .iter()
+                .map(|control| control.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::ControlUnavailable,
+            format!(
+                "control {:?} is unavailable on {}; visible controls: {available}",
+                request.control_id, state.screen
+            ),
+            Some(state.clone()),
+        )));
+    };
+
+    if !control.enabled {
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::ControlDisabled,
+            format!(
+                "control {:?} is disabled on {}; inspect `spacewars-cli ui state` and retry",
+                request.control_id, state.screen
+            ),
+            Some(state.clone()),
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_ui_preconditions(
+    expected_screen: Option<UiScreen>,
+    expected_revision: Option<u64>,
+    state: &UiState,
+) -> Result<(), Box<ControlFailure>> {
+    if let Some(expected) = expected_screen
+        && state.screen != expected
+    {
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::WrongScreen,
+            format!(
+                "expected screen {expected}, but current screen is {}; inspect `spacewars-cli ui state` and retry",
+                state.screen
+            ),
+            Some(state.clone()),
+        )));
+    }
+
+    if let Some(expected) = expected_revision
+        && state.revision != expected
+    {
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::StaleRevision,
+            format!(
+                "expected UI revision {expected}, but current revision is {}; inspect `spacewars-cli ui state` and retry",
+                state.revision
             ),
             Some(state.clone()),
         )));
@@ -537,6 +649,7 @@ mod tests {
             ControlCommand::Status
             | ControlCommand::UiState
             | ControlCommand::UiPress(_)
+            | ControlCommand::UiActivate(_)
             | ControlCommand::HostBenchmark => {
                 panic!("expected screenshot command")
             }
@@ -584,6 +697,33 @@ mod tests {
             "ui press\n",
             "ui press\nnot-json\n",
             "ui press\n{}\nextra\n",
+        ] {
+            assert!(matches!(
+                parse_command(body),
+                Err(CommandParseError::Structured(failure))
+                    if failure.code == ControlFailureCode::InvalidRequest
+            ));
+        }
+    }
+
+    #[test]
+    fn parse_ui_activate_command_and_reject_invalid_payloads_structurally() {
+        let request = UiActivateRequest {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            control_id: "launcher.settings".into(),
+            expected_screen: Some(UiScreen::LauncherMain),
+            expected_revision: Some(12),
+        };
+        let body = format!("ui activate\n{}\n", request.to_json().unwrap());
+        assert!(matches!(
+            parse_command(&body),
+            Ok(ControlCommand::UiActivate(parsed)) if parsed == request
+        ));
+
+        for body in [
+            "ui activate\n",
+            "ui activate\nnot-json\n",
+            "ui activate\n{}\nextra\n",
         ] {
             assert!(matches!(
                 parse_command(body),
@@ -693,6 +833,53 @@ mod tests {
 
         request.action = UiAction::Start;
         assert_eq!(validate_ui_press(&request, &state), Ok(()));
+    }
+
+    #[test]
+    fn ui_activate_validation_checks_preconditions_visibility_and_enabled_state() {
+        let mut state = UiState {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            revision: 7,
+            screen: UiScreen::LauncherMain,
+            active_scenario: None,
+            selected_scenario: "spacewars".into(),
+            selected_control: Some("launcher.start".into()),
+            controls: vec![UiControl::new("launcher.start", "Start Game", true)],
+            actions: vec![UiAction::Confirm, UiAction::Start],
+            scenario_revision: None,
+            paused: false,
+            benchmark_active: false,
+            error: None,
+        };
+        let mut request = UiActivateRequest::new("launcher.start");
+        request.expected_screen = Some(UiScreen::LauncherSettings);
+        request.expected_revision = Some(6);
+        assert_eq!(
+            validate_ui_activate(&request, &state).unwrap_err().code,
+            ControlFailureCode::WrongScreen
+        );
+
+        request.expected_screen = Some(UiScreen::LauncherMain);
+        assert_eq!(
+            validate_ui_activate(&request, &state).unwrap_err().code,
+            ControlFailureCode::StaleRevision
+        );
+
+        request.expected_revision = Some(7);
+        request.control_id = "launcher.missing".into();
+        let unavailable = validate_ui_activate(&request, &state).unwrap_err();
+        assert_eq!(unavailable.code, ControlFailureCode::ControlUnavailable);
+        assert_eq!(unavailable.current_state, Some(state.clone()));
+
+        request.control_id = "launcher.start".into();
+        state.controls[0].enabled = false;
+        assert_eq!(
+            validate_ui_activate(&request, &state).unwrap_err().code,
+            ControlFailureCode::ControlDisabled
+        );
+
+        state.controls[0].enabled = true;
+        assert_eq!(validate_ui_activate(&request, &state), Ok(()));
     }
 
     #[test]

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -18,16 +18,17 @@ use slint::Timer;
 use slint::{ComponentHandle, Rgba8Pixel, SharedPixelBuffer, TimerMode};
 #[cfg(unix)]
 use spacewars_control::{
-    ControlFailure, ControlFailureCode, ProtocolError, RuntimeStatus, UI_ACTIVATE_COMMAND,
-    UI_PRESS_COMMAND, UI_STATE_COMMAND, UI_STATE_SCHEMA_VERSION, UiAction, UiActivateRequest,
-    UiControl, UiPressRequest, UiScreen, UiState, parse_runtime_status,
+    ControlFailure, ControlFailureCode, HOST_PAUSE_COMMAND, HostPauseRequest, ProtocolError,
+    RuntimeStatus, UI_ACTIVATE_COMMAND, UI_PRESS_COMMAND, UI_STATE_COMMAND,
+    UI_STATE_SCHEMA_VERSION, UiAction, UiActivateRequest, UiControl, UiPressRequest, UiScreen,
+    UiState, parse_runtime_status,
 };
 
-use crate::MainWindow;
 #[cfg(unix)]
 use crate::ui_inventory::{
     ScreenVisibility, UiInventoryContext, classify_screen, inventory_for_screen,
 };
+use crate::{MainWindow, host};
 
 #[cfg(unix)]
 #[derive(Debug)]
@@ -44,6 +45,7 @@ enum ControlCommand {
     UiState,
     UiPress(UiPressRequest),
     UiActivate(UiActivateRequest),
+    HostPause(HostPauseRequest),
     HostBenchmark,
 }
 
@@ -132,7 +134,11 @@ pub fn control_socket_path() -> PathBuf {
 }
 
 #[cfg(unix)]
-pub fn start_control_server(window: &MainWindow, socket_path: PathBuf) -> Option<Timer> {
+pub fn start_control_server(
+    window: &MainWindow,
+    socket_path: PathBuf,
+    scenario_controls: host::SharedScenarioControls,
+) -> Option<Timer> {
     let (tx, rx) = mpsc::channel();
     if let Err(err) = spawn_listener(socket_path.clone(), tx) {
         tracing::warn!(
@@ -152,7 +158,7 @@ pub fn start_control_server(window: &MainWindow, socket_path: PathBuf) -> Option
         };
 
         while let Ok(request) = rx.try_recv() {
-            handle_request(&window, request, &mut ui_state_tracker);
+            handle_request(&window, request, &mut ui_state_tracker, &scenario_controls);
         }
     });
 
@@ -160,7 +166,11 @@ pub fn start_control_server(window: &MainWindow, socket_path: PathBuf) -> Option
 }
 
 #[cfg(not(unix))]
-pub fn start_control_server(_window: &MainWindow, _socket_path: PathBuf) -> Option<Timer> {
+pub fn start_control_server(
+    _window: &MainWindow,
+    _socket_path: PathBuf,
+    _scenario_controls: host::SharedScenarioControls,
+) -> Option<Timer> {
     tracing::info!("control socket is unavailable on this platform.");
     None
 }
@@ -285,6 +295,19 @@ fn parse_command(body: &str) -> Result<ControlCommand, CommandParseError> {
                 .map(ControlCommand::UiActivate)
                 .map_err(|error| invalid_mutation_request(error.to_string()))
         }
+        Some(HOST_PAUSE_COMMAND) => {
+            let payload = lines.next().ok_or_else(|| {
+                invalid_mutation_request("host pause requires a JSON request on the second line")
+            })?;
+            if lines.next().is_some() {
+                return Err(invalid_mutation_request(
+                    "host pause accepts exactly one JSON request line",
+                ));
+            }
+            HostPauseRequest::from_json(payload)
+                .map(ControlCommand::HostPause)
+                .map_err(|error| invalid_mutation_request(error.to_string()))
+        }
         Some("host benchmark") => {
             if lines.next().is_some() {
                 return Err(CommandParseError::Legacy("too many command lines".into()));
@@ -312,6 +335,7 @@ fn handle_request(
     window: &MainWindow,
     request: ControlRequest,
     ui_state_tracker: &mut UiStateTracker,
+    scenario_controls: &host::SharedScenarioControls,
 ) {
     match request.command {
         ControlCommand::Screenshot { output } => match write_window_screenshot(window, &output) {
@@ -332,6 +356,15 @@ fn handle_request(
         }
         ControlCommand::UiActivate(activation) => {
             handle_ui_activate(window, activation, request.response, ui_state_tracker);
+        }
+        ControlCommand::HostPause(pause) => {
+            handle_host_pause(
+                window,
+                pause,
+                request.response,
+                ui_state_tracker,
+                scenario_controls,
+            );
         }
         ControlCommand::HostBenchmark => {
             if !window.get_scenario_benchmark_available() {
@@ -426,6 +459,34 @@ fn handle_ui_activate(
 }
 
 #[cfg(unix)]
+fn handle_host_pause(
+    window: &MainWindow,
+    request: HostPauseRequest,
+    response: ResponseWriter,
+    ui_state_tracker: &mut UiStateTracker,
+    scenario_controls: &host::SharedScenarioControls,
+) {
+    let state = match ui_state(window, ui_state_tracker) {
+        Ok(state) => state,
+        Err(error) => {
+            response.error(error.to_string());
+            return;
+        }
+    };
+
+    if let Err(failure) = validate_host_pause(&request, &state) {
+        response.control_failure(*failure);
+        return;
+    }
+
+    scenario_controls.borrow_mut().request_pause();
+    match state.to_json() {
+        Ok(json) => response.ok(json),
+        Err(error) => response.error(error.to_string()),
+    }
+}
+
+#[cfg(unix)]
 fn validate_ui_press(request: &UiPressRequest, state: &UiState) -> Result<(), Box<ControlFailure>> {
     validate_ui_preconditions(request.expected_screen, request.expected_revision, state)?;
 
@@ -491,6 +552,27 @@ fn validate_ui_activate(
             format!(
                 "control {:?} is disabled on {}; inspect `spacewars-cli ui state` and retry",
                 request.control_id, state.screen
+            ),
+            Some(state.clone()),
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_host_pause(
+    request: &HostPauseRequest,
+    state: &UiState,
+) -> Result<(), Box<ControlFailure>> {
+    validate_ui_preconditions(request.expected_screen, request.expected_revision, state)?;
+
+    if state.screen != UiScreen::Gameplay {
+        return Err(Box::new(ControlFailure::new(
+            ControlFailureCode::WrongScreen,
+            format!(
+                "host pause requires gameplay, but current screen is {}; inspect `spacewars-cli ui state` and retry",
+                state.screen
             ),
             Some(state.clone()),
         )));
@@ -650,6 +732,7 @@ mod tests {
             | ControlCommand::UiState
             | ControlCommand::UiPress(_)
             | ControlCommand::UiActivate(_)
+            | ControlCommand::HostPause(_)
             | ControlCommand::HostBenchmark => {
                 panic!("expected screenshot command")
             }
@@ -724,6 +807,32 @@ mod tests {
             "ui activate\n",
             "ui activate\nnot-json\n",
             "ui activate\n{}\nextra\n",
+        ] {
+            assert!(matches!(
+                parse_command(body),
+                Err(CommandParseError::Structured(failure))
+                    if failure.code == ControlFailureCode::InvalidRequest
+            ));
+        }
+    }
+
+    #[test]
+    fn parse_host_pause_command_and_reject_invalid_payloads_structurally() {
+        let request = HostPauseRequest {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            expected_screen: Some(UiScreen::Gameplay),
+            expected_revision: Some(12),
+        };
+        let body = format!("host pause\n{}\n", request.to_json().unwrap());
+        assert!(matches!(
+            parse_command(&body),
+            Ok(ControlCommand::HostPause(parsed)) if parsed == request
+        ));
+
+        for body in [
+            "host pause\n",
+            "host pause\nnot-json\n",
+            "host pause\n{}\nextra\n",
         ] {
             assert!(matches!(
                 parse_command(body),
@@ -880,6 +989,44 @@ mod tests {
 
         state.controls[0].enabled = true;
         assert_eq!(validate_ui_activate(&request, &state), Ok(()));
+    }
+
+    #[test]
+    fn host_pause_validation_requires_current_gameplay() {
+        let mut state = UiState {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            revision: 7,
+            screen: UiScreen::LauncherMain,
+            active_scenario: None,
+            selected_scenario: "spacewars".into(),
+            selected_control: Some("launcher.start".into()),
+            controls: vec![UiControl::new("launcher.start", "Start Game", true)],
+            actions: UiAction::ALL.to_vec(),
+            scenario_revision: None,
+            paused: false,
+            benchmark_active: false,
+            error: None,
+        };
+        let mut request = HostPauseRequest::new();
+        request.expected_screen = Some(UiScreen::Gameplay);
+        request.expected_revision = Some(7);
+        assert_eq!(
+            validate_host_pause(&request, &state).unwrap_err().code,
+            ControlFailureCode::WrongScreen
+        );
+
+        state.screen = UiScreen::Gameplay;
+        state.active_scenario = Some("spacewars".into());
+        state.selected_control = None;
+        state.controls.clear();
+        state.actions.clear();
+        assert_eq!(validate_host_pause(&request, &state), Ok(()));
+
+        request.expected_revision = Some(6);
+        assert_eq!(
+            validate_host_pause(&request, &state).unwrap_err().code,
+            ControlFailureCode::StaleRevision
+        );
     }
 
     #[test]

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -346,11 +346,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     select_slint_backend(&args)?;
     let window = MainWindow::new()?;
-    let _control_server = ipc::start_control_server(&window, ipc::control_socket_path());
+    let scenario_controls = host::new_scenario_controls();
+    let _control_server = ipc::start_control_server(
+        &window,
+        ipc::control_socket_path(),
+        Rc::clone(&scenario_controls),
+    );
     let (input, gamepad_input) = input::new_shared_input();
     input::install_window_input(&window, Rc::clone(&input));
     let render_timer = Rc::new(RefCell::new(None));
-    let scenario_controls = host::new_scenario_controls();
     install_launcher_callbacks(
         &window,
         Rc::clone(&render_timer),

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -41,9 +41,8 @@ use scenario_pizza::{
 };
 use settings::LoadStatus;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, Timer, VecModel};
-use spacewars_control::NO_ACTIVE_SCENARIO_DIAGNOSTICS;
+use spacewars_control::{NO_ACTIVE_SCENARIO_DIAGNOSTICS, UiAction};
 use tracing_subscriber::EnvFilter;
-use ui_navigation::UiAction;
 
 slint::include_modules!();
 

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -15,6 +15,7 @@ mod nes_roms;
 mod raster;
 mod render;
 mod settings;
+mod ui_activation;
 mod ui_inventory;
 mod ui_navigation;
 

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -15,6 +15,7 @@ mod nes_roms;
 mod raster;
 mod render;
 mod settings;
+mod ui_inventory;
 mod ui_navigation;
 
 use std::cell::RefCell;

--- a/crates/engine-client/src/ui_activation.rs
+++ b/crates/engine-client/src/ui_activation.rs
@@ -1,0 +1,186 @@
+//! Stable control-ID activation routed through the ordinary menu-action path.
+
+use spacewars_control::UiAction;
+
+use crate::{MainWindow, handle_ui_action};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivationFocus {
+    Launcher(i32),
+    LauncherSettings(Option<i32>),
+    LauncherControls(i32),
+    TouchTest,
+    PauseMain(i32),
+    PauseControls,
+    GameOver(i32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActivationTarget {
+    focus: ActivationFocus,
+    action: UiAction,
+}
+
+pub(crate) fn activate(window: &MainWindow, control_id: &str) -> bool {
+    let Some(target) = activation_target(control_id, window.get_scenario_benchmark_available())
+    else {
+        return false;
+    };
+
+    match target.focus {
+        ActivationFocus::Launcher(index) => window.set_launcher_focus_index(index),
+        ActivationFocus::LauncherSettings(index) => {
+            if let Some(index) = index {
+                window.set_launcher_settings_focus_index(index);
+            }
+        }
+        ActivationFocus::LauncherControls(index) => {
+            window.set_launcher_controls_focus_index(index);
+        }
+        ActivationFocus::TouchTest | ActivationFocus::PauseControls => {}
+        ActivationFocus::PauseMain(index) => window.set_ingame_menu_focus_index(index),
+        ActivationFocus::GameOver(index) => window.set_game_over_focus_index(index),
+    }
+    handle_ui_action(window, target.action);
+    true
+}
+
+#[cfg(test)]
+pub(crate) fn supports(control_id: &str, benchmark_available: bool) -> bool {
+    activation_target(control_id, benchmark_available).is_some()
+}
+
+fn activation_target(control_id: &str, benchmark_available: bool) -> Option<ActivationTarget> {
+    let target = match control_id {
+        "launcher.scenario.previous" => launcher(0, UiAction::Left),
+        "launcher.scenario.next" => launcher(0, UiAction::Right),
+        "launcher.start" => launcher(1, UiAction::Confirm),
+        "launcher.settings" => launcher(2, UiAction::Confirm),
+        "launcher.controls" => launcher(3, UiAction::Confirm),
+        "launcher.quit" => launcher(4, UiAction::Confirm),
+        "launcher.settings.back" => launcher_settings(None, UiAction::Back),
+        "launcher.settings.start" => launcher_settings(None, UiAction::Start),
+        "launcher.controls.back" => launcher_controls(0),
+        "launcher.controls.touch-test" => launcher_controls(1),
+        "launcher.controls.start" => launcher_controls(2),
+        "launcher.touch-test.done" => ActivationTarget {
+            focus: ActivationFocus::TouchTest,
+            action: UiAction::Back,
+        },
+        "pause.resume" => pause_main(0),
+        "pause.restart" => pause_main(1),
+        "pause.benchmark" => pause_main(2),
+        "pause.controls" => pause_main(2 + i32::from(benchmark_available)),
+        "pause.return-to-launcher" => pause_main(3 + i32::from(benchmark_available)),
+        "pause.controls.back" => ActivationTarget {
+            focus: ActivationFocus::PauseControls,
+            action: UiAction::Back,
+        },
+        "pause.controls.resume" => ActivationTarget {
+            focus: ActivationFocus::PauseControls,
+            action: UiAction::Start,
+        },
+        "game-over.play-again" => game_over(0),
+        "game-over.return-to-launcher" => game_over(1),
+        _ => return launcher_setting_target(control_id),
+    };
+    Some(target)
+}
+
+fn launcher_setting_target(control_id: &str) -> Option<ActivationTarget> {
+    let (setting_id, action) = control_id
+        .strip_suffix(".previous")
+        .map(|id| (id, UiAction::Left))
+        .or_else(|| {
+            control_id
+                .strip_suffix(".next")
+                .map(|id| (id, UiAction::Right))
+        })?;
+    let focus_index = match setting_id {
+        "launcher.settings.renderer" | "launcher.settings.nes.cartridge" => 0,
+        "launcher.settings.raster-scale" => 1,
+        "launcher.settings.spacewars.preset" | "launcher.settings.pizza.desired-balls" => 2,
+        "launcher.settings.spacewars.planets" | "launcher.settings.pizza.spawn-rate" => 3,
+        "launcher.settings.spacewars.asteroids" => 4,
+        "launcher.settings.spacewars.player-health" => 5,
+        "launcher.settings.spacewars.player-2" => 6,
+        _ => return None,
+    };
+    Some(launcher_settings(Some(focus_index), action))
+}
+
+const fn launcher(index: i32, action: UiAction) -> ActivationTarget {
+    ActivationTarget {
+        focus: ActivationFocus::Launcher(index),
+        action,
+    }
+}
+
+const fn launcher_settings(index: Option<i32>, action: UiAction) -> ActivationTarget {
+    ActivationTarget {
+        focus: ActivationFocus::LauncherSettings(index),
+        action,
+    }
+}
+
+const fn launcher_controls(index: i32) -> ActivationTarget {
+    ActivationTarget {
+        focus: ActivationFocus::LauncherControls(index),
+        action: UiAction::Confirm,
+    }
+}
+
+const fn pause_main(index: i32) -> ActivationTarget {
+    ActivationTarget {
+        focus: ActivationFocus::PauseMain(index),
+        action: UiAction::Confirm,
+    }
+}
+
+const fn game_over(index: i32) -> ActivationTarget {
+    ActivationTarget {
+        focus: ActivationFocus::GameOver(index),
+        action: UiAction::Confirm,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pause_targets_account_for_the_optional_benchmark() {
+        assert_eq!(
+            activation_target("pause.controls", true),
+            Some(pause_main(3))
+        );
+        assert_eq!(
+            activation_target("pause.controls", false),
+            Some(pause_main(2))
+        );
+        assert_eq!(
+            activation_target("pause.return-to-launcher", true),
+            Some(pause_main(4))
+        );
+        assert_eq!(
+            activation_target("pause.return-to-launcher", false),
+            Some(pause_main(3))
+        );
+    }
+
+    #[test]
+    fn settings_targets_select_the_visible_row_and_direction() {
+        assert_eq!(
+            activation_target("launcher.settings.spacewars.player-health.previous", false),
+            Some(launcher_settings(Some(5), UiAction::Left))
+        );
+        assert_eq!(
+            activation_target("launcher.settings.pizza.spawn-rate.next", false),
+            Some(launcher_settings(Some(3), UiAction::Right))
+        );
+        assert_eq!(
+            activation_target("launcher.settings.unknown.next", false),
+            None
+        );
+    }
+}

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -1,6 +1,6 @@
 //! Stable control inventory for each externally visible UI screen.
 
-use spacewars_control::{UiControl, UiScreen};
+use spacewars_control::{UiAction, UiControl, UiScreen};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct ScreenVisibility {
@@ -63,6 +63,7 @@ pub(crate) struct UiInventoryContext {
 pub(crate) struct UiInventory {
     pub(crate) selected_control: Option<String>,
     pub(crate) controls: Vec<UiControl>,
+    pub(crate) actions: Vec<UiAction>,
     pub(crate) error: Option<String>,
 }
 
@@ -74,11 +75,13 @@ pub(crate) fn inventory_for_screen(screen: UiScreen, context: &UiInventoryContex
         UiScreen::LauncherTouchTest => UiInventory {
             selected_control: None,
             controls: vec![UiControl::new("launcher.touch-test.done", "Done", true)],
+            actions: vec![UiAction::Back, UiAction::Controls],
             error: None,
         },
         UiScreen::Gameplay => UiInventory {
             selected_control: None,
             controls: Vec::new(),
+            actions: Vec::new(),
             error: context.scenario_error.clone(),
         },
         UiScreen::PauseMain => pause_main_inventory(context),
@@ -87,6 +90,12 @@ pub(crate) fn inventory_for_screen(screen: UiScreen, context: &UiInventoryContex
             controls: vec![
                 UiControl::new("pause.controls.back", "Back", true),
                 UiControl::new("pause.controls.resume", "Resume", true),
+            ],
+            actions: vec![
+                UiAction::Confirm,
+                UiAction::Back,
+                UiAction::Start,
+                UiAction::Controls,
             ],
             error: context.scenario_error.clone(),
         },
@@ -98,6 +107,15 @@ pub(crate) fn inventory_for_screen(screen: UiScreen, context: &UiInventoryContex
             controls: vec![
                 UiControl::new("game-over.play-again", "Play Again", true),
                 UiControl::new("game-over.return-to-launcher", "Launcher", true),
+            ],
+            actions: vec![
+                UiAction::Up,
+                UiAction::Down,
+                UiAction::Left,
+                UiAction::Right,
+                UiAction::Confirm,
+                UiAction::Back,
+                UiAction::Start,
             ],
             error: context.scenario_error.clone(),
         },
@@ -125,6 +143,15 @@ fn launcher_main_inventory(context: &UiInventoryContext) -> UiInventory {
             UiControl::new("launcher.settings", "Settings", true),
             UiControl::new("launcher.controls", "Controls", true),
             UiControl::new("launcher.quit", "Quit", true),
+        ],
+        actions: vec![
+            UiAction::Up,
+            UiAction::Down,
+            UiAction::Left,
+            UiAction::Right,
+            UiAction::Confirm,
+            UiAction::Start,
+            UiAction::Controls,
         ],
         error: context.launcher_error.clone(),
     }
@@ -247,6 +274,7 @@ fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
     UiInventory {
         selected_control: selected_from_index(selected_ids, context.launcher_settings_focus_index),
         controls,
+        actions: UiAction::ALL.to_vec(),
         error: context.launcher_error.clone(),
     }
 }
@@ -270,6 +298,7 @@ fn launcher_controls_inventory(context: &UiInventoryContext) -> UiInventory {
                 context.launch_available,
             ),
         ],
+        actions: UiAction::ALL.to_vec(),
         error: context.launcher_error.clone(),
     }
 }
@@ -293,6 +322,7 @@ fn pause_main_inventory(context: &UiInventoryContext) -> UiInventory {
     UiInventory {
         selected_control: selected_from_index(&ids, context.ingame_menu_focus_index),
         controls,
+        actions: UiAction::ALL.to_vec(),
         error: context.scenario_error.clone(),
     }
 }
@@ -576,6 +606,58 @@ mod tests {
             let inventory = inventory_for_screen(screen, &context);
             assert_eq!(inventory.selected_control.as_deref(), selected);
             assert_eq!(control_ids(&inventory), ids);
+        }
+    }
+
+    #[test]
+    fn reports_only_actions_handled_by_each_screen() {
+        let context = context("spacewars");
+        let cases = [
+            (
+                UiScreen::LauncherMain,
+                vec![
+                    UiAction::Up,
+                    UiAction::Down,
+                    UiAction::Left,
+                    UiAction::Right,
+                    UiAction::Confirm,
+                    UiAction::Start,
+                    UiAction::Controls,
+                ],
+            ),
+            (UiScreen::LauncherSettings, UiAction::ALL.to_vec()),
+            (UiScreen::LauncherControls, UiAction::ALL.to_vec()),
+            (
+                UiScreen::LauncherTouchTest,
+                vec![UiAction::Back, UiAction::Controls],
+            ),
+            (UiScreen::Gameplay, vec![]),
+            (UiScreen::PauseMain, UiAction::ALL.to_vec()),
+            (
+                UiScreen::PauseControls,
+                vec![
+                    UiAction::Confirm,
+                    UiAction::Back,
+                    UiAction::Start,
+                    UiAction::Controls,
+                ],
+            ),
+            (
+                UiScreen::GameOver,
+                vec![
+                    UiAction::Up,
+                    UiAction::Down,
+                    UiAction::Left,
+                    UiAction::Right,
+                    UiAction::Confirm,
+                    UiAction::Back,
+                    UiAction::Start,
+                ],
+            ),
+        ];
+
+        for (screen, expected) in cases {
+            assert_eq!(inventory_for_screen(screen, &context).actions, expected);
         }
     }
 

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -1,0 +1,605 @@
+//! Stable control inventory for each externally visible UI screen.
+
+use spacewars_control::{UiControl, UiScreen};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ScreenVisibility {
+    pub(crate) launcher: bool,
+    pub(crate) launcher_controls: bool,
+    pub(crate) launcher_settings: bool,
+    pub(crate) touch_test: bool,
+    pub(crate) ingame_menu: bool,
+    pub(crate) ingame_controls: bool,
+    pub(crate) game_over: bool,
+}
+
+pub(crate) fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
+    if visibility.touch_test {
+        UiScreen::LauncherTouchTest
+    } else if visibility.launcher {
+        if visibility.launcher_controls {
+            UiScreen::LauncherControls
+        } else if visibility.launcher_settings {
+            UiScreen::LauncherSettings
+        } else {
+            UiScreen::LauncherMain
+        }
+    } else if visibility.game_over {
+        UiScreen::GameOver
+    } else if visibility.ingame_controls {
+        UiScreen::PauseControls
+    } else if visibility.ingame_menu {
+        UiScreen::PauseMain
+    } else {
+        UiScreen::Gameplay
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct UiInventoryContext {
+    pub(crate) selected_scenario: String,
+    pub(crate) launcher_focus_index: i32,
+    pub(crate) launcher_settings_focus_index: i32,
+    pub(crate) launcher_controls_focus_index: i32,
+    pub(crate) ingame_menu_focus_index: i32,
+    pub(crate) game_over_focus_index: i32,
+    pub(crate) benchmark_available: bool,
+    pub(crate) launch_available: bool,
+    pub(crate) launcher_error: Option<String>,
+    pub(crate) scenario_error: Option<String>,
+    pub(crate) renderer: String,
+    pub(crate) raster_scale: String,
+    pub(crate) spacewars_preset: String,
+    pub(crate) spacewars_planets: String,
+    pub(crate) spacewars_asteroids: String,
+    pub(crate) spacewars_player_health: String,
+    pub(crate) spacewars_player_2: String,
+    pub(crate) pizza_desired_balls: String,
+    pub(crate) pizza_spawn_rate: String,
+    pub(crate) nes_cartridge_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UiInventory {
+    pub(crate) selected_control: Option<String>,
+    pub(crate) controls: Vec<UiControl>,
+    pub(crate) error: Option<String>,
+}
+
+pub(crate) fn inventory_for_screen(screen: UiScreen, context: &UiInventoryContext) -> UiInventory {
+    match screen {
+        UiScreen::LauncherMain => launcher_main_inventory(context),
+        UiScreen::LauncherSettings => launcher_settings_inventory(context),
+        UiScreen::LauncherControls => launcher_controls_inventory(context),
+        UiScreen::LauncherTouchTest => UiInventory {
+            selected_control: None,
+            controls: vec![UiControl::new("launcher.touch-test.done", "Done", true)],
+            error: None,
+        },
+        UiScreen::Gameplay => UiInventory {
+            selected_control: None,
+            controls: Vec::new(),
+            error: context.scenario_error.clone(),
+        },
+        UiScreen::PauseMain => pause_main_inventory(context),
+        UiScreen::PauseControls => UiInventory {
+            selected_control: Some("pause.controls.back".into()),
+            controls: vec![
+                UiControl::new("pause.controls.back", "Back", true),
+                UiControl::new("pause.controls.resume", "Resume", true),
+            ],
+            error: context.scenario_error.clone(),
+        },
+        UiScreen::GameOver => UiInventory {
+            selected_control: selected_from_index(
+                &["game-over.play-again", "game-over.return-to-launcher"],
+                context.game_over_focus_index,
+            ),
+            controls: vec![
+                UiControl::new("game-over.play-again", "Play Again", true),
+                UiControl::new("game-over.return-to-launcher", "Launcher", true),
+            ],
+            error: context.scenario_error.clone(),
+        },
+    }
+}
+
+fn launcher_main_inventory(context: &UiInventoryContext) -> UiInventory {
+    UiInventory {
+        selected_control: selected_from_index(
+            &[
+                "launcher.scenario",
+                "launcher.start",
+                "launcher.settings",
+                "launcher.controls",
+                "launcher.quit",
+            ],
+            context.launcher_focus_index,
+        ),
+        controls: vec![
+            UiControl::new("launcher.scenario.previous", "‹", true)
+                .with_value(context.selected_scenario.clone()),
+            UiControl::new("launcher.scenario.next", "›", true)
+                .with_value(context.selected_scenario.clone()),
+            UiControl::new("launcher.start", "Start Game", context.launch_available),
+            UiControl::new("launcher.settings", "Settings", true),
+            UiControl::new("launcher.controls", "Controls", true),
+            UiControl::new("launcher.quit", "Quit", true),
+        ],
+        error: context.launcher_error.clone(),
+    }
+}
+
+fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
+    let mut controls = Vec::new();
+    let selected_ids: &[&str] = match context.selected_scenario.as_str() {
+        "spacewars" => {
+            push_choice(
+                &mut controls,
+                "launcher.settings.renderer",
+                &context.renderer,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.raster-scale",
+                &format!("{}×", context.raster_scale),
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.spacewars.preset",
+                &context.spacewars_preset,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.spacewars.planets",
+                &context.spacewars_planets,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.spacewars.asteroids",
+                &context.spacewars_asteroids,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.spacewars.player-health",
+                &format!("{}%", context.spacewars_player_health),
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.spacewars.player-2",
+                &context.spacewars_player_2,
+            );
+            &[
+                "launcher.settings.renderer",
+                "launcher.settings.raster-scale",
+                "launcher.settings.spacewars.preset",
+                "launcher.settings.spacewars.planets",
+                "launcher.settings.spacewars.asteroids",
+                "launcher.settings.spacewars.player-health",
+                "launcher.settings.spacewars.player-2",
+                "launcher.settings.back",
+            ]
+        }
+        "pizza" => {
+            push_choice(
+                &mut controls,
+                "launcher.settings.renderer",
+                &context.renderer,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.raster-scale",
+                &format!("{}×", context.raster_scale),
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.pizza.desired-balls",
+                &context.pizza_desired_balls,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.pizza.spawn-rate",
+                &context.pizza_spawn_rate,
+            );
+            &[
+                "launcher.settings.renderer",
+                "launcher.settings.raster-scale",
+                "launcher.settings.pizza.desired-balls",
+                "launcher.settings.pizza.spawn-rate",
+                "launcher.settings.back",
+            ]
+        }
+        "falling" => &["launcher.settings.back"],
+        "nes" => {
+            push_choice(
+                &mut controls,
+                "launcher.settings.nes.cartridge",
+                &context.nes_cartridge_name,
+            );
+            &["launcher.settings.nes.cartridge", "launcher.settings.back"]
+        }
+        _ => {
+            push_choice(
+                &mut controls,
+                "launcher.settings.renderer",
+                &context.renderer,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.raster-scale",
+                &format!("{}×", context.raster_scale),
+            );
+            &[
+                "launcher.settings.renderer",
+                "launcher.settings.raster-scale",
+                "launcher.settings.back",
+            ]
+        }
+    };
+
+    controls.push(UiControl::new("launcher.settings.back", "Back", true));
+    controls.push(UiControl::new(
+        "launcher.settings.start",
+        "Start Game",
+        context.launch_available,
+    ));
+
+    UiInventory {
+        selected_control: selected_from_index(selected_ids, context.launcher_settings_focus_index),
+        controls,
+        error: context.launcher_error.clone(),
+    }
+}
+
+fn launcher_controls_inventory(context: &UiInventoryContext) -> UiInventory {
+    UiInventory {
+        selected_control: selected_from_index(
+            &[
+                "launcher.controls.back",
+                "launcher.controls.touch-test",
+                "launcher.controls.start",
+            ],
+            context.launcher_controls_focus_index,
+        ),
+        controls: vec![
+            UiControl::new("launcher.controls.back", "Back", true),
+            UiControl::new("launcher.controls.touch-test", "Touch Test", true),
+            UiControl::new(
+                "launcher.controls.start",
+                "Start Game",
+                context.launch_available,
+            ),
+        ],
+        error: context.launcher_error.clone(),
+    }
+}
+
+fn pause_main_inventory(context: &UiInventoryContext) -> UiInventory {
+    let mut ids = vec!["pause.resume", "pause.restart"];
+    let mut controls = vec![
+        UiControl::new("pause.resume", "Resume", true),
+        UiControl::new("pause.restart", "Restart Round", true),
+    ];
+    if context.benchmark_available {
+        ids.push("pause.benchmark");
+        controls.push(UiControl::new("pause.benchmark", "Benchmark", true));
+    }
+    ids.extend(["pause.controls", "pause.return-to-launcher"]);
+    controls.extend([
+        UiControl::new("pause.controls", "Controls", true),
+        UiControl::new("pause.return-to-launcher", "Return to Launcher", true),
+    ]);
+
+    UiInventory {
+        selected_control: selected_from_index(&ids, context.ingame_menu_focus_index),
+        controls,
+        error: context.scenario_error.clone(),
+    }
+}
+
+fn push_choice(controls: &mut Vec<UiControl>, id: &str, value: &str) {
+    controls.push(UiControl::new(format!("{id}.previous"), "‹", true).with_value(value));
+    controls.push(UiControl::new(format!("{id}.next"), "›", true).with_value(value));
+}
+
+fn selected_from_index(ids: &[&str], index: i32) -> Option<String> {
+    usize::try_from(index)
+        .ok()
+        .and_then(|index| ids.get(index))
+        .map(|id| (*id).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context(scenario: &str) -> UiInventoryContext {
+        UiInventoryContext {
+            selected_scenario: scenario.into(),
+            launch_available: true,
+            renderer: "raster".into(),
+            raster_scale: "2.0".into(),
+            spacewars_preset: "Small Duel".into(),
+            spacewars_planets: "on".into(),
+            spacewars_asteroids: "off".into(),
+            spacewars_player_health: "125".into(),
+            spacewars_player_2: "rule bot".into(),
+            pizza_desired_balls: "75".into(),
+            pizza_spawn_rate: "0.10".into(),
+            nes_cartridge_name: "Demo Cartridge".into(),
+            ..Default::default()
+        }
+    }
+
+    fn control_ids(inventory: &UiInventory) -> Vec<&str> {
+        inventory
+            .controls
+            .iter()
+            .map(|control| control.id.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn classifies_all_ui_screens() {
+        let cases = [
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherMain,
+            ),
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    launcher_settings: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherSettings,
+            ),
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    launcher_controls: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherControls,
+            ),
+            (
+                ScreenVisibility {
+                    launcher: true,
+                    touch_test: true,
+                    ..Default::default()
+                },
+                UiScreen::LauncherTouchTest,
+            ),
+            (ScreenVisibility::default(), UiScreen::Gameplay),
+            (
+                ScreenVisibility {
+                    ingame_menu: true,
+                    ..Default::default()
+                },
+                UiScreen::PauseMain,
+            ),
+            (
+                ScreenVisibility {
+                    ingame_menu: true,
+                    ingame_controls: true,
+                    ..Default::default()
+                },
+                UiScreen::PauseControls,
+            ),
+            (
+                ScreenVisibility {
+                    game_over: true,
+                    ..Default::default()
+                },
+                UiScreen::GameOver,
+            ),
+        ];
+
+        for (visibility, expected) in cases {
+            assert_eq!(classify_screen(visibility), expected);
+        }
+    }
+
+    #[test]
+    fn classification_uses_visible_layer_order() {
+        assert_eq!(
+            classify_screen(ScreenVisibility {
+                launcher: true,
+                launcher_controls: true,
+                launcher_settings: true,
+                touch_test: true,
+                ingame_menu: true,
+                ingame_controls: true,
+                game_over: true,
+            }),
+            UiScreen::LauncherTouchTest
+        );
+        assert_eq!(
+            classify_screen(ScreenVisibility {
+                launcher: true,
+                launcher_controls: true,
+                launcher_settings: true,
+                game_over: true,
+                ..Default::default()
+            }),
+            UiScreen::LauncherControls
+        );
+        assert_eq!(
+            classify_screen(ScreenVisibility {
+                ingame_menu: true,
+                ingame_controls: true,
+                game_over: true,
+                ..Default::default()
+            }),
+            UiScreen::GameOver
+        );
+    }
+
+    #[test]
+    fn launcher_main_reports_actions_selection_readiness_and_error() {
+        let mut context = context("nes");
+        context.launcher_focus_index = 0;
+        context.launch_available = false;
+        context.launcher_error = Some("No cartridge selected".into());
+
+        let inventory = inventory_for_screen(UiScreen::LauncherMain, &context);
+
+        assert_eq!(
+            inventory.selected_control.as_deref(),
+            Some("launcher.scenario")
+        );
+        assert_eq!(
+            control_ids(&inventory),
+            [
+                "launcher.scenario.previous",
+                "launcher.scenario.next",
+                "launcher.start",
+                "launcher.settings",
+                "launcher.controls",
+                "launcher.quit",
+            ]
+        );
+        assert!(!inventory.controls[2].enabled);
+        assert_eq!(inventory.controls[0].value.as_deref(), Some("nes"));
+        assert_eq!(inventory.error.as_deref(), Some("No cartridge selected"));
+    }
+
+    #[test]
+    fn settings_inventory_matches_each_scenario() {
+        let cases = [
+            ("spacewars", 16, "launcher.settings.spacewars.player-2"),
+            ("pizza", 10, "launcher.settings.pizza.spawn-rate"),
+            ("rover-lab", 6, "launcher.settings.raster-scale"),
+            ("falling", 2, "launcher.settings.back"),
+            ("nes", 4, "launcher.settings.nes.cartridge"),
+        ];
+
+        for (scenario, control_count, selected) in cases {
+            let mut context = context(scenario);
+            context.launcher_settings_focus_index = match scenario {
+                "spacewars" => 6,
+                "pizza" => 3,
+                "rover-lab" => 1,
+                "falling" => 0,
+                "nes" => 0,
+                _ => unreachable!(),
+            };
+            let inventory = inventory_for_screen(UiScreen::LauncherSettings, &context);
+
+            assert_eq!(inventory.controls.len(), control_count);
+            assert_eq!(inventory.selected_control.as_deref(), Some(selected));
+            assert_eq!(
+                control_ids(&inventory)[control_count - 2..],
+                ["launcher.settings.back", "launcher.settings.start"]
+            );
+        }
+    }
+
+    #[test]
+    fn settings_choices_expose_the_visible_value() {
+        let inventory = inventory_for_screen(UiScreen::LauncherSettings, &context("spacewars"));
+        let value = |id: &str| {
+            inventory
+                .controls
+                .iter()
+                .find(|control| control.id == id)
+                .and_then(|control| control.value.as_deref())
+        };
+
+        assert_eq!(value("launcher.settings.renderer.previous"), Some("raster"));
+        assert_eq!(value("launcher.settings.raster-scale.next"), Some("2.0×"));
+        assert_eq!(
+            value("launcher.settings.spacewars.player-health.next"),
+            Some("125%")
+        );
+    }
+
+    #[test]
+    fn pause_inventory_tracks_dynamic_benchmark_and_selection() {
+        let mut context = context("pizza");
+        context.benchmark_available = true;
+        context.ingame_menu_focus_index = 2;
+        let with_benchmark = inventory_for_screen(UiScreen::PauseMain, &context);
+        assert_eq!(
+            with_benchmark.selected_control.as_deref(),
+            Some("pause.benchmark")
+        );
+        assert!(control_ids(&with_benchmark).contains(&"pause.benchmark"));
+
+        context.benchmark_available = false;
+        let without_benchmark = inventory_for_screen(UiScreen::PauseMain, &context);
+        assert_eq!(
+            without_benchmark.selected_control.as_deref(),
+            Some("pause.controls")
+        );
+        assert!(!control_ids(&without_benchmark).contains(&"pause.benchmark"));
+    }
+
+    #[test]
+    fn static_screens_report_their_visible_controls() {
+        let mut context = context("spacewars");
+        context.launcher_controls_focus_index = 1;
+        context.game_over_focus_index = 1;
+
+        let cases = [
+            (
+                UiScreen::LauncherControls,
+                Some("launcher.controls.touch-test"),
+                vec![
+                    "launcher.controls.back",
+                    "launcher.controls.touch-test",
+                    "launcher.controls.start",
+                ],
+            ),
+            (
+                UiScreen::LauncherTouchTest,
+                None,
+                vec!["launcher.touch-test.done"],
+            ),
+            (UiScreen::Gameplay, None, vec![]),
+            (
+                UiScreen::PauseControls,
+                Some("pause.controls.back"),
+                vec!["pause.controls.back", "pause.controls.resume"],
+            ),
+            (
+                UiScreen::GameOver,
+                Some("game-over.return-to-launcher"),
+                vec!["game-over.play-again", "game-over.return-to-launcher"],
+            ),
+        ];
+
+        for (screen, selected, ids) in cases {
+            let inventory = inventory_for_screen(screen, &context);
+            assert_eq!(inventory.selected_control.as_deref(), selected);
+            assert_eq!(control_ids(&inventory), ids);
+        }
+    }
+
+    #[test]
+    fn errors_follow_the_screen_that_displays_them() {
+        let mut context = context("spacewars");
+        context.launcher_error = Some("launcher failed".into());
+        context.scenario_error = Some("scenario failed".into());
+
+        assert_eq!(
+            inventory_for_screen(UiScreen::LauncherSettings, &context)
+                .error
+                .as_deref(),
+            Some("launcher failed")
+        );
+        assert_eq!(
+            inventory_for_screen(UiScreen::Gameplay, &context)
+                .error
+                .as_deref(),
+            Some("scenario failed")
+        );
+        assert_eq!(
+            inventory_for_screen(UiScreen::LauncherTouchTest, &context).error,
+            None
+        );
+    }
+}

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -662,6 +662,48 @@ mod tests {
     }
 
     #[test]
+    fn every_enabled_control_has_a_semantic_activation_mapping() {
+        for scenario in ["spacewars", "pizza", "rover-lab", "falling", "nes"] {
+            let context = context(scenario);
+            for screen in [
+                UiScreen::LauncherMain,
+                UiScreen::LauncherSettings,
+                UiScreen::LauncherControls,
+                UiScreen::LauncherTouchTest,
+            ] {
+                assert_inventory_is_activatable(screen, &context);
+            }
+        }
+
+        for benchmark_available in [false, true] {
+            let mut context = context("spacewars");
+            context.benchmark_available = benchmark_available;
+            for screen in [
+                UiScreen::Gameplay,
+                UiScreen::PauseMain,
+                UiScreen::PauseControls,
+                UiScreen::GameOver,
+            ] {
+                assert_inventory_is_activatable(screen, &context);
+            }
+        }
+    }
+
+    fn assert_inventory_is_activatable(screen: UiScreen, context: &UiInventoryContext) {
+        for control in inventory_for_screen(screen, context)
+            .controls
+            .into_iter()
+            .filter(|control| control.enabled)
+        {
+            assert!(
+                crate::ui_activation::supports(&control.id, context.benchmark_available),
+                "{} on {screen} has no semantic activation mapping",
+                control.id
+            );
+        }
+    }
+
+    #[test]
     fn errors_follow_the_screen_that_displays_them() {
         let mut context = context("spacewars");
         context.launcher_error = Some("launcher failed".into());

--- a/crates/engine-client/src/ui_navigation.rs
+++ b/crates/engine-client/src/ui_navigation.rs
@@ -1,37 +1,6 @@
 //! Backend-neutral menu actions shared by keyboards and gamepads.
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(i32)]
-pub(crate) enum UiAction {
-    Up = 0,
-    Down = 1,
-    Left = 2,
-    Right = 3,
-    Confirm = 4,
-    Back = 5,
-    Start = 6,
-    Controls = 7,
-}
-
-impl UiAction {
-    pub(crate) const fn code(self) -> i32 {
-        self as i32
-    }
-
-    pub(crate) const fn from_code(code: i32) -> Option<Self> {
-        match code {
-            0 => Some(Self::Up),
-            1 => Some(Self::Down),
-            2 => Some(Self::Left),
-            3 => Some(Self::Right),
-            4 => Some(Self::Confirm),
-            5 => Some(Self::Back),
-            6 => Some(Self::Start),
-            7 => Some(Self::Controls),
-            _ => None,
-        }
-    }
-}
+use spacewars_control::UiAction;
 
 pub(crate) fn moved_selection(current: i32, item_count: i32, delta: i32) -> i32 {
     if item_count <= 0 {
@@ -94,16 +63,7 @@ mod tests {
 
     #[test]
     fn action_codes_round_trip() {
-        for action in [
-            UiAction::Up,
-            UiAction::Down,
-            UiAction::Left,
-            UiAction::Right,
-            UiAction::Confirm,
-            UiAction::Back,
-            UiAction::Start,
-            UiAction::Controls,
-        ] {
+        for action in UiAction::ALL {
             assert_eq!(UiAction::from_code(action.code()), Some(action));
         }
         assert_eq!(UiAction::from_code(99), None);

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -1,0 +1,733 @@
+#![cfg(unix)]
+
+use std::any::Any;
+use std::collections::BTreeSet;
+use std::fs::{self, File};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde_json::{Value, json};
+use spacewars_control::{
+    ControlClient, ControlClientError, ControlFailure, ControlFailureCode, UiAction,
+    UiPressRequest, UiScreen, UiState, UiStatePredicate,
+};
+use tempfile::{Builder, TempDir};
+
+const ARTIFACT_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const READINESS_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_millis(250);
+const TRANSITION_TIMEOUT: Duration = Duration::from_secs(10);
+const PNG_SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn launcher_navigation_uses_the_public_control_api() {
+    run_functional_test("launcher-navigation", |harness| {
+        let mut state = harness.wait_until_ready();
+        assert_launcher_main(&state);
+
+        let mut reached = BTreeSet::from([selected_control(&state)]);
+        for action in [
+            UiAction::Down,
+            UiAction::Right,
+            UiAction::Down,
+            UiAction::Left,
+            UiAction::Up,
+            UiAction::Up,
+        ] {
+            state = harness.press_guarded(action, &state);
+            reached.insert(selected_control(&state));
+        }
+        assert_eq!(
+            reached,
+            BTreeSet::from([
+                "launcher.controls".into(),
+                "launcher.quit".into(),
+                "launcher.scenario".into(),
+                "launcher.settings".into(),
+                "launcher.start".into(),
+            ])
+        );
+        assert_eq!(selected_control(&state), "launcher.scenario");
+
+        state = harness.press_guarded(UiAction::Down, &state);
+        state = harness.press_guarded(UiAction::Right, &state);
+        assert_eq!(selected_control(&state), "launcher.settings");
+        state = harness.press_guarded(UiAction::Confirm, &state);
+        assert_eq!(state.screen, UiScreen::LauncherSettings);
+        assert_eq!(
+            control_ids(&state),
+            [
+                "launcher.settings.renderer.previous",
+                "launcher.settings.renderer.next",
+                "launcher.settings.raster-scale.previous",
+                "launcher.settings.raster-scale.next",
+                "launcher.settings.spacewars.preset.previous",
+                "launcher.settings.spacewars.preset.next",
+                "launcher.settings.spacewars.planets.previous",
+                "launcher.settings.spacewars.planets.next",
+                "launcher.settings.spacewars.asteroids.previous",
+                "launcher.settings.spacewars.asteroids.next",
+                "launcher.settings.spacewars.player-health.previous",
+                "launcher.settings.spacewars.player-health.next",
+                "launcher.settings.spacewars.player-2.previous",
+                "launcher.settings.spacewars.player-2.next",
+                "launcher.settings.back",
+                "launcher.settings.start",
+            ]
+        );
+        assert_eq!(state.actions, UiAction::ALL);
+
+        let renderer_before = control_value(&state, "launcher.settings.renderer.next");
+        let adjusted = harness.press_guarded(UiAction::Right, &state);
+        assert!(adjusted.revision > state.revision);
+        assert_ne!(
+            control_value(&adjusted, "launcher.settings.renderer.next"),
+            renderer_before
+        );
+        state = harness.press_guarded(UiAction::Back, &adjusted);
+        assert_eq!(state.screen, UiScreen::LauncherMain);
+
+        state = harness.press_guarded(UiAction::Up, &state);
+        state = harness.press_guarded(UiAction::Up, &state);
+        assert_eq!(selected_control(&state), "launcher.controls");
+        state = harness.press_guarded(UiAction::Confirm, &state);
+        assert_eq!(state.screen, UiScreen::LauncherControls);
+        assert_eq!(
+            control_ids(&state),
+            [
+                "launcher.controls.back",
+                "launcher.controls.touch-test",
+                "launcher.controls.start",
+            ]
+        );
+
+        state = harness.press_guarded(UiAction::Down, &state);
+        assert_eq!(selected_control(&state), "launcher.controls.touch-test");
+        state = harness.press_guarded(UiAction::Confirm, &state);
+        assert_eq!(state.screen, UiScreen::LauncherTouchTest);
+        assert_eq!(control_ids(&state), ["launcher.touch-test.done"]);
+        assert_eq!(state.actions, [UiAction::Back, UiAction::Controls]);
+
+        let unavailable = harness.expect_press_failure(
+            UiAction::Up,
+            Some(UiScreen::LauncherTouchTest),
+            Some(state.revision),
+        );
+        assert_eq!(unavailable.code, ControlFailureCode::ActionUnavailable);
+        assert_eq!(unavailable.current_state.as_ref(), Some(&state));
+
+        state = harness.press_guarded(UiAction::Back, &state);
+        assert_eq!(state.screen, UiScreen::LauncherControls);
+        state = harness.press_guarded(UiAction::Back, &state);
+        assert_eq!(state.screen, UiScreen::LauncherMain);
+
+        let wrong_screen = harness.expect_press_failure(
+            UiAction::Down,
+            Some(UiScreen::PauseMain),
+            Some(state.revision),
+        );
+        assert_eq!(wrong_screen.code, ControlFailureCode::WrongScreen);
+        assert_eq!(wrong_screen.current_state.as_ref(), Some(&state));
+
+        let stale = harness.expect_press_failure(
+            UiAction::Down,
+            Some(UiScreen::LauncherMain),
+            Some(state.revision.saturating_add(1)),
+        );
+        assert_eq!(stale.code, ControlFailureCode::StaleRevision);
+        assert_eq!(stale.current_state.as_ref(), Some(&state));
+
+        let unavailable = harness.expect_press_failure(
+            UiAction::Back,
+            Some(UiScreen::LauncherMain),
+            Some(state.revision),
+        );
+        assert_eq!(unavailable.code, ControlFailureCode::ActionUnavailable);
+        assert_eq!(unavailable.current_state.as_ref(), Some(&state));
+
+        assert_eq!(harness.state(), state);
+        harness.capture_screenshot("launcher.png");
+    });
+}
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn launcher_can_start_real_gameplay() {
+    run_functional_test("launcher-start-gameplay", |harness| {
+        let mut state = harness.wait_until_ready();
+        assert_launcher_main(&state);
+
+        state = harness.press_guarded(UiAction::Down, &state);
+        assert_eq!(selected_control(&state), "launcher.start");
+        let launcher_revision = state.revision;
+        harness.press_guarded(UiAction::Confirm, &state);
+
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                scenario: Some("spacewars".into()),
+                revision_after: Some(launcher_revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert_eq!(state.screen, UiScreen::Gameplay);
+        assert_eq!(state.active_scenario.as_deref(), Some("spacewars"));
+        assert_eq!(state.selected_scenario, "spacewars");
+        assert!(state.scenario_revision.is_some());
+        assert!(!state.paused);
+        assert!(state.controls.is_empty());
+        assert!(state.actions.is_empty());
+        harness.capture_screenshot("gameplay.png");
+    });
+}
+
+fn run_functional_test(name: &'static str, workflow: impl FnOnce(&mut FunctionalHarness)) {
+    let mut harness = FunctionalHarness::spawn(name)
+        .unwrap_or_else(|error| panic!("could not start {name}: {error}"));
+    let result = catch_unwind(AssertUnwindSafe(|| workflow(&mut harness)));
+    if let Err(payload) = result {
+        harness.failure = Some(panic_message(payload.as_ref()));
+        drop(harness);
+        resume_unwind(payload);
+    }
+}
+
+struct FunctionalHarness {
+    test_name: &'static str,
+    started_at: Instant,
+    run_directory: Option<TempDir>,
+    _socket_path: OwnedSocketPath,
+    client: ControlClient,
+    child: OwnedChild,
+    history: Vec<Value>,
+    last_state: Option<UiState>,
+    failure: Option<String>,
+}
+
+impl FunctionalHarness {
+    fn spawn(test_name: &'static str) -> Result<Self, String> {
+        let artifact_root = workspace_root().join("target/functional-test-artifacts");
+        fs::create_dir_all(&artifact_root).map_err(|error| {
+            format!(
+                "could not create artifact root {}: {error}",
+                artifact_root.display()
+            )
+        })?;
+        let run_directory = Builder::new()
+            .prefix(&format!("{test_name}-"))
+            .tempdir_in(&artifact_root)
+            .map_err(|error| format!("could not create test directory: {error}"))?;
+        let config_directory = run_directory.path().join("config");
+        fs::create_dir(&config_directory)
+            .map_err(|error| format!("could not create isolated config directory: {error}"))?;
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|error| format!("system clock is before the Unix epoch: {error}"))?
+            .as_nanos();
+        let socket_path = std::env::temp_dir().join(format!(
+            "spacewars-functional-{}-{nonce}.sock",
+            std::process::id()
+        ));
+        let log_path = run_directory.path().join("engine-client.log");
+        let log = File::create(&log_path)
+            .map_err(|error| format!("could not create {}: {error}", log_path.display()))?;
+        let stderr_log = log
+            .try_clone()
+            .map_err(|error| format!("could not clone engine log handle: {error}"))?;
+
+        let arguments = [
+            "--config-dir".to_string(),
+            config_directory.display().to_string(),
+            "--seed".into(),
+            "4242".into(),
+            "--renderer".into(),
+            "raster".into(),
+            "--raster-scale".into(),
+            "1.0".into(),
+        ];
+        let mut command = Command::new(env!("CARGO_BIN_EXE_engine-client"));
+        command
+            .args(&arguments)
+            .current_dir(workspace_root())
+            .env("RUST_LOG", "info")
+            .env("SLINT_BACKEND", "winit-software")
+            .env("SPACEWARS_CONTROL_SOCKET", &socket_path)
+            .env_remove("WAYLAND_DISPLAY")
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(stderr_log));
+        let child = OwnedChild(
+            command
+                .spawn()
+                .map_err(|error| format!("could not spawn engine-client: {error}"))?,
+        );
+
+        Ok(Self {
+            test_name,
+            started_at: Instant::now(),
+            run_directory: Some(run_directory),
+            _socket_path: OwnedSocketPath(socket_path.clone()),
+            client: ControlClient::new(socket_path),
+            child,
+            history: vec![json!({
+                "elapsed_ms": 0,
+                "command": "spawn engine-client",
+                "arguments": arguments,
+            })],
+            last_state: None,
+            failure: None,
+        })
+    }
+
+    fn wait_until_ready(&mut self) -> UiState {
+        let deadline = Instant::now()
+            .checked_add(READINESS_TIMEOUT)
+            .expect("readiness deadline must fit in Instant");
+        let mut last_error = None;
+
+        loop {
+            match self.child.0.try_wait() {
+                Ok(Some(status)) => {
+                    panic!("engine-client exited before readiness with {status}");
+                }
+                Ok(None) => {}
+                Err(error) => panic!("could not inspect engine-client: {error}"),
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                panic!(
+                    "timed out after {READINESS_TIMEOUT:?} waiting for engine-client readiness; last error: {}",
+                    last_error.as_deref().unwrap_or("none")
+                );
+            }
+            let request_deadline = deadline.min(
+                now.checked_add(REQUEST_TIMEOUT)
+                    .expect("request deadline must fit in Instant"),
+            );
+            match self.client.ui_state_before(request_deadline) {
+                Ok(state) => {
+                    self.record_state("ui state (readiness)", &state);
+                    return state;
+                }
+                Err(error) if is_retryable_readiness_error(&error) => {
+                    last_error = Some(error.to_string());
+                }
+                Err(error) => {
+                    self.record_error("ui state (readiness)", &error);
+                    panic!("engine-client readiness failed: {error}");
+                }
+            }
+            thread::sleep(POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
+        }
+    }
+
+    fn state(&mut self) -> UiState {
+        let result = self.client.ui_state();
+        self.require_state_result("ui state", result)
+    }
+
+    fn press_guarded(&mut self, action: UiAction, state: &UiState) -> UiState {
+        self.press(action, Some(state.screen), Some(state.revision))
+    }
+
+    fn press(
+        &mut self,
+        action: UiAction,
+        expected_screen: Option<UiScreen>,
+        expected_revision: Option<u64>,
+    ) -> UiState {
+        let request = press_request(action, expected_screen, expected_revision);
+        let command = format!(
+            "ui press {action} --expect-screen={} --expect-revision={}",
+            optional_screen(expected_screen),
+            optional_revision(expected_revision)
+        );
+        let result = self.client.ui_press(&request);
+        self.require_state_result(&command, result)
+    }
+
+    fn expect_press_failure(
+        &mut self,
+        action: UiAction,
+        expected_screen: Option<UiScreen>,
+        expected_revision: Option<u64>,
+    ) -> ControlFailure {
+        let request = press_request(action, expected_screen, expected_revision);
+        let command = format!(
+            "ui press {action} --expect-screen={} --expect-revision={}",
+            optional_screen(expected_screen),
+            optional_revision(expected_revision)
+        );
+        match self.client.ui_press(&request) {
+            Err(ControlClientError::Failure(failure)) => {
+                if let Some(state) = &failure.current_state {
+                    self.last_state = Some(state.clone());
+                }
+                self.history.push(json!({
+                    "elapsed_ms": self.elapsed_ms(),
+                    "command": command,
+                    "outcome": "rejected",
+                    "failure": failure,
+                }));
+                *failure
+            }
+            Ok(state) => {
+                self.record_state(&command, &state);
+                panic!("{command} succeeded, but a structured rejection was expected");
+            }
+            Err(error) => {
+                self.record_error(&command, &error);
+                panic!("{command} returned an unexpected error: {error}");
+            }
+        }
+    }
+
+    fn wait_for(&mut self, predicate: UiStatePredicate, timeout: Duration) -> UiState {
+        let command = format!(
+            "ui wait --screen={} --scenario={} --revision-after={} --timeout={timeout:?}",
+            optional_screen(predicate.screen),
+            predicate.scenario.as_deref().unwrap_or("none"),
+            optional_revision(predicate.revision_after),
+        );
+        let result = self.client.wait_for_ui_state(&predicate, timeout);
+        self.require_state_result(&command, result)
+    }
+
+    fn capture_screenshot(&mut self, name: &str) -> PathBuf {
+        let path = self.run_path().join(name);
+        let response = self.screenshot_request(&path, TRANSITION_TIMEOUT);
+        match response {
+            Ok(message) => {
+                self.history.push(json!({
+                    "elapsed_ms": self.elapsed_ms(),
+                    "command": format!("screenshot {}", path.display()),
+                    "outcome": "ok",
+                    "response": message,
+                }));
+            }
+            Err(error) => {
+                self.record_error_message(
+                    &format!("screenshot {}", path.display()),
+                    &error.to_string(),
+                    error.failure(),
+                );
+                panic!("screenshot capture failed: {error}");
+            }
+        }
+        let bytes = fs::read(&path).unwrap_or_else(|error| {
+            panic!("could not read screenshot {}: {error}", path.display())
+        });
+        assert!(
+            bytes.starts_with(PNG_SIGNATURE),
+            "{} is not a PNG",
+            path.display()
+        );
+        path
+    }
+
+    fn require_state_result(
+        &mut self,
+        command: &str,
+        result: Result<UiState, ControlClientError>,
+    ) -> UiState {
+        match result {
+            Ok(state) => {
+                self.record_state(command, &state);
+                state
+            }
+            Err(error) => {
+                self.record_error(command, &error);
+                panic!("{command} failed: {error}");
+            }
+        }
+    }
+
+    fn record_state(&mut self, command: &str, state: &UiState) {
+        self.last_state = Some(state.clone());
+        self.history.push(json!({
+            "elapsed_ms": self.elapsed_ms(),
+            "command": command,
+            "outcome": "ok",
+            "state": state,
+        }));
+    }
+
+    fn record_error(&mut self, command: &str, error: &ControlClientError) {
+        if let Some(state) = error
+            .failure()
+            .and_then(|failure| failure.current_state.as_ref())
+        {
+            self.last_state = Some(state.clone());
+        }
+        self.record_error_message(command, &error.to_string(), error.failure());
+    }
+
+    fn record_error_message(
+        &mut self,
+        command: &str,
+        message: &str,
+        failure: Option<&ControlFailure>,
+    ) {
+        self.history.push(json!({
+            "elapsed_ms": self.elapsed_ms(),
+            "command": command,
+            "outcome": "error",
+            "error": message,
+            "failure": failure,
+        }));
+    }
+
+    fn screenshot_request(
+        &self,
+        path: &Path,
+        timeout: Duration,
+    ) -> Result<String, ControlClientError> {
+        let output = path
+            .to_str()
+            .expect("functional-test paths must be valid UTF-8");
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .expect("screenshot deadline must fit in Instant");
+        self.client
+            .request_before(&format!("screenshot\n{output}\n"), deadline)
+    }
+
+    fn elapsed_ms(&self) -> u128 {
+        self.started_at.elapsed().as_millis()
+    }
+
+    fn run_path(&self) -> &Path {
+        self.run_directory
+            .as_ref()
+            .expect("run directory must exist until harness cleanup")
+            .path()
+    }
+
+    fn capture_live_failure_artifacts(&mut self) {
+        let deadline = Instant::now()
+            .checked_add(ARTIFACT_REQUEST_TIMEOUT)
+            .expect("artifact deadline must fit in Instant");
+        if let Ok(state) = self.client.ui_state_before(deadline) {
+            self.record_state("ui state (failure capture)", &state);
+        }
+
+        let screenshot = self.run_path().join("failure.png");
+        match self.screenshot_request(&screenshot, ARTIFACT_REQUEST_TIMEOUT) {
+            Ok(message) => self.history.push(json!({
+                "elapsed_ms": self.elapsed_ms(),
+                "command": format!("screenshot {} (failure capture)", screenshot.display()),
+                "outcome": "ok",
+                "response": message,
+            })),
+            Err(error) => self.record_error_message(
+                "screenshot (failure capture)",
+                &error.to_string(),
+                error.failure(),
+            ),
+        }
+    }
+
+    fn write_failure_artifacts(&self) {
+        if let Some(state) = &self.last_state {
+            write_json(&self.run_path().join("last-state.json"), state);
+        }
+        write_json(&self.run_path().join("command-history.json"), &self.history);
+        write_json(
+            &self.run_path().join("summary.json"),
+            &json!({
+                "schema_version": 1,
+                "name": self.test_name,
+                "duration_ms": self.elapsed_ms(),
+                "result": {
+                    "success": false,
+                    "error": self.failure.as_deref().unwrap_or("test panicked"),
+                },
+                "engine_log": "engine-client.log",
+                "last_state": self.last_state.as_ref().map(|_| "last-state.json"),
+                "command_history": "command-history.json",
+                "failure_screenshot": self
+                    .run_path()
+                    .join("failure.png")
+                    .exists()
+                    .then_some("failure.png"),
+            }),
+        );
+    }
+
+    fn terminate_child(&mut self) {
+        match self.child.0.try_wait() {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                let _ = self.child.0.kill();
+                let _ = self.child.0.wait();
+            }
+            Err(_) => {
+                let _ = self.child.0.kill();
+                let _ = self.child.0.wait();
+            }
+        }
+    }
+}
+
+impl Drop for FunctionalHarness {
+    fn drop(&mut self) {
+        let preserve = self.failure.is_some() || thread::panicking();
+        if preserve {
+            self.capture_live_failure_artifacts();
+        }
+        self.terminate_child();
+
+        if preserve {
+            self.write_failure_artifacts();
+            if let Some(run_directory) = self.run_directory.take() {
+                let path = run_directory.keep();
+                eprintln!("Preserved functional-test artifacts at {}", path.display());
+            }
+        }
+    }
+}
+
+struct OwnedChild(Child);
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        match self.0.try_wait() {
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
+    }
+}
+
+struct OwnedSocketPath(PathBuf);
+
+impl Drop for OwnedSocketPath {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+fn press_request(
+    action: UiAction,
+    expected_screen: Option<UiScreen>,
+    expected_revision: Option<u64>,
+) -> UiPressRequest {
+    let mut request = UiPressRequest::new(action);
+    request.expected_screen = expected_screen;
+    request.expected_revision = expected_revision;
+    request
+}
+
+fn assert_launcher_main(state: &UiState) {
+    assert_eq!(state.screen, UiScreen::LauncherMain);
+    assert_eq!(state.active_scenario, None);
+    assert_eq!(state.selected_scenario, "spacewars");
+    assert_eq!(selected_control(state), "launcher.scenario");
+    assert_eq!(
+        control_ids(state),
+        [
+            "launcher.scenario.previous",
+            "launcher.scenario.next",
+            "launcher.start",
+            "launcher.settings",
+            "launcher.controls",
+            "launcher.quit",
+        ]
+    );
+    assert_eq!(
+        state.actions,
+        [
+            UiAction::Up,
+            UiAction::Down,
+            UiAction::Left,
+            UiAction::Right,
+            UiAction::Confirm,
+            UiAction::Start,
+            UiAction::Controls,
+        ]
+    );
+}
+
+fn selected_control(state: &UiState) -> String {
+    state
+        .selected_control
+        .clone()
+        .unwrap_or_else(|| panic!("{} has no selected control", state.screen))
+}
+
+fn control_ids(state: &UiState) -> Vec<&str> {
+    state
+        .controls
+        .iter()
+        .map(|control| control.id.as_str())
+        .collect()
+}
+
+fn control_value<'a>(state: &'a UiState, id: &str) -> Option<&'a str> {
+    state
+        .controls
+        .iter()
+        .find(|control| control.id == id)
+        .and_then(|control| control.value.as_deref())
+}
+
+fn optional_screen(screen: Option<UiScreen>) -> &'static str {
+    screen.map(UiScreen::as_str).unwrap_or("none")
+}
+
+fn optional_revision(revision: Option<u64>) -> String {
+    revision
+        .map(|revision| revision.to_string())
+        .unwrap_or_else(|| "none".into())
+}
+
+fn is_retryable_readiness_error(error: &ControlClientError) -> bool {
+    match error {
+        ControlClientError::DeadlineElapsed => true,
+        ControlClientError::Io(error) => matches!(
+            error.kind(),
+            std::io::ErrorKind::NotFound
+                | std::io::ErrorKind::ConnectionRefused
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::TimedOut
+                | std::io::ErrorKind::WouldBlock
+        ),
+        _ => false,
+    }
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).into()
+    } else {
+        "non-string panic payload".into()
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("engine-client must live under <workspace>/crates")
+        .to_path_buf()
+}
+
+fn write_json(path: &Path, value: &impl Serialize) {
+    if let Ok(json) = serde_json::to_vec_pretty(value) {
+        let _ = fs::write(path, json);
+    }
+}

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -12,8 +12,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde::Serialize;
 use serde_json::{Value, json};
 use spacewars_control::{
-    ControlClient, ControlClientError, ControlFailure, ControlFailureCode, UiAction,
-    UiActivateRequest, UiPressRequest, UiScreen, UiState, UiStatePredicate,
+    ControlClient, ControlClientError, ControlFailure, ControlFailureCode, HostPauseRequest,
+    UiAction, UiActivateRequest, UiPressRequest, UiScreen, UiState, UiStatePredicate,
 };
 use tempfile::{Builder, TempDir};
 
@@ -172,10 +172,15 @@ fn launcher_navigation_uses_the_public_control_api() {
 
 #[test]
 #[ignore = "requires an explicit display; CI runs this test under Xvfb"]
-fn launcher_can_start_real_gameplay() {
-    run_functional_test("launcher-start-gameplay", |harness| {
+fn launcher_can_start_spacewars_and_use_pause_benchmark() {
+    run_functional_test("launcher-spacewars-pause-benchmark", |harness| {
         let mut state = harness.wait_until_ready();
         assert_launcher_main(&state);
+
+        let unavailable = harness.expect_pause_failure(&state);
+        assert_eq!(unavailable.code, ControlFailureCode::WrongScreen);
+        assert_eq!(unavailable.current_state.as_ref(), Some(&state));
+        assert_eq!(harness.state(), state);
 
         let launcher_revision = state.revision;
         harness.activate_guarded("launcher.start", &state);
@@ -191,11 +196,51 @@ fn launcher_can_start_real_gameplay() {
         assert_eq!(state.screen, UiScreen::Gameplay);
         assert_eq!(state.active_scenario.as_deref(), Some("spacewars"));
         assert_eq!(state.selected_scenario, "spacewars");
-        assert!(state.scenario_revision.is_some());
+        let gameplay_scenario_revision = state
+            .scenario_revision
+            .expect("gameplay must report a scenario revision");
         assert!(!state.paused);
+        assert!(!state.benchmark_active);
         assert!(state.controls.is_empty());
         assert!(state.actions.is_empty());
         harness.capture_screenshot("gameplay.png");
+
+        let pause_requested = harness.pause_guarded(&state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::PauseMain),
+                scenario: Some("spacewars".into()),
+                revision_after: Some(pause_requested.revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert!(state.paused);
+        assert!(!state.benchmark_active);
+        assert_eq!(
+            control_ids(&state),
+            [
+                "pause.resume",
+                "pause.restart",
+                "pause.benchmark",
+                "pause.controls",
+                "pause.return-to-launcher",
+            ]
+        );
+        harness.capture_screenshot("pause.png");
+
+        let benchmark_requested = harness.activate_guarded("pause.benchmark", &state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                scenario: Some("spacewars".into()),
+                revision_after: Some(benchmark_requested.revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert!(!state.paused);
+        assert!(state.benchmark_active);
+        assert_ne!(state.scenario_revision, Some(gameplay_scenario_revision));
+        harness.capture_screenshot("benchmark.png");
     });
 }
 
@@ -400,6 +445,46 @@ impl FunctionalHarness {
                 visited.insert(state.selected_scenario.clone()),
                 "scenario {target:?} is not reachable through launcher.scenario.next; visited {visited:?}"
             );
+        }
+    }
+
+    fn pause_guarded(&mut self, state: &UiState) -> UiState {
+        let request = pause_request(Some(state.screen), Some(state.revision));
+        let command = format!(
+            "host pause --expect-screen={} --expect-revision={}",
+            state.screen, state.revision
+        );
+        let result = self.client.host_pause_before(&request, request_deadline());
+        self.require_state_result(&command, result)
+    }
+
+    fn expect_pause_failure(&mut self, state: &UiState) -> ControlFailure {
+        let request = pause_request(Some(state.screen), Some(state.revision));
+        let command = format!(
+            "host pause --expect-screen={} --expect-revision={}",
+            state.screen, state.revision
+        );
+        match self.client.host_pause_before(&request, request_deadline()) {
+            Err(ControlClientError::Failure(failure)) => {
+                if let Some(state) = &failure.current_state {
+                    self.last_state = Some(state.clone());
+                }
+                self.history.push(json!({
+                    "elapsed_ms": self.elapsed_ms(),
+                    "command": command,
+                    "outcome": "rejected",
+                    "failure": failure,
+                }));
+                *failure
+            }
+            Ok(state) => {
+                self.record_state(&command, &state);
+                panic!("{command} succeeded, but a structured rejection was expected");
+            }
+            Err(error) => {
+                self.record_error(&command, &error);
+                panic!("{command} returned an unexpected error: {error}");
+            }
         }
     }
 
@@ -719,6 +804,16 @@ fn activate_request(
     expected_revision: Option<u64>,
 ) -> UiActivateRequest {
     let mut request = UiActivateRequest::new(control_id);
+    request.expected_screen = expected_screen;
+    request.expected_revision = expected_revision;
+    request
+}
+
+fn pause_request(
+    expected_screen: Option<UiScreen>,
+    expected_revision: Option<u64>,
+) -> HostPauseRequest {
+    let mut request = HostPauseRequest::new();
     request.expected_screen = expected_screen;
     request.expected_revision = expected_revision;
     request

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use spacewars_control::{
     ControlClient, ControlClientError, ControlFailure, ControlFailureCode, UiAction,
-    UiPressRequest, UiScreen, UiState, UiStatePredicate,
+    UiActivateRequest, UiPressRequest, UiScreen, UiState, UiStatePredicate,
 };
 use tempfile::{Builder, TempDir};
 
@@ -55,10 +55,7 @@ fn launcher_navigation_uses_the_public_control_api() {
         );
         assert_eq!(selected_control(&state), "launcher.scenario");
 
-        state = harness.press_guarded(UiAction::Down, &state);
-        state = harness.press_guarded(UiAction::Right, &state);
-        assert_eq!(selected_control(&state), "launcher.settings");
-        state = harness.press_guarded(UiAction::Confirm, &state);
+        state = harness.activate_guarded("launcher.settings", &state);
         assert_eq!(state.screen, UiScreen::LauncherSettings);
         assert_eq!(
             control_ids(&state),
@@ -84,19 +81,16 @@ fn launcher_navigation_uses_the_public_control_api() {
         assert_eq!(state.actions, UiAction::ALL);
 
         let renderer_before = control_value(&state, "launcher.settings.renderer.next");
-        let adjusted = harness.press_guarded(UiAction::Right, &state);
+        let adjusted = harness.activate_guarded("launcher.settings.renderer.next", &state);
         assert!(adjusted.revision > state.revision);
         assert_ne!(
             control_value(&adjusted, "launcher.settings.renderer.next"),
             renderer_before
         );
-        state = harness.press_guarded(UiAction::Back, &adjusted);
+        state = harness.activate_guarded("launcher.settings.back", &adjusted);
         assert_eq!(state.screen, UiScreen::LauncherMain);
 
-        state = harness.press_guarded(UiAction::Up, &state);
-        state = harness.press_guarded(UiAction::Up, &state);
-        assert_eq!(selected_control(&state), "launcher.controls");
-        state = harness.press_guarded(UiAction::Confirm, &state);
+        state = harness.activate_guarded("launcher.controls", &state);
         assert_eq!(state.screen, UiScreen::LauncherControls);
         assert_eq!(
             control_ids(&state),
@@ -107,9 +101,7 @@ fn launcher_navigation_uses_the_public_control_api() {
             ]
         );
 
-        state = harness.press_guarded(UiAction::Down, &state);
-        assert_eq!(selected_control(&state), "launcher.controls.touch-test");
-        state = harness.press_guarded(UiAction::Confirm, &state);
+        state = harness.activate_guarded("launcher.controls.touch-test", &state);
         assert_eq!(state.screen, UiScreen::LauncherTouchTest);
         assert_eq!(control_ids(&state), ["launcher.touch-test.done"]);
         assert_eq!(state.actions, [UiAction::Back, UiAction::Controls]);
@@ -122,26 +114,34 @@ fn launcher_navigation_uses_the_public_control_api() {
         assert_eq!(unavailable.code, ControlFailureCode::ActionUnavailable);
         assert_eq!(unavailable.current_state.as_ref(), Some(&state));
 
-        state = harness.press_guarded(UiAction::Back, &state);
+        state = harness.activate_guarded("launcher.touch-test.done", &state);
         assert_eq!(state.screen, UiScreen::LauncherControls);
-        state = harness.press_guarded(UiAction::Back, &state);
+        state = harness.activate_guarded("launcher.controls.back", &state);
         assert_eq!(state.screen, UiScreen::LauncherMain);
 
-        let wrong_screen = harness.expect_press_failure(
-            UiAction::Down,
+        let wrong_screen = harness.expect_activate_failure(
+            "launcher.settings",
             Some(UiScreen::PauseMain),
             Some(state.revision),
         );
         assert_eq!(wrong_screen.code, ControlFailureCode::WrongScreen);
         assert_eq!(wrong_screen.current_state.as_ref(), Some(&state));
 
-        let stale = harness.expect_press_failure(
-            UiAction::Down,
+        let stale = harness.expect_activate_failure(
+            "launcher.settings",
             Some(UiScreen::LauncherMain),
             Some(state.revision.saturating_add(1)),
         );
         assert_eq!(stale.code, ControlFailureCode::StaleRevision);
         assert_eq!(stale.current_state.as_ref(), Some(&state));
+
+        let unavailable = harness.expect_activate_failure(
+            "launcher.missing",
+            Some(UiScreen::LauncherMain),
+            Some(state.revision),
+        );
+        assert_eq!(unavailable.code, ControlFailureCode::ControlUnavailable);
+        assert_eq!(unavailable.current_state.as_ref(), Some(&state));
 
         let unavailable = harness.expect_press_failure(
             UiAction::Back,
@@ -151,6 +151,20 @@ fn launcher_navigation_uses_the_public_control_api() {
         assert_eq!(unavailable.code, ControlFailureCode::ActionUnavailable);
         assert_eq!(unavailable.current_state.as_ref(), Some(&state));
 
+        let original_scenario = state.selected_scenario.clone();
+        state = harness.activate_until_scenario("nes", state);
+        assert!(!control_enabled(&state, "launcher.start"));
+        let disabled = harness.expect_activate_failure(
+            "launcher.start",
+            Some(UiScreen::LauncherMain),
+            Some(state.revision),
+        );
+        assert_eq!(disabled.code, ControlFailureCode::ControlDisabled);
+        assert_eq!(disabled.current_state.as_ref(), Some(&state));
+        assert_eq!(harness.state(), state);
+
+        state = harness.activate_until_scenario(&original_scenario, state);
+        assert!(control_enabled(&state, "launcher.start"));
         assert_eq!(harness.state(), state);
         harness.capture_screenshot("launcher.png");
     });
@@ -163,10 +177,8 @@ fn launcher_can_start_real_gameplay() {
         let mut state = harness.wait_until_ready();
         assert_launcher_main(&state);
 
-        state = harness.press_guarded(UiAction::Down, &state);
-        assert_eq!(selected_control(&state), "launcher.start");
         let launcher_revision = state.revision;
-        harness.press_guarded(UiAction::Confirm, &state);
+        harness.activate_guarded("launcher.start", &state);
 
         state = harness.wait_for(
             UiStatePredicate {
@@ -330,7 +342,7 @@ impl FunctionalHarness {
     }
 
     fn state(&mut self) -> UiState {
-        let result = self.client.ui_state();
+        let result = self.client.ui_state_before(request_deadline());
         self.require_state_result("ui state", result)
     }
 
@@ -350,8 +362,45 @@ impl FunctionalHarness {
             optional_screen(expected_screen),
             optional_revision(expected_revision)
         );
-        let result = self.client.ui_press(&request);
+        let result = self.client.ui_press_before(&request, request_deadline());
         self.require_state_result(&command, result)
+    }
+
+    fn activate_guarded(&mut self, control_id: &str, state: &UiState) -> UiState {
+        self.activate(control_id, Some(state.screen), Some(state.revision))
+    }
+
+    fn activate(
+        &mut self,
+        control_id: &str,
+        expected_screen: Option<UiScreen>,
+        expected_revision: Option<u64>,
+    ) -> UiState {
+        let request = activate_request(control_id, expected_screen, expected_revision);
+        let command = format!(
+            "ui activate {control_id:?} --expect-screen={} --expect-revision={}",
+            optional_screen(expected_screen),
+            optional_revision(expected_revision)
+        );
+        let result = self.client.ui_activate_before(&request, request_deadline());
+        self.require_state_result(&command, result)
+    }
+
+    fn activate_until_scenario(&mut self, target: &str, mut state: UiState) -> UiState {
+        if state.selected_scenario == target {
+            return state;
+        }
+        let mut visited = BTreeSet::from([state.selected_scenario.clone()]);
+        loop {
+            state = self.activate_guarded("launcher.scenario.next", &state);
+            if state.selected_scenario == target {
+                return state;
+            }
+            assert!(
+                visited.insert(state.selected_scenario.clone()),
+                "scenario {target:?} is not reachable through launcher.scenario.next; visited {visited:?}"
+            );
+        }
     }
 
     fn expect_press_failure(
@@ -366,7 +415,43 @@ impl FunctionalHarness {
             optional_screen(expected_screen),
             optional_revision(expected_revision)
         );
-        match self.client.ui_press(&request) {
+        match self.client.ui_press_before(&request, request_deadline()) {
+            Err(ControlClientError::Failure(failure)) => {
+                if let Some(state) = &failure.current_state {
+                    self.last_state = Some(state.clone());
+                }
+                self.history.push(json!({
+                    "elapsed_ms": self.elapsed_ms(),
+                    "command": command,
+                    "outcome": "rejected",
+                    "failure": failure,
+                }));
+                *failure
+            }
+            Ok(state) => {
+                self.record_state(&command, &state);
+                panic!("{command} succeeded, but a structured rejection was expected");
+            }
+            Err(error) => {
+                self.record_error(&command, &error);
+                panic!("{command} returned an unexpected error: {error}");
+            }
+        }
+    }
+
+    fn expect_activate_failure(
+        &mut self,
+        control_id: &str,
+        expected_screen: Option<UiScreen>,
+        expected_revision: Option<u64>,
+    ) -> ControlFailure {
+        let request = activate_request(control_id, expected_screen, expected_revision);
+        let command = format!(
+            "ui activate {control_id:?} --expect-screen={} --expect-revision={}",
+            optional_screen(expected_screen),
+            optional_revision(expected_revision)
+        );
+        match self.client.ui_activate_before(&request, request_deadline()) {
             Err(ControlClientError::Failure(failure)) => {
                 if let Some(state) = &failure.current_state {
                     self.last_state = Some(state.clone());
@@ -628,6 +713,17 @@ fn press_request(
     request
 }
 
+fn activate_request(
+    control_id: &str,
+    expected_screen: Option<UiScreen>,
+    expected_revision: Option<u64>,
+) -> UiActivateRequest {
+    let mut request = UiActivateRequest::new(control_id);
+    request.expected_screen = expected_screen;
+    request.expected_revision = expected_revision;
+    request
+}
+
 fn assert_launcher_main(state: &UiState) {
     assert_eq!(state.screen, UiScreen::LauncherMain);
     assert_eq!(state.active_scenario, None);
@@ -681,6 +777,15 @@ fn control_value<'a>(state: &'a UiState, id: &str) -> Option<&'a str> {
         .and_then(|control| control.value.as_deref())
 }
 
+fn control_enabled(state: &UiState, id: &str) -> bool {
+    state
+        .controls
+        .iter()
+        .find(|control| control.id == id)
+        .unwrap_or_else(|| panic!("{} does not expose control {id:?}", state.screen))
+        .enabled
+}
+
 fn optional_screen(screen: Option<UiScreen>) -> &'static str {
     screen.map(UiScreen::as_str).unwrap_or("none")
 }
@@ -689,6 +794,12 @@ fn optional_revision(revision: Option<u64>) -> String {
     revision
         .map(|revision| revision.to_string())
         .unwrap_or_else(|| "none".into())
+}
+
+fn request_deadline() -> Instant {
+    Instant::now()
+        .checked_add(TRANSITION_TIMEOUT)
+        .expect("functional-test request deadline must fit in Instant")
 }
 
 fn is_retryable_readiness_error(error: &ControlClientError) -> bool {

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -172,8 +172,8 @@ fn launcher_navigation_uses_the_public_control_api() {
 
 #[test]
 #[ignore = "requires an explicit display; CI runs this test under Xvfb"]
-fn launcher_can_start_spacewars_and_use_pause_benchmark() {
-    run_functional_test("launcher-spacewars-pause-benchmark", |harness| {
+fn launcher_can_run_the_spacewars_menu_lifecycle() {
+    run_functional_test("launcher-spacewars-menu-lifecycle", |harness| {
         let mut state = harness.wait_until_ready();
         assert_launcher_main(&state);
 
@@ -239,8 +239,91 @@ fn launcher_can_start_spacewars_and_use_pause_benchmark() {
         );
         assert!(!state.paused);
         assert!(state.benchmark_active);
-        assert_ne!(state.scenario_revision, Some(gameplay_scenario_revision));
+        let benchmark_scenario_revision = state
+            .scenario_revision
+            .expect("benchmark must report a scenario revision");
+        assert_ne!(benchmark_scenario_revision, gameplay_scenario_revision);
         harness.capture_screenshot("benchmark.png");
+
+        let pause_requested = harness.pause_guarded(&state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::PauseMain),
+                scenario: Some("spacewars".into()),
+                revision_after: Some(pause_requested.revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert!(state.paused);
+        assert!(state.benchmark_active);
+
+        let restart_requested = harness.activate_guarded("pause.restart", &state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                scenario: Some("spacewars".into()),
+                revision_after: Some(restart_requested.revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        let restarted_scenario_revision = state
+            .scenario_revision
+            .expect("restarted gameplay must report a scenario revision");
+        assert_ne!(restarted_scenario_revision, benchmark_scenario_revision);
+        assert!(!state.paused);
+        assert!(!state.benchmark_active);
+        assert!(state.controls.is_empty());
+        assert!(state.actions.is_empty());
+        harness.capture_screenshot("restarted-gameplay.png");
+
+        let pause_requested = harness.pause_guarded(&state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::PauseMain),
+                scenario: Some("spacewars".into()),
+                revision_after: Some(pause_requested.revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert!(state.paused);
+        assert!(!state.benchmark_active);
+
+        let return_from_revision = state.revision;
+        harness.activate_guarded("pause.return-to-launcher", &state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::LauncherMain),
+                scenario: None,
+                revision_after: Some(return_from_revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert_launcher_main(&state);
+        assert_eq!(state.scenario_revision, None);
+        assert!(!state.paused);
+        assert!(!state.benchmark_active);
+        assert_eq!(state.error, None);
+        harness.capture_screenshot("returned-launcher.png");
+
+        let returned_launcher_revision = state.revision;
+        harness.activate_guarded("launcher.start", &state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                scenario: Some("spacewars".into()),
+                revision_after: Some(returned_launcher_revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        let relaunched_scenario_revision = state
+            .scenario_revision
+            .expect("relaunched gameplay must report a scenario revision");
+        assert_ne!(relaunched_scenario_revision, restarted_scenario_revision);
+        assert!(!state.paused);
+        assert!(!state.benchmark_active);
+        assert!(state.controls.is_empty());
+        assert!(state.actions.is_empty());
+        harness.capture_screenshot("relaunched-gameplay.png");
     });
 }
 

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -1,12 +1,17 @@
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use engine_common::DEFAULT_CONTROL_SOCKET;
 #[cfg(test)]
 use spacewars_control::UI_STATE_SCHEMA_VERSION;
-use spacewars_control::{UI_STATE_COMMAND, UiControl, UiState, parse_runtime_status};
+use spacewars_control::{
+    ControlClient, ControlClientError, ControlFailure, UiAction, UiControl, UiPressRequest,
+    UiScreen, UiState, UiStatePredicate, parse_runtime_status,
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "spacewars-cli", about = "Space-Wars runtime control helper")]
@@ -45,12 +50,118 @@ enum Command {
 
 #[derive(Debug, Subcommand)]
 enum UiCommand {
-    /// Print the current screen and scenario state.
+    /// Print the current screen, accepted actions, and visible controls.
     State {
         /// Emit the versioned state object as JSON.
         #[arg(long)]
         json: bool,
     },
+
+    /// Send one menu action and print the resulting UI state.
+    Press {
+        /// Action to route through the keyboard/gamepad menu handler.
+        #[arg(value_enum)]
+        action: UiActionArg,
+
+        /// Reject the action unless this screen is currently visible.
+        #[arg(long, value_enum)]
+        expect_screen: Option<UiScreenArg>,
+
+        /// Reject the action unless this exact UI revision is current.
+        #[arg(long)]
+        expect_revision: Option<u64>,
+
+        /// Emit success or structured control failures as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Poll until all supplied UI-state conditions match.
+    ///
+    /// At least one of --screen, --scenario, or --revision-after is required.
+    Wait {
+        /// Wait for this screen to be visible.
+        #[arg(long, value_enum)]
+        screen: Option<UiScreenArg>,
+
+        /// Wait for this active scenario, or the selected launcher scenario.
+        #[arg(long)]
+        scenario: Option<String>,
+
+        /// Wait for the UI revision to become greater than this value.
+        #[arg(long)]
+        revision_after: Option<u64>,
+
+        /// Maximum time to wait.
+        #[arg(long, default_value = "10s", value_parser = parse_timeout)]
+        timeout: Duration,
+
+        /// Emit success or structured timeout failures as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum UiActionArg {
+    Up,
+    Down,
+    Left,
+    Right,
+    Confirm,
+    Back,
+    Start,
+    Controls,
+}
+
+impl From<UiActionArg> for UiAction {
+    fn from(action: UiActionArg) -> Self {
+        match action {
+            UiActionArg::Up => Self::Up,
+            UiActionArg::Down => Self::Down,
+            UiActionArg::Left => Self::Left,
+            UiActionArg::Right => Self::Right,
+            UiActionArg::Confirm => Self::Confirm,
+            UiActionArg::Back => Self::Back,
+            UiActionArg::Start => Self::Start,
+            UiActionArg::Controls => Self::Controls,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum UiScreenArg {
+    #[value(name = "launcher.main")]
+    LauncherMain,
+    #[value(name = "launcher.settings")]
+    LauncherSettings,
+    #[value(name = "launcher.controls")]
+    LauncherControls,
+    #[value(name = "launcher.touch-test")]
+    LauncherTouchTest,
+    #[value(name = "gameplay")]
+    Gameplay,
+    #[value(name = "pause.main")]
+    PauseMain,
+    #[value(name = "pause.controls")]
+    PauseControls,
+    #[value(name = "game-over")]
+    GameOver,
+}
+
+impl From<UiScreenArg> for UiScreen {
+    fn from(screen: UiScreenArg) -> Self {
+        match screen {
+            UiScreenArg::LauncherMain => Self::LauncherMain,
+            UiScreenArg::LauncherSettings => Self::LauncherSettings,
+            UiScreenArg::LauncherControls => Self::LauncherControls,
+            UiScreenArg::LauncherTouchTest => Self::LauncherTouchTest,
+            UiScreenArg::Gameplay => Self::Gameplay,
+            UiScreenArg::PauseMain => Self::PauseMain,
+            UiScreenArg::PauseControls => Self::PauseControls,
+            UiScreenArg::GameOver => Self::GameOver,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -63,29 +174,99 @@ enum HostCommand {
     },
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+enum CliError {
+    Human(String),
+    Json(Box<ControlFailure>),
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(CliError::Human(error)) => {
+            eprintln!("Error: {error}");
+            ExitCode::FAILURE
+        }
+        Err(CliError::Json(failure)) => {
+            match failure.to_pretty_json() {
+                Ok(json) => eprintln!("{json}"),
+                Err(error) => eprintln!("Error: {error}"),
+            }
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), CliError> {
     let args = Args::parse();
     let socket = args
         .socket
         .or_else(|| std::env::var_os("SPACEWARS_CONTROL_SOCKET").map(PathBuf::from))
         .unwrap_or_else(|| PathBuf::from(DEFAULT_CONTROL_SOCKET));
+    let client = ControlClient::new(socket);
 
     match args.command {
-        Command::Status => request_status(&socket)?,
-        Command::Screenshot { output } => request_screenshot(&socket, output)?,
+        Command::Status => request_status(&client).map_err(human_error),
+        Command::Screenshot { output } => request_screenshot(&client, output).map_err(human_error),
         Command::Ui {
             command: UiCommand::State { json },
-        } => request_ui_state(&socket, json)?,
+        } => request_ui_state(&client, json).map_err(human_error),
+        Command::Ui {
+            command:
+                UiCommand::Press {
+                    action,
+                    expect_screen,
+                    expect_revision,
+                    json,
+                },
+        } => request_ui_press(
+            &client,
+            action.into(),
+            expect_screen.map(Into::into),
+            expect_revision,
+            json,
+        )
+        .map_err(|error| control_error(error, json)),
+        Command::Ui {
+            command:
+                UiCommand::Wait {
+                    screen,
+                    scenario,
+                    revision_after,
+                    timeout,
+                    json,
+                },
+        } => request_ui_wait(
+            &client,
+            UiStatePredicate {
+                screen: screen.map(Into::into),
+                scenario,
+                revision_after,
+            },
+            timeout,
+            json,
+        )
+        .map_err(|error| control_error(error, json)),
         Command::Host {
             command: HostCommand::Benchmark { timeout },
-        } => request_benchmark(&socket, timeout)?,
+        } => request_benchmark(&client, timeout).map_err(human_error),
     }
-
-    Ok(())
 }
 
-#[cfg(unix)]
-fn request_screenshot(socket: &Path, output: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+fn human_error(error: impl std::fmt::Display) -> CliError {
+    CliError::Human(error.to_string())
+}
+
+fn control_error(error: ControlClientError, json: bool) -> CliError {
+    match (json, error) {
+        (true, ControlClientError::Failure(failure)) => CliError::Json(failure),
+        (_, error) => human_error(error),
+    }
+}
+
+fn request_screenshot(
+    client: &ControlClient,
+    output: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
     let output = output
         .to_str()
         .ok_or("screenshot output path must be valid UTF-8")?;
@@ -93,42 +274,74 @@ fn request_screenshot(socket: &Path, output: PathBuf) -> Result<(), Box<dyn std:
         return Err("screenshot output path must not contain newlines".into());
     }
 
-    let message = send_request(socket, &format!("screenshot\n{output}\n"))?;
+    let message = client.request(&format!("screenshot\n{output}\n"))?;
     println!("{message}");
     Ok(())
 }
 
-#[cfg(unix)]
-fn request_status(socket: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let message = fetch_status(socket)?;
+fn request_status(client: &ControlClient) -> Result<(), ControlClientError> {
+    let message = fetch_status(client)?;
     println!("{message}");
     Ok(())
 }
 
-#[cfg(unix)]
-fn request_ui_state(socket: &Path, json: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let state = UiState::from_json(&send_request(socket, &format!("{UI_STATE_COMMAND}\n"))?)?;
+fn request_ui_state(client: &ControlClient, json: bool) -> Result<(), ControlClientError> {
+    print_ui_state(&client.ui_state()?, json)
+}
+
+fn request_ui_press(
+    client: &ControlClient,
+    action: UiAction,
+    expected_screen: Option<UiScreen>,
+    expected_revision: Option<u64>,
+    json: bool,
+) -> Result<(), ControlClientError> {
+    let mut request = UiPressRequest::new(action);
+    request.expected_screen = expected_screen;
+    request.expected_revision = expected_revision;
+    print_ui_state(&client.ui_press(&request)?, json)
+}
+
+fn request_ui_wait(
+    client: &ControlClient,
+    predicate: UiStatePredicate,
+    timeout: Duration,
+    json: bool,
+) -> Result<(), ControlClientError> {
+    if predicate.is_empty() {
+        return Err(ControlClientError::Failure(Box::new(ControlFailure::new(
+            spacewars_control::ControlFailureCode::InvalidRequest,
+            "ui wait requires --screen, --scenario, or --revision-after",
+            None,
+        ))));
+    }
+    print_ui_state(&client.wait_for_ui_state(&predicate, timeout)?, json)
+}
+
+fn print_ui_state(state: &UiState, json: bool) -> Result<(), ControlClientError> {
     if json {
         println!("{}", state.to_pretty_json()?);
     } else {
-        println!("{}", format_ui_state(&state));
+        println!("{}", format_ui_state(state));
     }
     Ok(())
 }
 
-#[cfg(unix)]
-fn request_benchmark(socket: &Path, timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
+fn request_benchmark(
+    client: &ControlClient,
+    timeout: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
     let deadline = Instant::now()
         .checked_add(timeout)
         .ok_or("benchmark timeout is too large")?;
-    let initial_status = fetch_status_before(socket, deadline)?;
+    let initial_status = fetch_status_before(client, deadline)?;
     let initial = parse_runtime_status(&initial_status)?;
 
-    send_request_before(socket, "host benchmark\n", deadline)?;
+    client.request_before("host benchmark\n", deadline)?;
 
     let mut last_status = initial_status;
     loop {
-        let status_text = fetch_status_before(socket, deadline).map_err(|error| {
+        let status_text = fetch_status_before(client, deadline).map_err(|error| {
             format!(
                 "failed while waiting up to {} for a new benchmark instance after scenario revision {}: {}; last status:\n{}",
                 format_duration(timeout),
@@ -161,75 +374,30 @@ fn request_benchmark(socket: &Path, timeout: Duration) -> Result<(), Box<dyn std
     }
 }
 
-#[cfg(unix)]
-fn fetch_status(socket: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    send_request(socket, "status\n")
+fn fetch_status(client: &ControlClient) -> Result<String, ControlClientError> {
+    client.request("status\n")
 }
 
-#[cfg(unix)]
 fn fetch_status_before(
-    socket: &Path,
+    client: &ControlClient,
     deadline: Instant,
-) -> Result<String, Box<dyn std::error::Error>> {
-    send_request_before(socket, "status\n", deadline)
-}
-
-#[cfg(unix)]
-fn send_request_before(
-    socket: &Path,
-    request: &str,
-    deadline: Instant,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let remaining = deadline.saturating_duration_since(Instant::now());
-    if remaining.is_zero() {
-        return Err("control request deadline elapsed".into());
-    }
-    send_request_with_timeout(socket, request, Some(remaining))
-}
-
-#[cfg(unix)]
-fn send_request(socket: &Path, request: &str) -> Result<String, Box<dyn std::error::Error>> {
-    send_request_with_timeout(socket, request, None)
-}
-
-#[cfg(unix)]
-fn send_request_with_timeout(
-    socket: &Path,
-    request: &str,
-    timeout: Option<Duration>,
-) -> Result<String, Box<dyn std::error::Error>> {
-    use std::os::unix::net::UnixStream;
-
-    let mut stream = UnixStream::connect(socket)?;
-    stream.set_read_timeout(timeout)?;
-    stream.set_write_timeout(timeout)?;
-    stream.write_all(request.as_bytes())?;
-    stream.shutdown(std::net::Shutdown::Write)?;
-
-    let mut response = String::new();
-    stream.read_to_string(&mut response)?;
-    match parse_response(&response) {
-        Ok(message) => Ok(message.to_string()),
-        Err(message) => Err(message.into()),
-    }
-}
-
-fn parse_response(response: &str) -> Result<&str, String> {
-    let response = response.trim_end();
-    if let Some(message) = response.strip_prefix("ok ") {
-        Ok(message)
-    } else if let Some(message) = response.strip_prefix("error ") {
-        Err(message.to_string())
-    } else {
-        Err(format!(
-            "unexpected response from engine-client: {response:?}"
-        ))
-    }
+) -> Result<String, ControlClientError> {
+    client.request_before("status\n", deadline)
 }
 
 fn format_ui_state(state: &UiState) -> String {
+    let actions = if state.actions.is_empty() {
+        "none".into()
+    } else {
+        state
+            .actions
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    };
     let mut output = format!(
-        "schema_version={}\nrevision={}\nscreen={}\nactive_scenario={}\nselected_scenario={}\nselected_control={}\nscenario_revision={}\npaused={}\nbenchmark_active={}\nerror={}\ncontrols={}",
+        "schema_version={}\nrevision={}\nscreen={}\nactive_scenario={}\nselected_scenario={}\nselected_control={}\nscenario_revision={}\npaused={}\nbenchmark_active={}\nerror={}\nactions={}\ncontrols={}",
         state.schema_version,
         state.revision,
         state.screen,
@@ -240,6 +408,7 @@ fn format_ui_state(state: &UiState) -> String {
         state.paused,
         state.benchmark_active,
         state.error.as_deref().unwrap_or("none"),
+        actions,
         state.controls.len(),
     );
     for control in &state.controls {
@@ -295,26 +464,6 @@ fn format_duration(duration: Duration) -> String {
     }
 }
 
-#[cfg(not(unix))]
-fn request_screenshot(_socket: &Path, _output: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    Err("spacewars-cli screenshot requires Unix domain sockets".into())
-}
-
-#[cfg(not(unix))]
-fn request_status(_socket: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    Err("spacewars-cli status requires Unix domain sockets".into())
-}
-
-#[cfg(not(unix))]
-fn request_ui_state(_socket: &Path, _json: bool) -> Result<(), Box<dyn std::error::Error>> {
-    Err("spacewars-cli ui state requires Unix domain sockets".into())
-}
-
-#[cfg(not(unix))]
-fn request_benchmark(_socket: &Path, _timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
-    Err("spacewars-cli host benchmark requires Unix domain sockets".into())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -352,23 +501,76 @@ mod tests {
     }
 
     #[test]
-    fn accepts_multiline_success_response() {
-        assert_eq!(
-            parse_response("ok scenario=pizza\nfps=59.8\nframes_total=123\n").unwrap(),
-            "scenario=pizza\nfps=59.8\nframes_total=123"
-        );
+    fn parses_ui_press_with_preconditions() {
+        let args = Args::try_parse_from([
+            "spacewars-cli",
+            "ui",
+            "press",
+            "confirm",
+            "--expect-screen",
+            "launcher.main",
+            "--expect-revision",
+            "12",
+            "--json",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            args.command,
+            Command::Ui {
+                command: UiCommand::Press {
+                    action: UiActionArg::Confirm,
+                    expect_screen: Some(UiScreenArg::LauncherMain),
+                    expect_revision: Some(12),
+                    json: true,
+                }
+            }
+        ));
     }
 
     #[test]
-    fn reports_engine_and_protocol_errors() {
-        assert_eq!(
-            parse_response("error screenshot failed\n").unwrap_err(),
-            "screenshot failed"
-        );
-        assert_eq!(
-            parse_response("").unwrap_err(),
-            "unexpected response from engine-client: \"\""
-        );
+    fn press_help_lists_all_actions() {
+        let error = Args::try_parse_from(["spacewars-cli", "ui", "press", "unknown"])
+            .unwrap_err()
+            .to_string();
+
+        for action in UiAction::ALL {
+            assert!(
+                error.contains(action.as_str()),
+                "missing {action} in {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_combined_ui_wait_predicate() {
+        let args = Args::try_parse_from([
+            "spacewars-cli",
+            "ui",
+            "wait",
+            "--screen",
+            "gameplay",
+            "--scenario",
+            "pizza",
+            "--revision-after",
+            "8",
+            "--timeout",
+            "750ms",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            args.command,
+            Command::Ui {
+                command: UiCommand::Wait {
+                    screen: Some(UiScreenArg::Gameplay),
+                    scenario: Some(scenario),
+                    revision_after: Some(8),
+                    timeout,
+                    json: false,
+                }
+            } if scenario == "pizza" && timeout == Duration::from_millis(750)
+        ));
     }
 
     #[test]
@@ -376,7 +578,7 @@ mod tests {
         let state = UiState {
             schema_version: UI_STATE_SCHEMA_VERSION,
             revision: 8,
-            screen: spacewars_control::UiScreen::PauseMain,
+            screen: UiScreen::PauseMain,
             active_scenario: Some("pizza".into()),
             selected_scenario: "pizza".into(),
             selected_control: Some("pause.resume".into()),
@@ -384,6 +586,7 @@ mod tests {
                 UiControl::new("pause.resume", "Resume", true),
                 UiControl::new("pause.restart", "Restart Round", true),
             ],
+            actions: UiAction::ALL.to_vec(),
             scenario_revision: Some(3),
             paused: true,
             benchmark_active: false,
@@ -392,7 +595,7 @@ mod tests {
 
         assert_eq!(
             format_ui_state(&state),
-            "schema_version=1\nrevision=8\nscreen=pause.main\nactive_scenario=pizza\nselected_scenario=pizza\nselected_control=pause.resume\nscenario_revision=3\npaused=true\nbenchmark_active=false\nerror=Paused by controller\ncontrols=2\ncontrol=pause.resume label=\"Resume\" enabled=true\ncontrol=pause.restart label=\"Restart Round\" enabled=true"
+            "schema_version=1\nrevision=8\nscreen=pause.main\nactive_scenario=pizza\nselected_scenario=pizza\nselected_control=pause.resume\nscenario_revision=3\npaused=true\nbenchmark_active=false\nerror=Paused by controller\nactions=up,down,left,right,confirm,back,start,controls\ncontrols=2\ncontrol=pause.resume label=\"Resume\" enabled=true\ncontrol=pause.restart label=\"Restart Round\" enabled=true"
         );
     }
 
@@ -402,5 +605,18 @@ mod tests {
         assert_eq!(parse_timeout("750ms").unwrap(), Duration::from_millis(750));
         assert!(parse_timeout("0s").is_err());
         assert!(parse_timeout("3").is_err());
+    }
+
+    #[test]
+    fn empty_wait_predicate_is_rejected_before_polling() {
+        let error = request_ui_wait(
+            &ControlClient::new(Path::new("/unused")),
+            UiStatePredicate::default(),
+            Duration::from_secs(1),
+            false,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("requires --screen"));
     }
 }

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -9,8 +9,9 @@ use engine_common::DEFAULT_CONTROL_SOCKET;
 #[cfg(test)]
 use spacewars_control::UI_STATE_SCHEMA_VERSION;
 use spacewars_control::{
-    ControlClient, ControlClientError, ControlFailure, UiAction, UiActivateRequest, UiControl,
-    UiPressRequest, UiScreen, UiState, UiStatePredicate, parse_runtime_status,
+    ControlClient, ControlClientError, ControlFailure, HostPauseRequest, UiAction,
+    UiActivateRequest, UiControl, UiPressRequest, UiScreen, UiState, UiStatePredicate,
+    parse_runtime_status,
 };
 
 #[derive(Debug, Parser)]
@@ -184,6 +185,21 @@ impl From<UiScreenArg> for UiScreen {
 
 #[derive(Debug, Subcommand)]
 enum HostCommand {
+    /// Pause active gameplay and wait for the pause menu.
+    Pause {
+        /// Reject the request unless this exact UI revision is current.
+        #[arg(long)]
+        expect_revision: Option<u64>,
+
+        /// Maximum time for the pause menu to become visible.
+        #[arg(long, default_value = "3s", value_parser = parse_timeout)]
+        timeout: Duration,
+
+        /// Emit success or structured control failures as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Start a new benchmark instance and wait until the host confirms it.
     Benchmark {
         /// Maximum time to wait for a new benchmark instance.
@@ -281,6 +297,15 @@ fn run() -> Result<(), CliError> {
         )
         .map_err(|error| control_error(error, json)),
         Command::Host {
+            command:
+                HostCommand::Pause {
+                    expect_revision,
+                    timeout,
+                    json,
+                },
+        } => request_host_pause(&client, expect_revision, timeout, json)
+            .map_err(|error| control_error(error, json)),
+        Command::Host {
             command: HostCommand::Benchmark { timeout },
         } => request_benchmark(&client, timeout).map_err(human_error),
     }
@@ -363,6 +388,33 @@ fn request_ui_wait(
         ))));
     }
     print_ui_state(&client.wait_for_ui_state(&predicate, timeout)?, json)
+}
+
+fn request_host_pause(
+    client: &ControlClient,
+    expected_revision: Option<u64>,
+    timeout: Duration,
+    json: bool,
+) -> Result<(), ControlClientError> {
+    let deadline = Instant::now().checked_add(timeout).ok_or_else(|| {
+        ControlClientError::Failure(Box::new(ControlFailure::new(
+            spacewars_control::ControlFailureCode::Timeout,
+            "host pause timeout is too large",
+            None,
+        )))
+    })?;
+    let observed = client.ui_state_before(deadline)?;
+    let mut request = HostPauseRequest::new();
+    request.expected_screen = Some(UiScreen::Gameplay);
+    request.expected_revision = Some(expected_revision.unwrap_or(observed.revision));
+    let accepted = client.host_pause_before(&request, deadline)?;
+    let predicate = UiStatePredicate {
+        screen: Some(UiScreen::PauseMain),
+        scenario: accepted.active_scenario.clone(),
+        revision_after: Some(accepted.revision),
+    };
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    print_ui_state(&client.wait_for_ui_state(&predicate, remaining)?, json)
 }
 
 fn print_ui_state(state: &UiState, json: bool) -> Result<(), ControlClientError> {
@@ -533,6 +585,32 @@ mod tests {
             panic!("expected host benchmark command");
         };
         assert_eq!(timeout, Duration::from_secs(3));
+    }
+
+    #[test]
+    fn parses_host_pause_subcommand() {
+        let args = Args::try_parse_from([
+            "spacewars-cli",
+            "host",
+            "pause",
+            "--expect-revision",
+            "12",
+            "--timeout",
+            "750ms",
+            "--json",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            args.command,
+            Command::Host {
+                command: HostCommand::Pause {
+                    expect_revision: Some(12),
+                    timeout,
+                    json: true,
+                }
+            } if timeout == Duration::from_millis(750)
+        ));
     }
 
     #[test]

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 use engine_common::DEFAULT_CONTROL_SOCKET;
 #[cfg(test)]
 use spacewars_control::UI_STATE_SCHEMA_VERSION;
-use spacewars_control::{UI_STATE_COMMAND, UiState, parse_runtime_status};
+use spacewars_control::{UI_STATE_COMMAND, UiControl, UiState, parse_runtime_status};
 
 #[derive(Debug, Parser)]
 #[command(name = "spacewars-cli", about = "Space-Wars runtime control helper")]
@@ -228,16 +228,35 @@ fn parse_response(response: &str) -> Result<&str, String> {
 }
 
 fn format_ui_state(state: &UiState) -> String {
-    format!(
-        "schema_version={}\nrevision={}\nscreen={}\nactive_scenario={}\nselected_scenario={}\nscenario_revision={}\npaused={}\nbenchmark_active={}",
+    let mut output = format!(
+        "schema_version={}\nrevision={}\nscreen={}\nactive_scenario={}\nselected_scenario={}\nselected_control={}\nscenario_revision={}\npaused={}\nbenchmark_active={}\nerror={}\ncontrols={}",
         state.schema_version,
         state.revision,
         state.screen,
         state.active_scenario.as_deref().unwrap_or("none"),
         state.selected_scenario,
+        state.selected_control.as_deref().unwrap_or("none"),
         format_scenario_revision(state.scenario_revision),
         state.paused,
         state.benchmark_active,
+        state.error.as_deref().unwrap_or("none"),
+        state.controls.len(),
+    );
+    for control in &state.controls {
+        output.push_str(&format_control(control));
+    }
+    output
+}
+
+fn format_control(control: &UiControl) -> String {
+    let value = control
+        .value
+        .as_deref()
+        .map(|value| format!(" value={value:?}"))
+        .unwrap_or_default();
+    format!(
+        "\ncontrol={} label={:?} enabled={}{}",
+        control.id, control.label, control.enabled, value
     )
 }
 
@@ -360,14 +379,20 @@ mod tests {
             screen: spacewars_control::UiScreen::PauseMain,
             active_scenario: Some("pizza".into()),
             selected_scenario: "pizza".into(),
+            selected_control: Some("pause.resume".into()),
+            controls: vec![
+                UiControl::new("pause.resume", "Resume", true),
+                UiControl::new("pause.restart", "Restart Round", true),
+            ],
             scenario_revision: Some(3),
             paused: true,
             benchmark_active: false,
+            error: Some("Paused by controller".into()),
         };
 
         assert_eq!(
             format_ui_state(&state),
-            "schema_version=1\nrevision=8\nscreen=pause.main\nactive_scenario=pizza\nselected_scenario=pizza\nscenario_revision=3\npaused=true\nbenchmark_active=false"
+            "schema_version=1\nrevision=8\nscreen=pause.main\nactive_scenario=pizza\nselected_scenario=pizza\nselected_control=pause.resume\nscenario_revision=3\npaused=true\nbenchmark_active=false\nerror=Paused by controller\ncontrols=2\ncontrol=pause.resume label=\"Resume\" enabled=true\ncontrol=pause.restart label=\"Restart Round\" enabled=true"
         );
     }
 

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -9,8 +9,8 @@ use engine_common::DEFAULT_CONTROL_SOCKET;
 #[cfg(test)]
 use spacewars_control::UI_STATE_SCHEMA_VERSION;
 use spacewars_control::{
-    ControlClient, ControlClientError, ControlFailure, UiAction, UiControl, UiPressRequest,
-    UiScreen, UiState, UiStatePredicate, parse_runtime_status,
+    ControlClient, ControlClientError, ControlFailure, UiAction, UiActivateRequest, UiControl,
+    UiPressRequest, UiScreen, UiState, UiStatePredicate, parse_runtime_status,
 };
 
 #[derive(Debug, Parser)]
@@ -68,6 +68,24 @@ enum UiCommand {
         expect_screen: Option<UiScreenArg>,
 
         /// Reject the action unless this exact UI revision is current.
+        #[arg(long)]
+        expect_revision: Option<u64>,
+
+        /// Emit success or structured control failures as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Activate one visible control by its stable ID.
+    Activate {
+        /// Stable control ID reported by `ui state`.
+        control_id: String,
+
+        /// Reject the activation unless this screen is currently visible.
+        #[arg(long, value_enum)]
+        expect_screen: Option<UiScreenArg>,
+
+        /// Reject the activation unless this exact UI revision is current.
         #[arg(long)]
         expect_revision: Option<u64>,
 
@@ -228,6 +246,22 @@ fn run() -> Result<(), CliError> {
         .map_err(|error| control_error(error, json)),
         Command::Ui {
             command:
+                UiCommand::Activate {
+                    control_id,
+                    expect_screen,
+                    expect_revision,
+                    json,
+                },
+        } => request_ui_activate(
+            &client,
+            control_id,
+            expect_screen.map(Into::into),
+            expect_revision,
+            json,
+        )
+        .map_err(|error| control_error(error, json)),
+        Command::Ui {
+            command:
                 UiCommand::Wait {
                     screen,
                     scenario,
@@ -300,6 +334,19 @@ fn request_ui_press(
     request.expected_screen = expected_screen;
     request.expected_revision = expected_revision;
     print_ui_state(&client.ui_press(&request)?, json)
+}
+
+fn request_ui_activate(
+    client: &ControlClient,
+    control_id: String,
+    expected_screen: Option<UiScreen>,
+    expected_revision: Option<u64>,
+    json: bool,
+) -> Result<(), ControlClientError> {
+    let mut request = UiActivateRequest::new(control_id);
+    request.expected_screen = expected_screen;
+    request.expected_revision = expected_revision;
+    print_ui_state(&client.ui_activate(&request)?, json)
 }
 
 fn request_ui_wait(
@@ -525,6 +572,34 @@ mod tests {
                     json: true,
                 }
             }
+        ));
+    }
+
+    #[test]
+    fn parses_ui_activate_with_preconditions() {
+        let args = Args::try_parse_from([
+            "spacewars-cli",
+            "ui",
+            "activate",
+            "launcher.settings",
+            "--expect-screen",
+            "launcher.main",
+            "--expect-revision",
+            "12",
+            "--json",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            args.command,
+            Command::Ui {
+                command: UiCommand::Activate {
+                    control_id,
+                    expect_screen: Some(UiScreenArg::LauncherMain),
+                    expect_revision: Some(12),
+                    json: true,
+                }
+            } if control_id == "launcher.settings"
         ));
     }
 

--- a/crates/spacewars-control/src/client.rs
+++ b/crates/spacewars-control/src/client.rs
@@ -1,0 +1,458 @@
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::{
+    ControlFailure, ControlFailureCode, ProtocolError, UI_PRESS_COMMAND, UI_STATE_COMMAND,
+    UiPressRequest, UiScreen, UiState,
+};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Client for the engine's local control socket.
+#[derive(Debug, Clone)]
+pub struct ControlClient {
+    socket_path: PathBuf,
+}
+
+impl ControlClient {
+    pub fn new(socket_path: impl Into<PathBuf>) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+        }
+    }
+
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    pub fn request(&self, request: &str) -> Result<String, ControlClientError> {
+        self.request_with_timeout(request, None)
+    }
+
+    pub fn request_before(
+        &self,
+        request: &str,
+        deadline: Instant,
+    ) -> Result<String, ControlClientError> {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(ControlClientError::DeadlineElapsed);
+        }
+        self.request_with_timeout(request, Some(remaining))
+    }
+
+    pub fn ui_state(&self) -> Result<UiState, ControlClientError> {
+        self.parse_ui_state(self.request(&format!("{UI_STATE_COMMAND}\n"))?)
+    }
+
+    pub fn ui_state_before(&self, deadline: Instant) -> Result<UiState, ControlClientError> {
+        self.parse_ui_state(self.request_before(&format!("{UI_STATE_COMMAND}\n"), deadline)?)
+    }
+
+    pub fn ui_press(&self, request: &UiPressRequest) -> Result<UiState, ControlClientError> {
+        let payload = request.to_json()?;
+        self.parse_ui_state(self.request(&format!("{UI_PRESS_COMMAND}\n{payload}\n"))?)
+    }
+
+    pub fn wait_for_ui_state(
+        &self,
+        predicate: &UiStatePredicate,
+        timeout: Duration,
+    ) -> Result<UiState, ControlClientError> {
+        let Some(deadline) = Instant::now().checked_add(timeout) else {
+            return Err(ControlClientError::Failure(Box::new(ControlFailure::new(
+                ControlFailureCode::Timeout,
+                "UI wait timeout is too large",
+                None,
+            ))));
+        };
+        let mut last_state = None;
+
+        loop {
+            match self.ui_state_before(deadline) {
+                Ok(state) if predicate.matches(&state) => return Ok(state),
+                Ok(state) => last_state = Some(state),
+                Err(ControlClientError::DeadlineElapsed) => {
+                    return Err(wait_timeout(predicate, timeout, last_state));
+                }
+                Err(ControlClientError::Io(ref error)) if is_deadline_io_error(error) => {
+                    return Err(wait_timeout(predicate, timeout, last_state));
+                }
+                Err(error) => return Err(error),
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(wait_timeout(predicate, timeout, last_state));
+            }
+            std::thread::sleep(POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
+        }
+    }
+
+    fn parse_ui_state(&self, json: String) -> Result<UiState, ControlClientError> {
+        Ok(UiState::from_json(&json)?)
+    }
+
+    #[cfg(unix)]
+    fn request_with_timeout(
+        &self,
+        request: &str,
+        timeout: Option<Duration>,
+    ) -> Result<String, ControlClientError> {
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixStream;
+
+        let mut stream = UnixStream::connect(&self.socket_path)?;
+        stream.set_read_timeout(timeout)?;
+        stream.set_write_timeout(timeout)?;
+        stream.write_all(request.as_bytes())?;
+        stream.shutdown(std::net::Shutdown::Write)?;
+
+        let mut response = String::new();
+        stream.read_to_string(&mut response)?;
+        parse_response(&response)
+    }
+
+    #[cfg(not(unix))]
+    fn request_with_timeout(
+        &self,
+        _request: &str,
+        _timeout: Option<Duration>,
+    ) -> Result<String, ControlClientError> {
+        Err(ControlClientError::UnsupportedPlatform)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UiStatePredicate {
+    pub screen: Option<UiScreen>,
+    pub scenario: Option<String>,
+    pub revision_after: Option<u64>,
+}
+
+impl UiStatePredicate {
+    pub fn is_empty(&self) -> bool {
+        self.screen.is_none() && self.scenario.is_none() && self.revision_after.is_none()
+    }
+
+    pub fn matches(&self, state: &UiState) -> bool {
+        self.screen.is_none_or(|screen| state.screen == screen)
+            && self.scenario.as_deref().is_none_or(|scenario| {
+                state
+                    .active_scenario
+                    .as_deref()
+                    .unwrap_or(&state.selected_scenario)
+                    == scenario
+            })
+            && self
+                .revision_after
+                .is_none_or(|revision| state.revision > revision)
+    }
+
+    fn description(&self) -> String {
+        let mut conditions = Vec::new();
+        if let Some(screen) = self.screen {
+            conditions.push(format!("screen={screen}"));
+        }
+        if let Some(scenario) = &self.scenario {
+            conditions.push(format!("scenario={scenario}"));
+        }
+        if let Some(revision) = self.revision_after {
+            conditions.push(format!("revision>{revision}"));
+        }
+        if conditions.is_empty() {
+            "any UI state".into()
+        } else {
+            conditions.join(", ")
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ControlClientError {
+    Io(io::Error),
+    Protocol(ProtocolError),
+    Failure(Box<ControlFailure>),
+    ServerMessage(String),
+    UnexpectedResponse(String),
+    DeadlineElapsed,
+    UnsupportedPlatform,
+}
+
+impl ControlClientError {
+    pub fn failure(&self) -> Option<&ControlFailure> {
+        match self {
+            Self::Failure(failure) => Some(failure),
+            _ => None,
+        }
+    }
+
+    pub fn into_failure(self) -> Option<ControlFailure> {
+        match self {
+            Self::Failure(failure) => Some(*failure),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ControlClientError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "control socket I/O failed: {error}"),
+            Self::Protocol(error) => error.fmt(formatter),
+            Self::Failure(failure) => {
+                write!(formatter, "{}: {}", failure.code, failure.message)?;
+                if let Some(state) = &failure.current_state {
+                    write!(
+                        formatter,
+                        "; current screen={} revision={}",
+                        state.screen, state.revision
+                    )?;
+                }
+                Ok(())
+            }
+            Self::ServerMessage(message) => formatter.write_str(message),
+            Self::UnexpectedResponse(response) => {
+                write!(
+                    formatter,
+                    "unexpected response from engine-client: {response:?}"
+                )
+            }
+            Self::DeadlineElapsed => formatter.write_str("control request deadline elapsed"),
+            Self::UnsupportedPlatform => {
+                formatter.write_str("Space-Wars control requires Unix domain sockets")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ControlClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Protocol(error) => Some(error),
+            Self::Failure(_)
+            | Self::ServerMessage(_)
+            | Self::UnexpectedResponse(_)
+            | Self::DeadlineElapsed
+            | Self::UnsupportedPlatform => None,
+        }
+    }
+}
+
+impl From<io::Error> for ControlClientError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<ProtocolError> for ControlClientError {
+    fn from(error: ProtocolError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+fn parse_response(response: &str) -> Result<String, ControlClientError> {
+    let response = response.trim_end();
+    if let Some(message) = response.strip_prefix("ok ") {
+        Ok(message.into())
+    } else if let Some(message) = response.strip_prefix("error ") {
+        match ControlFailure::from_json(message) {
+            Ok(failure) => Err(ControlClientError::Failure(Box::new(failure))),
+            Err(_) => Err(ControlClientError::ServerMessage(message.into())),
+        }
+    } else {
+        Err(ControlClientError::UnexpectedResponse(response.into()))
+    }
+}
+
+fn is_deadline_io_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+    )
+}
+
+fn wait_timeout(
+    predicate: &UiStatePredicate,
+    timeout: Duration,
+    current_state: Option<UiState>,
+) -> ControlClientError {
+    ControlClientError::Failure(Box::new(ControlFailure::new(
+        ControlFailureCode::Timeout,
+        format!(
+            "timed out after {} waiting for {}",
+            format_duration(timeout),
+            predicate.description()
+        ),
+        current_state,
+    )))
+}
+
+fn format_duration(duration: Duration) -> String {
+    if duration.subsec_millis() == 0 {
+        format!("{}s", duration.as_secs())
+    } else {
+        format!("{}ms", duration.as_millis())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{UI_STATE_SCHEMA_VERSION, UiAction, UiControl};
+    #[cfg(unix)]
+    use std::io::{Read, Write};
+    #[cfg(unix)]
+    use std::os::unix::net::UnixListener;
+    #[cfg(unix)]
+    use std::thread;
+    #[cfg(unix)]
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn state(screen: UiScreen, revision: u64) -> UiState {
+        UiState {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            revision,
+            screen,
+            active_scenario: None,
+            selected_scenario: "spacewars".into(),
+            selected_control: Some("launcher.start".into()),
+            controls: vec![UiControl::new("launcher.start", "Start Game", true)],
+            actions: vec![UiAction::Confirm, UiAction::Start],
+            scenario_revision: None,
+            paused: false,
+            benchmark_active: false,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn parses_success_legacy_error_and_structured_error() {
+        assert_eq!(
+            parse_response("ok scenario=pizza\nfps=59.8\n").unwrap(),
+            "scenario=pizza\nfps=59.8"
+        );
+        assert!(matches!(
+            parse_response("error screenshot failed\n"),
+            Err(ControlClientError::ServerMessage(message)) if message == "screenshot failed"
+        ));
+
+        let failure = ControlFailure::new(
+            ControlFailureCode::WrongScreen,
+            "expected launcher.main",
+            Some(state(UiScreen::PauseMain, 8)),
+        );
+        let response = format!("error {}\n", failure.to_json().unwrap());
+        assert!(matches!(
+            parse_response(&response),
+            Err(ControlClientError::Failure(parsed)) if *parsed == failure
+        ));
+        assert!(matches!(
+            parse_response(""),
+            Err(ControlClientError::UnexpectedResponse(response)) if response.is_empty()
+        ));
+    }
+
+    #[test]
+    fn state_predicates_combine_screen_scenario_and_revision() {
+        let predicate = UiStatePredicate {
+            screen: Some(UiScreen::LauncherMain),
+            scenario: Some("spacewars".into()),
+            revision_after: Some(7),
+        };
+
+        assert!(predicate.matches(&state(UiScreen::LauncherMain, 8)));
+        assert!(!predicate.matches(&state(UiScreen::PauseMain, 8)));
+        assert!(!predicate.matches(&state(UiScreen::LauncherMain, 7)));
+
+        let mut active = state(UiScreen::Gameplay, 9);
+        active.active_scenario = Some("pizza".into());
+        assert!(
+            UiStatePredicate {
+                scenario: Some("pizza".into()),
+                ..Default::default()
+            }
+            .matches(&active)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wait_polls_until_a_later_state_matches() {
+        let socket = TestSocket::new("wait-success");
+        let listener = UnixListener::bind(&socket.0).unwrap();
+        let first = state(UiScreen::LauncherMain, 1);
+        let second = state(UiScreen::LauncherSettings, 2);
+        let responses = [first, second.clone()];
+        let server = thread::spawn(move || {
+            for state in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut request = String::new();
+                stream.read_to_string(&mut request).unwrap();
+                assert_eq!(request, "ui state\n");
+                writeln!(stream, "ok {}", state.to_json().unwrap()).unwrap();
+            }
+        });
+
+        let result = ControlClient::new(&socket.0)
+            .wait_for_ui_state(
+                &UiStatePredicate {
+                    screen: Some(UiScreen::LauncherSettings),
+                    revision_after: Some(1),
+                    ..Default::default()
+                },
+                Duration::from_secs(1),
+            )
+            .unwrap();
+
+        assert_eq!(result, second);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn wait_timeout_is_structured_and_retains_the_last_state() {
+        let last_state = state(UiScreen::LauncherMain, 3);
+        let error = wait_timeout(
+            &UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                revision_after: Some(3),
+                ..Default::default()
+            },
+            Duration::from_millis(250),
+            Some(last_state.clone()),
+        );
+        let failure = error.failure().unwrap();
+
+        assert_eq!(failure.code, ControlFailureCode::Timeout);
+        assert!(failure.message.contains("screen=gameplay"));
+        assert!(failure.message.contains("revision>3"));
+        assert_eq!(failure.current_state, Some(last_state));
+    }
+
+    #[cfg(unix)]
+    struct TestSocket(PathBuf);
+
+    #[cfg(unix)]
+    impl TestSocket {
+        fn new(label: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            Self(std::env::temp_dir().join(format!(
+                "spacewars-control-{}-{nonce}-{label}.sock",
+                std::process::id()
+            )))
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for TestSocket {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+}

--- a/crates/spacewars-control/src/client.rs
+++ b/crates/spacewars-control/src/client.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::{
-    ControlFailure, ControlFailureCode, ProtocolError, UI_PRESS_COMMAND, UI_STATE_COMMAND,
-    UiPressRequest, UiScreen, UiState,
+    ControlFailure, ControlFailureCode, ProtocolError, UI_ACTIVATE_COMMAND, UI_PRESS_COMMAND,
+    UI_STATE_COMMAND, UiActivateRequest, UiPressRequest, UiScreen, UiState,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -54,6 +54,33 @@ impl ControlClient {
     pub fn ui_press(&self, request: &UiPressRequest) -> Result<UiState, ControlClientError> {
         let payload = request.to_json()?;
         self.parse_ui_state(self.request(&format!("{UI_PRESS_COMMAND}\n{payload}\n"))?)
+    }
+
+    pub fn ui_press_before(
+        &self,
+        request: &UiPressRequest,
+        deadline: Instant,
+    ) -> Result<UiState, ControlClientError> {
+        let payload = request.to_json()?;
+        self.parse_ui_state(
+            self.request_before(&format!("{UI_PRESS_COMMAND}\n{payload}\n"), deadline)?,
+        )
+    }
+
+    pub fn ui_activate(&self, request: &UiActivateRequest) -> Result<UiState, ControlClientError> {
+        let payload = request.to_json()?;
+        self.parse_ui_state(self.request(&format!("{UI_ACTIVATE_COMMAND}\n{payload}\n"))?)
+    }
+
+    pub fn ui_activate_before(
+        &self,
+        request: &UiActivateRequest,
+        deadline: Instant,
+    ) -> Result<UiState, ControlClientError> {
+        let payload = request.to_json()?;
+        self.parse_ui_state(
+            self.request_before(&format!("{UI_ACTIVATE_COMMAND}\n{payload}\n"), deadline)?,
+        )
     }
 
     pub fn wait_for_ui_state(

--- a/crates/spacewars-control/src/client.rs
+++ b/crates/spacewars-control/src/client.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::{
-    ControlFailure, ControlFailureCode, ProtocolError, UI_ACTIVATE_COMMAND, UI_PRESS_COMMAND,
-    UI_STATE_COMMAND, UiActivateRequest, UiPressRequest, UiScreen, UiState,
+    ControlFailure, ControlFailureCode, HOST_PAUSE_COMMAND, HostPauseRequest, ProtocolError,
+    UI_ACTIVATE_COMMAND, UI_PRESS_COMMAND, UI_STATE_COMMAND, UiActivateRequest, UiPressRequest,
+    UiScreen, UiState,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -80,6 +81,22 @@ impl ControlClient {
         let payload = request.to_json()?;
         self.parse_ui_state(
             self.request_before(&format!("{UI_ACTIVATE_COMMAND}\n{payload}\n"), deadline)?,
+        )
+    }
+
+    pub fn host_pause(&self, request: &HostPauseRequest) -> Result<UiState, ControlClientError> {
+        let payload = request.to_json()?;
+        self.parse_ui_state(self.request(&format!("{HOST_PAUSE_COMMAND}\n{payload}\n"))?)
+    }
+
+    pub fn host_pause_before(
+        &self,
+        request: &HostPauseRequest,
+        deadline: Instant,
+    ) -> Result<UiState, ControlClientError> {
+        let payload = request.to_json()?;
+        self.parse_ui_state(
+            self.request_before(&format!("{HOST_PAUSE_COMMAND}\n{payload}\n"), deadline)?,
         )
     }
 

--- a/crates/spacewars-control/src/lib.rs
+++ b/crates/spacewars-control/src/lib.rs
@@ -11,6 +11,7 @@ pub use client::{ControlClient, ControlClientError, UiStatePredicate};
 pub const UI_STATE_COMMAND: &str = "ui state";
 pub const UI_PRESS_COMMAND: &str = "ui press";
 pub const UI_ACTIVATE_COMMAND: &str = "ui activate";
+pub const HOST_PAUSE_COMMAND: &str = "host pause";
 pub const UI_STATE_SCHEMA_VERSION: u32 = 1;
 pub const NO_ACTIVE_SCENARIO_DIAGNOSTICS: &str = "No active scenario diagnostics.";
 
@@ -243,6 +244,42 @@ impl UiActivateRequest {
     pub fn to_json(&self) -> Result<String, ProtocolError> {
         validate_schema_version(self.schema_version)?;
         Ok(serde_json::to_string(self)?)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostPauseRequest {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub expected_screen: Option<UiScreen>,
+    #[serde(default)]
+    pub expected_revision: Option<u64>,
+}
+
+impl HostPauseRequest {
+    pub fn new() -> Self {
+        Self {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            expected_screen: None,
+            expected_revision: None,
+        }
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, ProtocolError> {
+        let request: Self = serde_json::from_str(json)?;
+        validate_schema_version(request.schema_version)?;
+        Ok(request)
+    }
+
+    pub fn to_json(&self) -> Result<String, ProtocolError> {
+        validate_schema_version(self.schema_version)?;
+        Ok(serde_json::to_string(self)?)
+    }
+}
+
+impl Default for HostPauseRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -601,6 +638,14 @@ mod tests {
         request.expected_revision = Some(5);
         assert_eq!(
             UiActivateRequest::from_json(&request.to_json().unwrap()).unwrap(),
+            request
+        );
+
+        let mut request = HostPauseRequest::new();
+        request.expected_screen = Some(UiScreen::Gameplay);
+        request.expected_revision = Some(6);
+        assert_eq!(
+            HostPauseRequest::from_json(&request.to_json().unwrap()).unwrap(),
             request
         );
 

--- a/crates/spacewars-control/src/lib.rs
+++ b/crates/spacewars-control/src/lib.rs
@@ -10,6 +10,7 @@ pub use client::{ControlClient, ControlClientError, UiStatePredicate};
 
 pub const UI_STATE_COMMAND: &str = "ui state";
 pub const UI_PRESS_COMMAND: &str = "ui press";
+pub const UI_ACTIVATE_COMMAND: &str = "ui activate";
 pub const UI_STATE_SCHEMA_VERSION: u32 = 1;
 pub const NO_ACTIVE_SCENARIO_DIAGNOSTICS: &str = "No active scenario diagnostics.";
 
@@ -213,6 +214,38 @@ impl UiPressRequest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiActivateRequest {
+    pub schema_version: u32,
+    pub control_id: String,
+    #[serde(default)]
+    pub expected_screen: Option<UiScreen>,
+    #[serde(default)]
+    pub expected_revision: Option<u64>,
+}
+
+impl UiActivateRequest {
+    pub fn new(control_id: impl Into<String>) -> Self {
+        Self {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            control_id: control_id.into(),
+            expected_screen: None,
+            expected_revision: None,
+        }
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, ProtocolError> {
+        let request: Self = serde_json::from_str(json)?;
+        validate_schema_version(request.schema_version)?;
+        Ok(request)
+    }
+
+    pub fn to_json(&self) -> Result<String, ProtocolError> {
+        validate_schema_version(self.schema_version)?;
+        Ok(serde_json::to_string(self)?)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ControlFailureCode {
@@ -220,6 +253,8 @@ pub enum ControlFailureCode {
     WrongScreen,
     StaleRevision,
     ActionUnavailable,
+    ControlUnavailable,
+    ControlDisabled,
     Timeout,
 }
 
@@ -230,6 +265,8 @@ impl fmt::Display for ControlFailureCode {
             Self::WrongScreen => "wrong-screen",
             Self::StaleRevision => "stale-revision",
             Self::ActionUnavailable => "action-unavailable",
+            Self::ControlUnavailable => "control-unavailable",
+            Self::ControlDisabled => "control-disabled",
             Self::Timeout => "timeout",
         };
         formatter.write_str(label)
@@ -531,12 +568,39 @@ mod tests {
     }
 
     #[test]
-    fn press_requests_and_structured_failures_round_trip() {
+    fn failure_code_names_are_stable() {
+        for (code, name) in [
+            (ControlFailureCode::InvalidRequest, "invalid-request"),
+            (ControlFailureCode::WrongScreen, "wrong-screen"),
+            (ControlFailureCode::StaleRevision, "stale-revision"),
+            (ControlFailureCode::ActionUnavailable, "action-unavailable"),
+            (
+                ControlFailureCode::ControlUnavailable,
+                "control-unavailable",
+            ),
+            (ControlFailureCode::ControlDisabled, "control-disabled"),
+            (ControlFailureCode::Timeout, "timeout"),
+        ] {
+            assert_eq!(code.to_string(), name);
+            assert_eq!(serde_json::to_string(&code).unwrap(), format!("\"{name}\""));
+        }
+    }
+
+    #[test]
+    fn mutation_requests_and_structured_failures_round_trip() {
         let mut request = UiPressRequest::new(UiAction::Confirm);
         request.expected_screen = Some(UiScreen::LauncherMain);
         request.expected_revision = Some(4);
         assert_eq!(
             UiPressRequest::from_json(&request.to_json().unwrap()).unwrap(),
+            request
+        );
+
+        let mut request = UiActivateRequest::new("launcher.settings");
+        request.expected_screen = Some(UiScreen::LauncherMain);
+        request.expected_revision = Some(5);
+        assert_eq!(
+            UiActivateRequest::from_json(&request.to_json().unwrap()).unwrap(),
             request
         );
 

--- a/crates/spacewars-control/src/lib.rs
+++ b/crates/spacewars-control/src/lib.rs
@@ -60,15 +60,46 @@ impl fmt::Display for UiScreen {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiControl {
+    pub id: String,
+    pub label: String,
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+impl UiControl {
+    pub fn new(id: impl Into<String>, label: impl Into<String>, enabled: bool) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            enabled,
+            value: None,
+        }
+    }
+
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UiState {
     pub schema_version: u32,
     pub revision: u64,
     pub screen: UiScreen,
     pub active_scenario: Option<String>,
     pub selected_scenario: String,
+    #[serde(default)]
+    pub selected_control: Option<String>,
+    #[serde(default)]
+    pub controls: Vec<UiControl>,
     pub scenario_revision: Option<u64>,
     pub paused: bool,
     pub benchmark_active: bool,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 impl UiState {
@@ -219,9 +250,16 @@ mod tests {
             screen: UiScreen::LauncherMain,
             active_scenario: None,
             selected_scenario: "spacewars".into(),
+            selected_control: Some("launcher.scenario".into()),
+            controls: vec![
+                UiControl::new("launcher.scenario.previous", "‹", true).with_value("spacewars"),
+                UiControl::new("launcher.scenario.next", "›", true).with_value("spacewars"),
+                UiControl::new("launcher.start", "Start Game", true),
+            ],
             scenario_revision: None,
             paused: false,
             benchmark_active: false,
+            error: None,
         }
     }
 
@@ -268,6 +306,38 @@ mod tests {
             UiState::from_json(&serde_json::to_string(&unsupported).unwrap()),
             Err(ProtocolError::UnsupportedSchemaVersion { .. })
         ));
+    }
+
+    #[test]
+    fn ui_state_additions_accept_the_original_v1_payload() {
+        let original = r#"{
+            "schema_version": 1,
+            "revision": 2,
+            "screen": "gameplay",
+            "active_scenario": "pizza",
+            "selected_scenario": "pizza",
+            "scenario_revision": 7,
+            "paused": false,
+            "benchmark_active": false
+        }"#;
+
+        let state = UiState::from_json(original).unwrap();
+
+        assert_eq!(state.selected_control, None);
+        assert!(state.controls.is_empty());
+        assert_eq!(state.error, None);
+    }
+
+    #[test]
+    fn control_values_are_optional_in_json() {
+        let json = sample_state().to_json().unwrap();
+        let controls = serde_json::from_str::<serde_json::Value>(&json).unwrap()["controls"]
+            .as_array()
+            .unwrap()
+            .clone();
+
+        assert_eq!(controls[0]["value"], "spacewars");
+        assert!(controls[2].get("value").is_none());
     }
 
     #[test]

--- a/crates/spacewars-control/src/lib.rs
+++ b/crates/spacewars-control/src/lib.rs
@@ -4,7 +4,12 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+mod client;
+
+pub use client::{ControlClient, ControlClientError, UiStatePredicate};
+
 pub const UI_STATE_COMMAND: &str = "ui state";
+pub const UI_PRESS_COMMAND: &str = "ui press";
 pub const UI_STATE_SCHEMA_VERSION: u32 = 1;
 pub const NO_ACTIVE_SCENARIO_DIAGNOSTICS: &str = "No active scenario diagnostics.";
 
@@ -59,6 +64,78 @@ impl fmt::Display for UiScreen {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UiAction {
+    Up,
+    Down,
+    Left,
+    Right,
+    Confirm,
+    Back,
+    Start,
+    Controls,
+}
+
+impl UiAction {
+    pub const ALL: [Self; 8] = [
+        Self::Up,
+        Self::Down,
+        Self::Left,
+        Self::Right,
+        Self::Confirm,
+        Self::Back,
+        Self::Start,
+        Self::Controls,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Up => "up",
+            Self::Down => "down",
+            Self::Left => "left",
+            Self::Right => "right",
+            Self::Confirm => "confirm",
+            Self::Back => "back",
+            Self::Start => "start",
+            Self::Controls => "controls",
+        }
+    }
+
+    pub const fn code(self) -> i32 {
+        match self {
+            Self::Up => 0,
+            Self::Down => 1,
+            Self::Left => 2,
+            Self::Right => 3,
+            Self::Confirm => 4,
+            Self::Back => 5,
+            Self::Start => 6,
+            Self::Controls => 7,
+        }
+    }
+
+    pub const fn from_code(code: i32) -> Option<Self> {
+        match code {
+            0 => Some(Self::Up),
+            1 => Some(Self::Down),
+            2 => Some(Self::Left),
+            3 => Some(Self::Right),
+            4 => Some(Self::Confirm),
+            5 => Some(Self::Back),
+            6 => Some(Self::Start),
+            7 => Some(Self::Controls),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UiAction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UiControl {
     pub id: String,
@@ -95,11 +172,108 @@ pub struct UiState {
     pub selected_control: Option<String>,
     #[serde(default)]
     pub controls: Vec<UiControl>,
+    #[serde(default)]
+    pub actions: Vec<UiAction>,
     pub scenario_revision: Option<u64>,
     pub paused: bool,
     pub benchmark_active: bool,
     #[serde(default)]
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiPressRequest {
+    pub schema_version: u32,
+    pub action: UiAction,
+    #[serde(default)]
+    pub expected_screen: Option<UiScreen>,
+    #[serde(default)]
+    pub expected_revision: Option<u64>,
+}
+
+impl UiPressRequest {
+    pub fn new(action: UiAction) -> Self {
+        Self {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            action,
+            expected_screen: None,
+            expected_revision: None,
+        }
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, ProtocolError> {
+        let request: Self = serde_json::from_str(json)?;
+        validate_schema_version(request.schema_version)?;
+        Ok(request)
+    }
+
+    pub fn to_json(&self) -> Result<String, ProtocolError> {
+        validate_schema_version(self.schema_version)?;
+        Ok(serde_json::to_string(self)?)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ControlFailureCode {
+    InvalidRequest,
+    WrongScreen,
+    StaleRevision,
+    ActionUnavailable,
+    Timeout,
+}
+
+impl fmt::Display for ControlFailureCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::InvalidRequest => "invalid-request",
+            Self::WrongScreen => "wrong-screen",
+            Self::StaleRevision => "stale-revision",
+            Self::ActionUnavailable => "action-unavailable",
+            Self::Timeout => "timeout",
+        };
+        formatter.write_str(label)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlFailure {
+    pub schema_version: u32,
+    pub code: ControlFailureCode,
+    pub message: String,
+    #[serde(default)]
+    pub current_state: Option<UiState>,
+}
+
+impl ControlFailure {
+    pub fn new(
+        code: ControlFailureCode,
+        message: impl Into<String>,
+        current_state: Option<UiState>,
+    ) -> Self {
+        Self {
+            schema_version: UI_STATE_SCHEMA_VERSION,
+            code,
+            message: message.into(),
+            current_state,
+        }
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, ProtocolError> {
+        let failure: Self = serde_json::from_str(json)?;
+        validate_schema_version(failure.schema_version)?;
+        Ok(failure)
+    }
+
+    pub fn to_json(&self) -> Result<String, ProtocolError> {
+        validate_schema_version(self.schema_version)?;
+        Ok(serde_json::to_string(self)?)
+    }
+
+    pub fn to_pretty_json(&self) -> Result<String, ProtocolError> {
+        validate_schema_version(self.schema_version)?;
+        Ok(serde_json::to_string_pretty(self)?)
+    }
 }
 
 impl UiState {
@@ -120,14 +294,18 @@ impl UiState {
     }
 
     fn validate(&self) -> Result<(), ProtocolError> {
-        if self.schema_version != UI_STATE_SCHEMA_VERSION {
-            return Err(ProtocolError::UnsupportedSchemaVersion {
-                found: self.schema_version,
-                supported: UI_STATE_SCHEMA_VERSION,
-            });
-        }
-        Ok(())
+        validate_schema_version(self.schema_version)
     }
+}
+
+fn validate_schema_version(schema_version: u32) -> Result<(), ProtocolError> {
+    if schema_version != UI_STATE_SCHEMA_VERSION {
+        return Err(ProtocolError::UnsupportedSchemaVersion {
+            found: schema_version,
+            supported: UI_STATE_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -204,10 +382,10 @@ pub enum ProtocolError {
 impl fmt::Display for ProtocolError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Json(error) => write!(formatter, "invalid UI state JSON: {error}"),
+            Self::Json(error) => write!(formatter, "invalid control protocol JSON: {error}"),
             Self::UnsupportedSchemaVersion { found, supported } => write!(
                 formatter,
-                "unsupported UI state schema version {found}; this client supports version {supported}"
+                "unsupported control schema version {found}; this client supports version {supported}"
             ),
             Self::MissingRuntimeField(field) => {
                 write!(formatter, "runtime diagnostics are missing {field}")
@@ -255,6 +433,15 @@ mod tests {
                 UiControl::new("launcher.scenario.previous", "‹", true).with_value("spacewars"),
                 UiControl::new("launcher.scenario.next", "›", true).with_value("spacewars"),
                 UiControl::new("launcher.start", "Start Game", true),
+            ],
+            actions: vec![
+                UiAction::Up,
+                UiAction::Down,
+                UiAction::Left,
+                UiAction::Right,
+                UiAction::Confirm,
+                UiAction::Start,
+                UiAction::Controls,
             ],
             scenario_revision: None,
             paused: false,
@@ -325,7 +512,43 @@ mod tests {
 
         assert_eq!(state.selected_control, None);
         assert!(state.controls.is_empty());
+        assert!(state.actions.is_empty());
         assert_eq!(state.error, None);
+    }
+
+    #[test]
+    fn action_names_codes_and_json_are_stable() {
+        for (code, action) in UiAction::ALL.into_iter().enumerate() {
+            assert_eq!(UiAction::from_code(code as i32), Some(action));
+            assert_eq!(action.code(), code as i32);
+            assert_eq!(action.to_string(), action.as_str());
+            assert_eq!(
+                serde_json::to_string(&action).unwrap(),
+                format!("\"{}\"", action.as_str())
+            );
+        }
+        assert_eq!(UiAction::from_code(99), None);
+    }
+
+    #[test]
+    fn press_requests_and_structured_failures_round_trip() {
+        let mut request = UiPressRequest::new(UiAction::Confirm);
+        request.expected_screen = Some(UiScreen::LauncherMain);
+        request.expected_revision = Some(4);
+        assert_eq!(
+            UiPressRequest::from_json(&request.to_json().unwrap()).unwrap(),
+            request
+        );
+
+        let failure = ControlFailure::new(
+            ControlFailureCode::StaleRevision,
+            "expected revision 3 but current revision is 4",
+            Some(sample_state()),
+        );
+        assert_eq!(
+            ControlFailure::from_json(&failure.to_json().unwrap()).unwrap(),
+            failure
+        );
     }
 
     #[test]

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -19,11 +19,12 @@ The initial workflows verify:
 
 - launcher state, inventory, accepted actions, and reachability of every menu
   choice;
+- ID-based activation of visible controls without depending on focus order;
 - opening, changing, and closing Spacewars Settings;
 - opening Controls, entering and leaving Touch Test, and returning to the
   launcher;
-- wrong-screen, stale-revision, and unavailable-action rejections without state
-  mutation;
+- wrong-screen, stale-revision, unavailable-action, unavailable-control, and
+  disabled-control rejections without state mutation;
 - launcher and gameplay screenshots; and
 - starting a real deterministic Spacewars scenario and observing `gameplay`
   with a scenario instance revision.

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -25,10 +25,12 @@ The initial workflows verify:
   launcher;
 - wrong-screen, stale-revision, unavailable-action, unavailable-control, and
   disabled-control rejections without state mutation;
-- launcher, gameplay, pause-menu, and benchmark screenshots; and
+- launcher, gameplay, pause-menu, benchmark, restarted-gameplay,
+  returned-launcher, and relaunched-gameplay screenshots; and
 - starting a real deterministic Spacewars scenario, pausing through the guarded
   host API, observing the conditional Benchmark menu control, and activating it
-  to start a new benchmark scenario revision.
+  to start a new benchmark scenario revision; then restarting into a normal
+  round, returning to the launcher, and launching Spacewars again.
 
 These are semantic UI tests. They do not validate physical touchscreen hit
 testing, LinuxKMS coordinate transforms, or panel rotation.
@@ -88,6 +90,6 @@ Keep functional tests black-box:
 5. Wait on observable predicates with deadlines; do not use transition sleeps.
 6. Assert both the postcondition and state that must remain unchanged on errors.
 
-Scenario restart and return-to-launcher coverage will be added when their
-explicit public lifecycle operations land. The current API deliberately does
-not reinterpret menu actions as gameplay controls.
+Restart and return-to-launcher are exercised by activating their visible pause
+menu controls through the public semantic-control API. The test gates every
+asynchronous host transition on observable state and scenario revisions.

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -1,0 +1,91 @@
+# Functional UI tests
+
+The functional suite launches the real `engine-client` binary and controls it
+only through the public Unix-socket API in `spacewars-control`. It protects the
+process, protocol, Slint callback, menu-navigation, rendering, and screenshot
+boundaries that unit tests cannot cover together.
+
+Each test owns:
+
+- a fresh `engine-client` process;
+- an isolated temporary settings directory;
+- a unique short control-socket path;
+- deterministic seed `4242`;
+- the Winit software renderer;
+- readiness and transition polling with explicit deadlines; and
+- a child guard that always terminates and reaps the process.
+
+The initial workflows verify:
+
+- launcher state, inventory, accepted actions, and reachability of every menu
+  choice;
+- opening, changing, and closing Spacewars Settings;
+- opening Controls, entering and leaving Touch Test, and returning to the
+  launcher;
+- wrong-screen, stale-revision, and unavailable-action rejections without state
+  mutation;
+- launcher and gameplay screenshots; and
+- starting a real deterministic Spacewars scenario and observing `gameplay`
+  with a scenario instance revision.
+
+These are semantic UI tests. They do not validate physical touchscreen hit
+testing, LinuxKMS coordinate transforms, or panel rotation.
+
+## Run locally
+
+On Debian or Ubuntu, install the virtual display tools once:
+
+```sh
+sudo apt-get install xvfb xauth
+```
+
+Run the suite under an isolated X display:
+
+```sh
+xvfb-run -a -s "-screen 0 1280x1024x24" \
+  cargo test -p engine-client --test ui_control_functional -- \
+  --ignored --test-threads=1
+```
+
+To watch the workflows on an existing X display, omit `xvfb-run`:
+
+```sh
+cargo test -p engine-client --test ui_control_functional -- \
+  --ignored --test-threads=1 --nocapture
+```
+
+The tests are marked ignored so the ordinary cross-platform workspace command
+does not require a display. Linux CI runs them explicitly under Xvfb.
+
+## Failure artifacts
+
+Successful runs remove their temporary data. A failing workflow preserves a
+directory under `target/functional-test-artifacts/` containing as much of the
+following as the still-running client can provide:
+
+```text
+engine-client.log
+failure.png
+last-state.json
+command-history.json
+summary.json
+```
+
+CI uploads that directory when the functional step fails. `summary.json` and
+`command-history.json` are versioned JSON; test and engine diagnostics remain on
+stderr or in the log, keeping control output out of stdout.
+
+## Adding workflows
+
+Keep functional tests black-box:
+
+1. Start a fresh client and wait for readiness.
+2. Assert the initial state before acting.
+3. Drive only `ControlClient` operations available to ordinary tooling.
+4. Guard mutations with screen/revision preconditions.
+5. Wait on observable predicates with deadlines; do not use transition sleeps.
+6. Assert both the postcondition and state that must remain unchanged on errors.
+
+Scenario pause, restart, and return-to-launcher coverage will be added when
+their explicit public lifecycle operations land. The current API deliberately
+does not reinterpret menu actions as gameplay controls.

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -25,9 +25,10 @@ The initial workflows verify:
   launcher;
 - wrong-screen, stale-revision, unavailable-action, unavailable-control, and
   disabled-control rejections without state mutation;
-- launcher and gameplay screenshots; and
-- starting a real deterministic Spacewars scenario and observing `gameplay`
-  with a scenario instance revision.
+- launcher, gameplay, pause-menu, and benchmark screenshots; and
+- starting a real deterministic Spacewars scenario, pausing through the guarded
+  host API, observing the conditional Benchmark menu control, and activating it
+  to start a new benchmark scenario revision.
 
 These are semantic UI tests. They do not validate physical touchscreen hit
 testing, LinuxKMS coordinate transforms, or panel rotation.
@@ -87,6 +88,6 @@ Keep functional tests black-box:
 5. Wait on observable predicates with deadlines; do not use transition sleeps.
 6. Assert both the postcondition and state that must remain unchanged on errors.
 
-Scenario pause, restart, and return-to-launcher coverage will be added when
-their explicit public lifecycle operations land. The current API deliberately
-does not reinterpret menu actions as gameplay controls.
+Scenario restart and return-to-launcher coverage will be added when their
+explicit public lifecycle operations land. The current API deliberately does
+not reinterpret menu actions as gameplay controls.

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -175,6 +175,9 @@ spacewars-cli ui state --json
 
 The versioned JSON snapshot includes the UI revision, exact screen, selected and
 active scenario IDs, scenario instance revision, and pause/benchmark state. A
+screen inventory identifies the selected control and every visible control by
+stable ID, label, and enabled state; settings arrows also include their current
+displayed value. Visible launcher or scenario errors appear in the same state. A
 launcher snapshot always has no active scenario, including after returning from
 gameplay. `status` remains available for detailed performance and
 scenario-specific diagnostics.

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -231,6 +231,18 @@ spacewars-cli ui activate pause.benchmark --expect-screen pause.main
 `host pause` automatically guards the observed gameplay revision. The Benchmark
 control is present only when the active scenario supports it.
 
+Restart a round or return to the launcher through the same visible pause menu:
+
+```sh
+spacewars-cli host pause --timeout 3s
+spacewars-cli ui activate pause.restart --expect-screen pause.main
+spacewars-cli ui wait --screen gameplay --scenario spacewars --timeout 3s
+
+spacewars-cli host pause --timeout 3s
+spacewars-cli ui activate pause.return-to-launcher --expect-screen pause.main
+spacewars-cli ui wait --screen launcher.main --timeout 3s
+```
+
 Synchronize a sampler or screenshot with the start of a fresh visual benchmark:
 
 ```sh

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -221,6 +221,16 @@ All supplied conditions must match. The CLI polling loop has a deadline and
 does not block the Slint event loop. A structured timeout includes the last UI
 state it observed.
 
+Pause active gameplay and wait for the visible pause menu:
+
+```sh
+spacewars-cli host pause --timeout 3s
+spacewars-cli ui activate pause.benchmark --expect-screen pause.main
+```
+
+`host pause` automatically guards the observed gameplay revision. The Benchmark
+control is present only when the active scenario supports it.
+
 Synchronize a sampler or screenshot with the start of a fresh visual benchmark:
 
 ```sh

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -175,12 +175,38 @@ spacewars-cli ui state --json
 
 The versioned JSON snapshot includes the UI revision, exact screen, selected and
 active scenario IDs, scenario instance revision, and pause/benchmark state. A
-screen inventory identifies the selected control and every visible control by
-stable ID, label, and enabled state; settings arrows also include their current
-displayed value. Visible launcher or scenario errors appear in the same state. A
-launcher snapshot always has no active scenario, including after returning from
-gameplay. `status` remains available for detailed performance and
-scenario-specific diagnostics.
+screen inventory identifies the accepted menu actions, selected control, and
+every visible control by stable ID, label, and enabled state; settings arrows
+also include their current displayed value. Visible launcher or scenario errors
+appear in the same state. A launcher snapshot always has no active scenario,
+including after returning from gameplay. `status` remains available for detailed
+performance and scenario-specific diagnostics.
+
+Drive the visible menu through the same action handler as keyboard and gamepad
+input. Preconditions protect an observe-then-act sequence from UI races:
+
+```sh
+spacewars-cli ui press down --expect-screen launcher.main
+spacewars-cli ui press confirm \
+  --expect-screen launcher.main --expect-revision 12 --json
+```
+
+A successful press returns the resulting state. A failure identifies a wrong
+screen, stale revision, or unavailable action and includes the current state.
+Use `spacewars-cli ui press --help` to list valid action and screen names; the
+current screen's effective actions also appear in `ui state`.
+
+Poll for state conditions with a bounded client-side wait:
+
+```sh
+spacewars-cli ui wait --screen launcher.settings --timeout 2s
+spacewars-cli ui wait --screen gameplay --scenario spacewars \
+  --revision-after 12 --timeout 10s --json
+```
+
+All supplied conditions must match. The CLI polling loop has a deadline and
+does not block the Slint event loop. A structured timeout includes the last UI
+state it observed.
 
 Synchronize a sampler or screenshot with the start of a fresh visual benchmark:
 

--- a/docs/pi-kiosk.md
+++ b/docs/pi-kiosk.md
@@ -196,6 +196,19 @@ screen, stale revision, or unavailable action and includes the current state.
 Use `spacewars-cli ui press --help` to list valid action and screen names; the
 current screen's effective actions also appear in `ui state`.
 
+Activate a visible control by its stable inventory ID when automation should
+not depend on focus order:
+
+```sh
+spacewars-cli ui activate launcher.controls \
+  --expect-screen launcher.main --expect-revision 12
+spacewars-cli ui activate launcher.controls.touch-test --json
+```
+
+Activation runs through the same menu and host callbacks as the corresponding
+visible control. Unknown, hidden, or disabled controls fail structurally and
+include the current state.
+
 Poll for state conditions with a bounded client-side wait:
 
 ```sh


### PR DESCRIPTION
## Summary

- add versioned UI state snapshots with stable control inventories and structured failures
- add guarded navigation, semantic control activation, bounded state waits, and host pause support through the shared control client and CLI
- add real-process functional tests with isolated configuration, sockets, cleanup, screenshots, logs, and failure history
- exercise launcher navigation and the Spacewars lifecycle through gameplay, pause, benchmark, restart, return to launcher, and relaunch
- run the functional suite in Linux CI and document local and Pi CLI workflows

## Testing

- cargo test --locked --workspace --all-targets -q
- cargo test --locked -p engine-client --test ui_control_functional -- --ignored --test-threads=1
- strict Clippy checks for the engine binary and functional-test target
- cargo fmt --all -- --check
- git diff --check

## Notes

These semantic tests validate the public UI and host callback paths. Physical touchscreen hit-testing and panel rotation remain separate device checks.

Refs #31