### PR TITLE
Add V6/V7 ship navigation policies and richer evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,17 +201,23 @@ cargo run --release -p engine-agent -- \
 ```
 
 Controller versions are explicit (`rule-v5`) so old and new brains can be run
-side by side. `rule` remains a convenience alias for the current default, but
-named suites and saved comparisons pin a concrete version. Reports record the
-identity returned by the instantiated brain rather than inferring it from the
-CLI spelling.
+side by side. The bounded port-replanning candidate is selectable as
+`rule-v6`, and the persistent multi-body escape candidate is `rule-v7`.
+`rule` remains a convenience alias for the V5 default while candidates are
+evaluated. Named suites and saved comparisons pin a concrete version. Reports
+record the identity returned by the instantiated brain rather than inferring
+it from the CLI spelling.
 
 Episode reports include the winner or tick-limit outcome, captures, ship
 losses, rebuilds, eliminations, collision incidents, docking/departure outcomes,
-final planet/form/health state, strategic objective selections and tick counts,
-canonical action count, and a deterministic trace fingerprint. The batch
-summary adds winner counts and measured ticks and simulated seconds per wall
-second.
+final planet/form/health state, strategic objective selections, port replans,
+multi-body escape activations, goal tick counts, canonical action count, and a
+deterministic trace fingerprint. Health telemetry records cumulative damage and
+healing in normalized full-health-bar units, the portion observed during body
+contact, minimum and mean ship health, ship/pod exposure, damaged and
+critical-health totals and longest streaks, mechanical body-contact ticks, and
+the longest sustained body contact. The batch summary adds winner counts and
+measured ticks and simulated seconds per wall second.
 `--seed-step` changes the interval between seeds; setting it to zero repeats
 the same seed for reproducibility or throughput measurements. Release builds
 are recommended whenever performance numbers matter.
@@ -223,13 +229,13 @@ cargo run --release -p engine-agent -- --suite navigation-v1
 ```
 
 `navigation-v1` fixes seeds 0 through 5, `rule-v5` self-play, 36,000 ticks per
-episode, no random asteroids, and very high ship health. Planet and ship
-collisions remain enabled and are measured, but they should not terminate a
-navigation episode. Body/ship contact metrics re-arm only after 30 quiet ticks,
-so a sustained or briefly flickering scrape counts as one incident. Docking
-metrics report contact entries and exits. A capture/rebuild departure succeeds
-only after the craft clears the planet surface by 90 world units beyond its
-collision hull.
+episode, no random asteroids, and 200 ship health (twice the normal value).
+Planet and ship collisions remain enabled and are measured. Body/ship contact
+metrics re-arm only after 30 quiet ticks, so a sustained or briefly flickering
+scrape counts as one incident; contact-duration metrics separately expose long
+scrapes. Docking metrics report contact entries and exits. A capture/rebuild
+departure succeeds only after the craft clears the planet surface by 90 world
+units beyond its collision hull.
 
 Run the ordinary-health strategy comparison suite:
 
@@ -263,8 +269,7 @@ with Rust 1.89 on Linux. A new brain version should leave these v5 manifests
 unchanged; update a manifest only when an intentional shared scenario or
 physics change means the historical workload itself has changed.
 
-After registering a future controller such as `rule-v6`, compare it with v5 in
-one paired, side-neutral run:
+Compare the V6 candidate with V5 in one paired, side-neutral strategy run:
 
 ```sh
 cargo run --locked --release -p engine-agent -- \
@@ -279,8 +284,28 @@ candidate roles. `--output json` retains all individual episodes for paired
 offline analysis. Wall-clock throughput remains informational rather than a
 correctness gate.
 
-The profile's four seeds are a quick smoke comparison. Broaden it without
-changing the world contract when a candidate is ready for a longer run:
+Compare V7 directly with the V6 behavior it composes:
+
+```sh
+cargo run --locked --release -p engine-agent -- \
+  --compare strategy-v1 --baseline rule-v6 --candidate rule-v7
+```
+
+V7 observes V6's ordinary body avoidance and takes over only after the chosen
+body switches twice within a short simultaneous-threat window. Its cumulative
+activation count is included in strategy metrics, so a comparison shows how
+often the added behavior actually ran.
+
+Use the same paired method with the long, double-health navigation workload:
+
+```sh
+cargo run --locked --release -p engine-agent -- \
+  --compare navigation-v1 --baseline rule-v5 --candidate rule-v6
+```
+
+The navigation profile's six seeds are a quick smoke comparison. Broaden it
+without changing the world contract when a candidate is ready for a longer
+run:
 
 ```sh
 cargo run --locked --release -p engine-agent -- \
@@ -304,10 +329,12 @@ The event trace records strategic and brain/port transitions, captures, safe
 departures, and a five-second heartbeat while a captured departure remains
 unfinished. Each sample includes the persistent objective and selection
 reason, docking state, surface clearance, outward speed, world velocity,
-guidance telemetry, body-avoidance progress and escape-assist state, contacts,
-and the emitted intent. `--output json` includes the same structured events for
-offline comparison. Tracing is available on custom batches rather than named
-suites so the suite contract and its normal report size remain fixed.
+guidance telemetry, body-avoidance progress and escape-assist state,
+port-attempt age/stall/obstruction, cumulative replans, active target cooldown,
+multi-body escape state/age/body count/activation count, contacts, and the
+emitted intent. `--output json` includes the same structured events for offline
+comparison. Tracing is available on custom batches rather than named suites so
+the suite contract and its normal report size remain fixed.
 
 Falling and NES Library pass the d-pad, `A`, `B`, `Select`, and `Start` to the
 cartridge. Press `Start` + `Select` together for the host controls menu so a

--- a/crates/engine-agent/baselines/navigation-v1.json
+++ b/crates/engine-agent/baselines/navigation-v1.json
@@ -8,15 +8,15 @@
       "controllers": ["rule_ship_v5", "rule_ship_v5"],
       "max_ticks": 36000,
       "ticks": 36000,
-      "trace_sha256": "0a1be75d1a5de48ad22b08d366f8d4e2b94887e663b8e25a60b72d4f9d774d5a"
+      "trace_sha256": "dee6e8d6fd53614f09080df4f4df400f213eea8aa90d2d01a1c92367471aed4b"
     },
     {
       "seed": 1,
       "preset": "navigation",
       "controllers": ["rule_ship_v5", "rule_ship_v5"],
       "max_ticks": 36000,
-      "ticks": 36000,
-      "trace_sha256": "463dade110e4be0388e5acb430f8006fe0e177e95665bc34c8db79538a02d356"
+      "ticks": 17367,
+      "trace_sha256": "9a5b9d5513a5385a6c7b54bcbe54cbc727e19748dcce7a0fd7f0f9c98026db4f"
     },
     {
       "seed": 2,
@@ -24,23 +24,23 @@
       "controllers": ["rule_ship_v5", "rule_ship_v5"],
       "max_ticks": 36000,
       "ticks": 36000,
-      "trace_sha256": "214d8251e73c2b978adbd0b515bfbf92a130ade0de10ad8f04f586dc9e8550b0"
+      "trace_sha256": "d4e5b51c681389d3c170f8fc8c0b287998fec7306944a83040fc9b3763f96e84"
     },
     {
       "seed": 3,
       "preset": "navigation",
       "controllers": ["rule_ship_v5", "rule_ship_v5"],
       "max_ticks": 36000,
-      "ticks": 36000,
-      "trace_sha256": "048b84958b806183afbe97d1614f555fea17b73e0f05410665867a4d7716ff9c"
+      "ticks": 29668,
+      "trace_sha256": "df63e9a3d9091836b73293621d09a9a56e6922f076e68e7b31c9e4b78134cbf1"
     },
     {
       "seed": 4,
       "preset": "navigation",
       "controllers": ["rule_ship_v5", "rule_ship_v5"],
       "max_ticks": 36000,
-      "ticks": 36000,
-      "trace_sha256": "6e920ec71f0a13116064ee2d0ddd9dbde4bfe697e820994cdc6de0ce8aae5f9d"
+      "ticks": 21352,
+      "trace_sha256": "475842aaee1f729a983a9ef39aa6a7e131157c7c0aa318c373595434d46332bd"
     },
     {
       "seed": 5,
@@ -48,7 +48,7 @@
       "controllers": ["rule_ship_v5", "rule_ship_v5"],
       "max_ticks": 36000,
       "ticks": 36000,
-      "trace_sha256": "b08f556344df468d1f1034c8558076d17b2a5e87a9935d804911cb34700d31aa"
+      "trace_sha256": "f1d682723036b4af1305fecf03cd152b3506c007bb61028ad554f747df531f9c"
     }
   ]
 }

--- a/crates/engine-agent/src/lib.rs
+++ b/crates/engine-agent/src/lib.rs
@@ -25,16 +25,16 @@ use spacewars_ai::{
     ShipBrain, StrategicGoal, StrategyTelemetry,
 };
 
-pub const REPORT_SCHEMA_VERSION: u32 = 3;
+pub const REPORT_SCHEMA_VERSION: u32 = 4;
 pub const BASELINE_SCHEMA_VERSION: u32 = 1;
-pub const POLICY_COMPARISON_SCHEMA_VERSION: u32 = 1;
+pub const POLICY_COMPARISON_SCHEMA_VERSION: u32 = 2;
 pub const NAVIGATION_V1_SUITE_ID: &str = "navigation_v1";
 pub const NAVIGATION_V1_SEEDS: [u64; 6] = [0, 1, 2, 3, 4, 5];
 pub const NAVIGATION_V1_MAX_TICKS: u64 = 36_000;
 pub const STRATEGY_V1_SUITE_ID: &str = "strategy_v1";
 pub const STRATEGY_V1_SEEDS: [u64; 4] = [0, 1, 2, 3];
 pub const STRATEGY_V1_MAX_TICKS: u64 = 18_000;
-const NAVIGATION_HEALTH_PERCENT: u32 = 100_000;
+const NAVIGATION_HEALTH_PERCENT: u32 = 200;
 const NAVIGATION_SAFE_DEPARTURE_CLEARANCE: f32 = 90.0;
 const CONTACT_INCIDENT_REARM_TICKS: u64 = 30;
 const NAVIGATION_TRACE_HEARTBEAT_TICKS: u64 = 300;
@@ -46,6 +46,8 @@ const STRATEGY_V1_BASELINE_JSON: &str = include_str!("../baselines/strategy-v1.j
 pub enum ControllerKind {
     Idle,
     RuleV5,
+    RuleV6,
+    RuleV7,
 }
 
 impl ControllerKind {
@@ -53,6 +55,8 @@ impl ControllerKind {
         match self {
             Self::Idle => None,
             Self::RuleV5 => Some(BuiltInPolicy::RuleV5),
+            Self::RuleV6 => Some(BuiltInPolicy::RuleV6),
+            Self::RuleV7 => Some(BuiltInPolicy::RuleV7),
         }
     }
 
@@ -60,6 +64,8 @@ impl ControllerKind {
         match self {
             Self::Idle => "idle_v1",
             Self::RuleV5 => BuiltInPolicy::RuleV5.descriptor().policy_id,
+            Self::RuleV6 => BuiltInPolicy::RuleV6.descriptor().policy_id,
+            Self::RuleV7 => BuiltInPolicy::RuleV7.descriptor().policy_id,
         }
     }
 }
@@ -154,12 +160,14 @@ impl EvaluationSuite {
 /// Unlike [`EvaluationSuite`], a profile does not pin either controller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PolicyComparisonProfile {
+    NavigationV1,
     StrategyV1,
 }
 
 impl PolicyComparisonProfile {
     pub const fn id(self) -> &'static str {
         match self {
+            Self::NavigationV1 => NAVIGATION_V1_SUITE_ID,
             Self::StrategyV1 => STRATEGY_V1_SUITE_ID,
         }
     }
@@ -170,6 +178,16 @@ impl PolicyComparisonProfile {
         candidate: ControllerKind,
     ) -> PolicyComparisonConfig {
         match self {
+            Self::NavigationV1 => PolicyComparisonConfig {
+                workload_id: Some(NAVIGATION_V1_SUITE_ID),
+                start_seed: NAVIGATION_V1_SEEDS[0],
+                seed_step: 1,
+                episodes: NAVIGATION_V1_SEEDS.len() as u32,
+                preset: SpacewarsPreset::Navigation,
+                baseline,
+                candidate,
+                max_ticks: NAVIGATION_V1_MAX_TICKS,
+            },
             Self::StrategyV1 => PolicyComparisonConfig {
                 workload_id: Some(STRATEGY_V1_SUITE_ID),
                 start_seed: STRATEGY_V1_SEEDS[0],
@@ -337,6 +355,16 @@ pub struct NavigationTraceEvent {
     pub avoidance_emergency_escape_assist: bool,
     pub target_planet: Option<usize>,
     pub port_phase: Option<PortNavigationPhase>,
+    pub port_attempt_age_ticks: u64,
+    pub port_attempt_stalled_ticks: u64,
+    pub port_attempt_obstructed_ticks: u64,
+    pub port_replan_count: u64,
+    pub cooled_port_planet: Option<usize>,
+    pub port_cooldown_remaining_ticks: u64,
+    pub multi_body_escape_active: bool,
+    pub multi_body_escape_age_ticks: u64,
+    pub multi_body_escape_body_count: u32,
+    pub multi_body_escape_activations: u64,
     pub docked_planet: Option<usize>,
     pub focus_planet: Option<usize>,
     pub pending_capture_planet: Option<usize>,
@@ -363,6 +391,8 @@ pub struct NavigationTraceEvent {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 pub struct StrategyMetrics {
     pub objective_selections: u64,
+    pub port_replans: u64,
+    pub multi_body_escape_activations: u64,
     pub idle_ticks: u64,
     pub survive_ticks: u64,
     pub attack_ticks: u64,
@@ -388,6 +418,8 @@ impl StrategyMetrics {
 
     fn add_assign(&mut self, other: Self) {
         self.objective_selections += other.objective_selections;
+        self.port_replans += other.port_replans;
+        self.multi_body_escape_activations += other.multi_body_escape_activations;
         self.idle_ticks += other.idle_ticks;
         self.survive_ticks += other.survive_ticks;
         self.attack_ticks += other.attack_ticks;
@@ -398,7 +430,79 @@ impl StrategyMetrics {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+/// Health and sustained-contact measurements for one controller seat.
+///
+/// Damage and healing are normalized to the configured maximum ship life, so
+/// `1.0` represents one complete health bar and cumulative values may exceed
+/// one after repairs or rebuild cycles. Escape-pod rebuild progress is not
+/// counted as ship damage or healing.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct HealthMetrics {
+    pub damage_taken_fraction: f64,
+    pub damage_while_in_body_contact_fraction: f64,
+    pub healing_received_fraction: f64,
+    pub minimum_life_fraction: f32,
+    pub mean_ship_life_fraction: f64,
+    pub ship_ticks: u64,
+    pub pod_ticks: u64,
+    pub damaged_ticks: u64,
+    pub critical_ticks: u64,
+    pub longest_damaged_streak_ticks: u64,
+    pub longest_critical_streak_ticks: u64,
+    pub body_contact_ticks: u64,
+    pub longest_body_contact_ticks: u64,
+}
+
+impl Default for HealthMetrics {
+    fn default() -> Self {
+        Self {
+            damage_taken_fraction: 0.0,
+            damage_while_in_body_contact_fraction: 0.0,
+            healing_received_fraction: 0.0,
+            minimum_life_fraction: 1.0,
+            mean_ship_life_fraction: 1.0,
+            ship_ticks: 0,
+            pod_ticks: 0,
+            damaged_ticks: 0,
+            critical_ticks: 0,
+            longest_damaged_streak_ticks: 0,
+            longest_critical_streak_ticks: 0,
+            body_contact_ticks: 0,
+            longest_body_contact_ticks: 0,
+        }
+    }
+}
+
+impl HealthMetrics {
+    fn add_episode(&mut self, other: Self) {
+        let combined_ship_ticks = self.ship_ticks + other.ship_ticks;
+        if combined_ship_ticks > 0 {
+            self.mean_ship_life_fraction = (self.mean_ship_life_fraction * self.ship_ticks as f64
+                + other.mean_ship_life_fraction * other.ship_ticks as f64)
+                / combined_ship_ticks as f64;
+        }
+        self.damage_taken_fraction += other.damage_taken_fraction;
+        self.damage_while_in_body_contact_fraction += other.damage_while_in_body_contact_fraction;
+        self.healing_received_fraction += other.healing_received_fraction;
+        self.minimum_life_fraction = self.minimum_life_fraction.min(other.minimum_life_fraction);
+        self.ship_ticks = combined_ship_ticks;
+        self.pod_ticks += other.pod_ticks;
+        self.damaged_ticks += other.damaged_ticks;
+        self.critical_ticks += other.critical_ticks;
+        self.longest_damaged_streak_ticks = self
+            .longest_damaged_streak_ticks
+            .max(other.longest_damaged_streak_ticks);
+        self.longest_critical_streak_ticks = self
+            .longest_critical_streak_ticks
+            .max(other.longest_critical_streak_ticks);
+        self.body_contact_ticks += other.body_contact_ticks;
+        self.longest_body_contact_ticks = self
+            .longest_body_contact_ticks
+            .max(other.longest_body_contact_ticks);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PolicyMetrics {
     pub controller: ControllerKind,
     pub policy_id: &'static str,
@@ -411,6 +515,7 @@ pub struct PolicyMetrics {
     pub sun_impact_losses: u64,
     pub rebuilds: u64,
     pub body_contacts: u64,
+    pub health: HealthMetrics,
 }
 
 impl PolicyMetrics {
@@ -426,6 +531,7 @@ impl PolicyMetrics {
             sun_impact_losses: 0,
             rebuilds: 0,
             body_contacts: 0,
+            health: HealthMetrics::default(),
         }
     }
 }
@@ -456,6 +562,7 @@ pub struct EpisodeSummary {
     pub final_planet_counts: [usize; SPACEWARS_PLAYER_COUNT],
     pub final_ship_forms: [ShipForm; SPACEWARS_PLAYER_COUNT],
     pub final_life_fractions: [f32; SPACEWARS_PLAYER_COUNT],
+    pub health: [HealthMetrics; SPACEWARS_PLAYER_COUNT],
     pub strategy: [StrategyMetrics; SPACEWARS_PLAYER_COUNT],
     pub actions_emitted: u64,
     pub trace_sha256: String,
@@ -483,6 +590,7 @@ pub struct BatchSummary {
     pub port_departures: [u64; SPACEWARS_PLAYER_COUNT],
     pub safe_capture_departures: [u64; SPACEWARS_PLAYER_COUNT],
     pub safe_rebuild_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    pub health: [HealthMetrics; SPACEWARS_PLAYER_COUNT],
     pub strategy: [StrategyMetrics; SPACEWARS_PLAYER_COUNT],
     pub policy_metrics: Vec<PolicyMetrics>,
     pub wall_seconds: f64,
@@ -623,7 +731,7 @@ impl std::error::Error for BaselineVerificationError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ComparedPolicyMetrics {
     pub controller: ControllerDescriptor,
     pub episodes: u32,
@@ -645,6 +753,7 @@ pub struct ComparedPolicyMetrics {
     pub safe_capture_departures: u64,
     pub safe_rebuild_departures: u64,
     pub final_planet_count_sum: u64,
+    pub health: HealthMetrics,
     pub strategy: StrategyMetrics,
 }
 
@@ -671,6 +780,7 @@ impl ComparedPolicyMetrics {
             safe_capture_departures: 0,
             safe_rebuild_departures: 0,
             final_planet_count_sum: 0,
+            health: HealthMetrics::default(),
             strategy: StrategyMetrics::default(),
         }
     }
@@ -700,11 +810,12 @@ impl ComparedPolicyMetrics {
         self.safe_capture_departures += episode.safe_capture_departures[player];
         self.safe_rebuild_departures += episode.safe_rebuild_departures[player];
         self.final_planet_count_sum += episode.final_planet_counts[player] as u64;
+        self.health.add_episode(episode.health[player]);
         self.strategy.add_assign(episode.strategy[player]);
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PolicyComparisonSummary {
     pub seed_pairs: u32,
     pub episode_runs: u32,
@@ -827,13 +938,18 @@ struct StrategyMetricTracker {
 }
 
 impl StrategyMetricTracker {
-    fn observe(&mut self, telemetry: StrategyTelemetry) {
-        let identity = telemetry.into();
+    fn observe(&mut self, telemetry: BrainTelemetry) {
+        let identity = telemetry.strategy.into();
         if self.previous != Some(identity) {
             self.metrics.objective_selections += 1;
             self.previous = Some(identity);
         }
-        self.metrics.observe_goal(telemetry.goal);
+        self.metrics.port_replans = self.metrics.port_replans.max(telemetry.port_replan_count);
+        self.metrics.multi_body_escape_activations = self
+            .metrics
+            .multi_body_escape_activations
+            .max(telemetry.multi_body_escape_activations);
+        self.metrics.observe_goal(telemetry.strategy.goal);
     }
 }
 
@@ -847,6 +963,9 @@ struct NavigationTraceSemantic {
     avoidance_emergency_escape_assist: bool,
     target_planet: Option<usize>,
     port_phase: Option<PortNavigationPhase>,
+    port_replan_count: u64,
+    multi_body_escape_active: bool,
+    multi_body_escape_activations: u64,
     docked_planet: Option<usize>,
 }
 
@@ -913,6 +1032,9 @@ impl NavigationTraceCollector {
             avoidance_emergency_escape_assist: telemetry.avoidance_emergency_escape_assist,
             target_planet: telemetry.target_planet.map(|planet| planet.index()),
             port_phase: telemetry.port_phase,
+            port_replan_count: telemetry.port_replan_count,
+            multi_body_escape_active: telemetry.multi_body_escape_active,
+            multi_body_escape_activations: telemetry.multi_body_escape_activations,
             docked_planet,
         };
         let captured_planet = self.capture_transition(state);
@@ -983,6 +1105,16 @@ impl NavigationTraceCollector {
                 avoidance_emergency_escape_assist: telemetry.avoidance_emergency_escape_assist,
                 target_planet: semantic.target_planet,
                 port_phase: telemetry.port_phase,
+                port_attempt_age_ticks: telemetry.port_attempt_age_ticks,
+                port_attempt_stalled_ticks: telemetry.port_attempt_stalled_ticks,
+                port_attempt_obstructed_ticks: telemetry.port_attempt_obstructed_ticks,
+                port_replan_count: telemetry.port_replan_count,
+                cooled_port_planet: telemetry.cooled_port_planet.map(|planet| planet.index()),
+                port_cooldown_remaining_ticks: telemetry.port_cooldown_remaining_ticks,
+                multi_body_escape_active: telemetry.multi_body_escape_active,
+                multi_body_escape_age_ticks: telemetry.multi_body_escape_age_ticks,
+                multi_body_escape_body_count: telemetry.multi_body_escape_body_count,
+                multi_body_escape_activations: telemetry.multi_body_escape_activations,
                 docked_planet,
                 focus_planet,
                 pending_capture_planet: pending_capture.map(|pending| pending.planet),
@@ -1087,6 +1219,116 @@ fn trace_planet_geometry(
     })
 }
 
+#[derive(Debug, Clone, Copy)]
+struct PlayerHealthTracker {
+    previous_form: ShipForm,
+    previous_life_fraction: f32,
+    damaged_streak: u64,
+    critical_streak: u64,
+    body_contact_streak: u64,
+    metrics: HealthMetrics,
+}
+
+impl PlayerHealthTracker {
+    fn new(form: ShipForm, life: f32, life_max: f32) -> Self {
+        let life_fraction = normalized_health_fraction(life, life_max);
+        let mut metrics = HealthMetrics::default();
+        if form == ShipForm::Ship {
+            metrics.minimum_life_fraction = life_fraction;
+        }
+        Self {
+            previous_form: form,
+            previous_life_fraction: life_fraction,
+            damaged_streak: 0,
+            critical_streak: 0,
+            body_contact_streak: 0,
+            metrics,
+        }
+    }
+
+    fn observe(&mut self, form: ShipForm, life: f32, life_max: f32, body_contact: bool) {
+        let life_fraction = normalized_health_fraction(life, life_max);
+        let mut damage_taken = 0.0;
+        match (self.previous_form, form) {
+            (ShipForm::Ship, ShipForm::Ship) => {
+                let change = life_fraction - self.previous_life_fraction;
+                if change < 0.0 {
+                    damage_taken = f64::from(-change);
+                } else {
+                    self.metrics.healing_received_fraction += f64::from(change);
+                }
+            }
+            (ShipForm::Ship, ShipForm::EscapePod) => {
+                // Count destruction as consuming the ship's remaining health,
+                // but do not count any overkill or later pod rebuild progress.
+                damage_taken = f64::from(self.previous_life_fraction.max(0.0));
+                self.metrics.minimum_life_fraction = 0.0;
+            }
+            (ShipForm::EscapePod, ShipForm::Ship | ShipForm::EscapePod) => {}
+        }
+        self.metrics.damage_taken_fraction += damage_taken;
+        if body_contact {
+            self.metrics.damage_while_in_body_contact_fraction += damage_taken;
+        }
+
+        if form == ShipForm::Ship {
+            let previous_ship_ticks = self.metrics.ship_ticks;
+            self.metrics.ship_ticks += 1;
+            self.metrics.mean_ship_life_fraction = (self.metrics.mean_ship_life_fraction
+                * previous_ship_ticks as f64
+                + f64::from(life_fraction))
+                / self.metrics.ship_ticks as f64;
+            self.metrics.minimum_life_fraction =
+                self.metrics.minimum_life_fraction.min(life_fraction);
+            if life_fraction < 1.0 - f32::EPSILON {
+                self.metrics.damaged_ticks += 1;
+                self.damaged_streak = self.damaged_streak.saturating_add(1);
+                self.metrics.longest_damaged_streak_ticks = self
+                    .metrics
+                    .longest_damaged_streak_ticks
+                    .max(self.damaged_streak);
+            } else {
+                self.damaged_streak = 0;
+            }
+            if life_fraction <= 0.5 {
+                self.metrics.critical_ticks += 1;
+                self.critical_streak = self.critical_streak.saturating_add(1);
+                self.metrics.longest_critical_streak_ticks = self
+                    .metrics
+                    .longest_critical_streak_ticks
+                    .max(self.critical_streak);
+            } else {
+                self.critical_streak = 0;
+            }
+        } else {
+            self.metrics.pod_ticks += 1;
+            self.damaged_streak = 0;
+            self.critical_streak = 0;
+        }
+
+        if body_contact {
+            self.body_contact_streak = self.body_contact_streak.saturating_add(1);
+            self.metrics.body_contact_ticks += 1;
+            self.metrics.longest_body_contact_ticks = self
+                .metrics
+                .longest_body_contact_ticks
+                .max(self.body_contact_streak);
+        } else {
+            self.body_contact_streak = 0;
+        }
+        self.previous_form = form;
+        self.previous_life_fraction = life_fraction;
+    }
+}
+
+fn normalized_health_fraction(life: f32, life_max: f32) -> f32 {
+    if life_max > 0.0 {
+        (life / life_max).clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
 #[derive(Debug)]
 struct TransitionTracker {
     previous_planet_owners: Vec<Option<usize>>,
@@ -1111,6 +1353,7 @@ struct TransitionTracker {
     port_departures: [u64; SPACEWARS_PLAYER_COUNT],
     safe_capture_departures: [u64; SPACEWARS_PLAYER_COUNT],
     safe_rebuild_departures: [u64; SPACEWARS_PLAYER_COUNT],
+    health: [PlayerHealthTracker; SPACEWARS_PLAYER_COUNT],
 }
 
 impl TransitionTracker {
@@ -1146,6 +1389,10 @@ impl TransitionTracker {
             port_departures: [0; SPACEWARS_PLAYER_COUNT],
             safe_capture_departures: [0; SPACEWARS_PLAYER_COUNT],
             safe_rebuild_departures: [0; SPACEWARS_PLAYER_COUNT],
+            health: std::array::from_fn(|player| {
+                let ship = &state.ships[player];
+                PlayerHealthTracker::new(ship.form, ship.life, ship.life_max)
+            }),
         }
     }
 
@@ -1171,6 +1418,11 @@ impl TransitionTracker {
         }
 
         let body_collisions = mechanical_body_contacts(state);
+        for player in 0..SPACEWARS_PLAYER_COUNT {
+            let ship = &state.ships[player];
+            let body_contact = body_collisions.iter().any(|contact| contact.ship == player);
+            self.health[player].observe(ship.form, ship.life, ship.life_max, body_contact);
+        }
         for contact in
             rearmed_contacts(&body_collisions, &mut self.body_contact_history, state.tick)
         {
@@ -1389,7 +1641,7 @@ pub fn run_episode(config: EpisodeConfig) -> Result<EpisodeSummary, RunError> {
             let actor = PlayerId::from_index(player).expect("Spacewars has exactly two players");
             let intent = controller.intent(&state, actor)?;
             let telemetry = controller.telemetry();
-            strategy_trackers[player].observe(telemetry.strategy);
+            strategy_trackers[player].observe(telemetry);
             if config.trace_player == Some(actor) {
                 if let Some(collector) = &mut navigation_trace {
                     collector.observe(&state, telemetry, intent, false);
@@ -1445,12 +1697,9 @@ pub fn run_episode(config: EpisodeConfig) -> Result<EpisodeSummary, RunError> {
         final_ship_forms: std::array::from_fn(|player| state.ships[player].form),
         final_life_fractions: std::array::from_fn(|player| {
             let ship = &state.ships[player];
-            if ship.life_max > 0.0 {
-                (ship.life / ship.life_max).clamp(0.0, 1.0)
-            } else {
-                0.0
-            }
+            normalized_health_fraction(ship.life, ship.life_max)
         }),
+        health: transitions.health.map(|tracker| tracker.metrics),
         strategy: strategy_trackers.map(|tracker| tracker.metrics),
         actions_emitted,
         trace_sha256: format!("{:x}", trace.finalize()),
@@ -1645,6 +1894,7 @@ fn summarize_batch(episodes: &[EpisodeSummary], wall_seconds: f64) -> BatchSumma
     let mut port_departures = [0_u64; SPACEWARS_PLAYER_COUNT];
     let mut safe_capture_departures = [0_u64; SPACEWARS_PLAYER_COUNT];
     let mut safe_rebuild_departures = [0_u64; SPACEWARS_PLAYER_COUNT];
+    let mut health = [HealthMetrics::default(); SPACEWARS_PLAYER_COUNT];
     let mut strategy = [StrategyMetrics::default(); SPACEWARS_PLAYER_COUNT];
     let mut policy_metrics = BTreeMap::new();
     let mut total_ticks = 0_u64;
@@ -1669,6 +1919,7 @@ fn summarize_batch(episodes: &[EpisodeSummary], wall_seconds: f64) -> BatchSumma
             policy.sun_impact_losses += episode.sun_impact_losses[player];
             policy.rebuilds += episode.rebuilds[player];
             policy.body_contacts += episode.body_contacts[player];
+            policy.health.add_episode(episode.health[player]);
 
             captures[player] += episode.captures[player];
             ship_losses[player] += episode.ship_losses[player];
@@ -1683,6 +1934,7 @@ fn summarize_batch(episodes: &[EpisodeSummary], wall_seconds: f64) -> BatchSumma
             port_departures[player] += episode.port_departures[player];
             safe_capture_departures[player] += episode.safe_capture_departures[player];
             safe_rebuild_departures[player] += episode.safe_rebuild_departures[player];
+            health[player].add_episode(episode.health[player]);
             strategy[player].add_assign(episode.strategy[player]);
         }
     }
@@ -1707,6 +1959,7 @@ fn summarize_batch(episodes: &[EpisodeSummary], wall_seconds: f64) -> BatchSumma
         port_departures,
         safe_capture_departures,
         safe_rebuild_departures,
+        health,
         strategy,
         policy_metrics: policy_metrics.into_values().collect(),
         wall_seconds,
@@ -1980,15 +2233,81 @@ mod tests {
 
     #[test]
     fn evaluator_reports_the_instantiated_policy_version() {
-        let controller = SeatController::new(ControllerKind::RuleV5, PlayerId::PLAYER_2, 9);
+        for (kind, policy_id) in [
+            (ControllerKind::RuleV5, "rule_ship_v5"),
+            (ControllerKind::RuleV6, "rule_ship_v6"),
+            (ControllerKind::RuleV7, "rule_ship_v7"),
+        ] {
+            let controller = SeatController::new(kind, PlayerId::PLAYER_2, 9);
 
-        assert_eq!(
-            controller.descriptor(),
-            ControllerDescriptor {
-                kind: ControllerKind::RuleV5,
-                policy_id: "rule_ship_v5",
-            }
-        );
+            assert_eq!(
+                controller.descriptor(),
+                ControllerDescriptor { kind, policy_id }
+            );
+        }
+    }
+
+    #[test]
+    fn strategy_metrics_count_cumulative_port_replans_once() {
+        let mut tracker = StrategyMetricTracker::default();
+        for (port_replan_count, multi_body_escape_activations) in
+            [(0, 0), (1, 1), (1, 1), (2, 3), (2, 3)]
+        {
+            tracker.observe(BrainTelemetry {
+                port_replan_count,
+                multi_body_escape_activations,
+                ..BrainTelemetry::default()
+            });
+        }
+
+        assert_eq!(tracker.metrics.port_replans, 2);
+        assert_eq!(tracker.metrics.multi_body_escape_activations, 3);
+        assert_eq!(tracker.metrics.objective_selections, 1);
+        assert_eq!(tracker.metrics.idle_ticks, 5);
+    }
+
+    #[test]
+    fn health_metrics_normalize_damage_healing_and_contact_duration() {
+        let mut tracker = PlayerHealthTracker::new(ShipForm::Ship, 100.0, 100.0);
+
+        tracker.observe(ShipForm::Ship, 80.0, 100.0, false);
+        tracker.observe(ShipForm::Ship, 90.0, 100.0, true);
+        tracker.observe(ShipForm::Ship, 40.0, 100.0, true);
+        tracker.observe(ShipForm::EscapePod, 0.0, 100.0, true);
+        // Pod rebuild progress and the completed rebuild are not ship healing.
+        tracker.observe(ShipForm::EscapePod, 50.0, 100.0, false);
+        tracker.observe(ShipForm::Ship, 100.0, 100.0, false);
+
+        assert!((tracker.metrics.damage_taken_fraction - 1.1).abs() < 1.0e-6);
+        assert!((tracker.metrics.damage_while_in_body_contact_fraction - 0.9).abs() < 1.0e-6);
+        assert!((tracker.metrics.healing_received_fraction - 0.1).abs() < 1.0e-6);
+        assert_eq!(tracker.metrics.minimum_life_fraction, 0.0);
+        assert!((tracker.metrics.mean_ship_life_fraction - 0.775).abs() < 1.0e-6);
+        assert_eq!(tracker.metrics.ship_ticks, 4);
+        assert_eq!(tracker.metrics.pod_ticks, 2);
+        assert_eq!(tracker.metrics.damaged_ticks, 3);
+        assert_eq!(tracker.metrics.critical_ticks, 1);
+        assert_eq!(tracker.metrics.longest_damaged_streak_ticks, 3);
+        assert_eq!(tracker.metrics.longest_critical_streak_ticks, 1);
+        assert_eq!(tracker.metrics.body_contact_ticks, 3);
+        assert_eq!(tracker.metrics.longest_body_contact_ticks, 3);
+    }
+
+    #[test]
+    fn aggregate_health_uses_a_ship_tick_weighted_mean() {
+        let mut aggregate = HealthMetrics {
+            mean_ship_life_fraction: 0.75,
+            ship_ticks: 2,
+            ..HealthMetrics::default()
+        };
+        aggregate.add_episode(HealthMetrics {
+            mean_ship_life_fraction: 0.25,
+            ship_ticks: 1,
+            ..HealthMetrics::default()
+        });
+
+        assert_eq!(aggregate.ship_ticks, 3);
+        assert!((aggregate.mean_ship_life_fraction - 7.0 / 12.0).abs() < 1.0e-12);
     }
 
     #[test]
@@ -2034,10 +2353,12 @@ mod tests {
     }
 
     #[test]
-    fn navigation_preset_removes_asteroids_and_raises_ship_health() {
+    fn navigation_preset_removes_asteroids_and_doubles_ship_health() {
         let config = SpacewarsPreset::Navigation.config();
+        let normal_health = SpacewarsConfig::default().players[0].health_percent;
 
         assert_eq!(config.asteroid_probability_per_sec, 0.0);
+        assert_eq!(NAVIGATION_HEALTH_PERCENT, normal_health * 2);
         assert!(
             config
                 .players
@@ -2062,6 +2383,20 @@ mod tests {
                 && config.max_ticks == NAVIGATION_V1_MAX_TICKS
                 && config.trace_player.is_none()
         }));
+    }
+
+    #[test]
+    fn navigation_comparison_reuses_the_named_world_contract() {
+        let config = PolicyComparisonProfile::NavigationV1
+            .config(ControllerKind::RuleV5, ControllerKind::RuleV6);
+
+        assert_eq!(config.workload_id, Some(NAVIGATION_V1_SUITE_ID));
+        assert_eq!(config.start_seed, NAVIGATION_V1_SEEDS[0]);
+        assert_eq!(config.episodes, NAVIGATION_V1_SEEDS.len() as u32);
+        assert_eq!(config.preset, SpacewarsPreset::Navigation);
+        assert_eq!(config.max_ticks, NAVIGATION_V1_MAX_TICKS);
+        assert_eq!(config.baseline, ControllerKind::RuleV5);
+        assert_eq!(config.candidate, ControllerKind::RuleV6);
     }
 
     #[test]
@@ -2420,14 +2755,19 @@ mod tests {
         .unwrap();
         let json = serde_json::to_string(&report).unwrap();
 
-        assert!(json.contains("\"schema_version\":3"));
+        assert!(json.contains("\"schema_version\":4"));
         assert!(json.contains("\"policy_id\":\"idle_v1\""));
         assert!(json.contains("\"kind\":\"rule_v5\""));
         assert!(json.contains("\"policy_id\":\"rule_ship_v5\""));
         assert!(json.contains("\"trace_sha256\""));
         assert!(json.contains("\"objective_selections\""));
+        assert!(json.contains("\"port_replans\""));
         assert!(json.contains("\"policy_metrics\""));
         assert!(json.contains("\"planet_impact_losses\""));
+        assert!(json.contains("\"damage_taken_fraction\""));
+        assert!(json.contains("\"mean_ship_life_fraction\""));
+        assert!(json.contains("\"pod_ticks\""));
+        assert!(json.contains("\"longest_body_contact_ticks\""));
     }
 
     #[test]
@@ -2456,6 +2796,8 @@ mod tests {
         assert_eq!(idle.ticks, 2);
         assert_eq!(rule.seat_episodes, 2);
         assert_eq!(rule.ticks, 2);
+        assert_eq!(idle.health, report.summary.health[0]);
+        assert_eq!(rule.health, report.summary.health[1]);
     }
 
     #[test]

--- a/crates/engine-agent/src/main.rs
+++ b/crates/engine-agent/src/main.rs
@@ -150,12 +150,14 @@ enum SuiteArg {
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum ComparisonArg {
+    NavigationV1,
     StrategyV1,
 }
 
 impl From<ComparisonArg> for PolicyComparisonProfile {
     fn from(value: ComparisonArg) -> Self {
         match value {
+            ComparisonArg::NavigationV1 => Self::NavigationV1,
             ComparisonArg::StrategyV1 => Self::StrategyV1,
         }
     }
@@ -175,6 +177,10 @@ enum ControllerArg {
     Idle,
     #[value(name = "rule-v5", alias = "rule")]
     RuleV5,
+    #[value(name = "rule-v6")]
+    RuleV6,
+    #[value(name = "rule-v7")]
+    RuleV7,
 }
 
 impl From<ControllerArg> for ControllerKind {
@@ -182,6 +188,8 @@ impl From<ControllerArg> for ControllerKind {
         match value {
             ControllerArg::Idle => Self::Idle,
             ControllerArg::RuleV5 => Self::RuleV5,
+            ControllerArg::RuleV6 => Self::RuleV6,
+            ControllerArg::RuleV7 => Self::RuleV7,
         }
     }
 }
@@ -296,7 +304,7 @@ fn print_policy_comparison_report(report: &PolicyComparisonReport) {
 
 fn print_compared_policy(role: &str, metrics: &ComparedPolicyMetrics) {
     println!(
-        "{role}={} wins={} tick-limits={} captures={} losses={} losses(planet/sun)={}/{} rebuilds={} contacts(body/ship)={}/{} docks={} departures(port/safe-capture/safe-rebuild)={}/{}/{} planets-sum={} strategy={:?}",
+        "{role}={} wins={} tick-limits={} captures={} losses={} losses(planet/sun)={}/{} rebuilds={} contacts(body/ship)={}/{} docks={} departures(port/safe-capture/safe-rebuild)={}/{}/{} planets-sum={} health={:?} strategy={:?}",
         metrics.controller.policy_id,
         metrics.wins,
         metrics.tick_limits,
@@ -312,6 +320,7 @@ fn print_compared_policy(role: &str, metrics: &ComparedPolicyMetrics) {
         metrics.safe_capture_departures,
         metrics.safe_rebuild_departures,
         metrics.final_planet_count_sum,
+        metrics.health,
         metrics.strategy,
     );
 }
@@ -322,7 +331,7 @@ fn print_text_report(report: &RunReport) {
     }
     for episode in &report.episodes {
         println!(
-            "seed={} controllers={:?} outcome={} ticks={} sim={:.1}s captures={:?} losses={:?} losses(planet/sun)={:?}/{:?} rebuilds={:?} contacts(body/ship)={:?}/{:?} impacts(debris/laser)={:?}/{:?} docks={:?} departures(port/safe-capture/safe-rebuild)={:?}/{:?}/{:?} planets={:?} strategy={:?} actions={} trace={}",
+            "seed={} controllers={:?} outcome={} ticks={} sim={:.1}s captures={:?} losses={:?} losses(planet/sun)={:?}/{:?} rebuilds={:?} contacts(body/ship)={:?}/{:?} impacts(debris/laser)={:?}/{:?} docks={:?} departures(port/safe-capture/safe-rebuild)={:?}/{:?}/{:?} planets={:?} health={:?} strategy={:?} actions={} trace={}",
             episode.seed,
             episode.controllers,
             episode.outcome,
@@ -342,6 +351,7 @@ fn print_text_report(report: &RunReport) {
             episode.safe_capture_departures,
             episode.safe_rebuild_departures,
             episode.final_planet_counts,
+            episode.health,
             episode.strategy,
             episode.actions_emitted,
             episode
@@ -351,7 +361,7 @@ fn print_text_report(report: &RunReport) {
         );
         for event in &episode.navigation_trace {
             println!(
-                "  nav tick={} p={} reason={:?} strategy={:?} strategy-target={:?}/{:?} strategy-score={} strategy-reason={:?} goal={:?} avoid={:?} avoid-clearance={} avoid-outward={} predictive={} avoid-closest={} avoid-predicted-clearance={} avoid-age={}/{} assist={}/{} phase={:?} target={:?} docked={:?} pending={:?} age={} focus={:?} clearance={} outward={} port-distance={} port-omega={} velocity=({:.1},{:.1}) speed={:.1} rotation={:.2} port-rotation={} omega(control/measured)={:.2}/{:.2} heading={:.2} desired={:.1} relative={:.1} contact(body/ship)={}/{} intent(turn={:.2} thrust={:.1} brake={:.1} wings={} laser={} cannon={})",
+                "  nav tick={} p={} reason={:?} strategy={:?} strategy-target={:?}/{:?} strategy-score={} strategy-reason={:?} goal={:?} avoid={:?} avoid-clearance={} avoid-outward={} predictive={} avoid-closest={} avoid-predicted-clearance={} avoid-age={}/{} assist={}/{} phase={:?} target={:?} attempt(age/stalled/obstructed)={}/{}/{} replans={} cooldown={:?}/{} multi(active/age/bodies/activations)={}/{}/{}/{} docked={:?} pending={:?} age={} focus={:?} clearance={} outward={} port-distance={} port-omega={} velocity=({:.1},{:.1}) speed={:.1} rotation={:.2} port-rotation={} omega(control/measured)={:.2}/{:.2} heading={:.2} desired={:.1} relative={:.1} contact(body/ship)={}/{} intent(turn={:.2} thrust={:.1} brake={:.1} wings={} laser={} cannon={})",
                 event.tick,
                 event.player.index() + 1,
                 event.reasons,
@@ -373,6 +383,16 @@ fn print_text_report(report: &RunReport) {
                 event.avoidance_emergency_escape_assist,
                 event.port_phase,
                 event.target_planet,
+                event.port_attempt_age_ticks,
+                event.port_attempt_stalled_ticks,
+                event.port_attempt_obstructed_ticks,
+                event.port_replan_count,
+                event.cooled_port_planet,
+                event.port_cooldown_remaining_ticks,
+                event.multi_body_escape_active,
+                event.multi_body_escape_age_ticks,
+                event.multi_body_escape_body_count,
+                event.multi_body_escape_activations,
                 event.docked_planet,
                 event.pending_capture_planet,
                 optional_u64(event.pending_capture_ticks),
@@ -404,7 +424,7 @@ fn print_text_report(report: &RunReport) {
     }
     let summary = &report.summary;
     println!(
-        "episodes={} winners={:?} tick_limits={} ticks={} wall={:.3}s ticks/s={:.0} realtime={:.1}x captures={:?} losses={:?} losses(planet/sun)={:?}/{:?} rebuilds={:?} contacts(body/ship)={:?}/{:?} impacts(debris/laser)={:?}/{:?} docks={:?} departures(port/safe-capture/safe-rebuild)={:?}/{:?}/{:?} strategy={:?} policies={:?}",
+        "episodes={} winners={:?} tick_limits={} ticks={} wall={:.3}s ticks/s={:.0} realtime={:.1}x captures={:?} losses={:?} losses(planet/sun)={:?}/{:?} rebuilds={:?} contacts(body/ship)={:?}/{:?} impacts(debris/laser)={:?}/{:?} docks={:?} departures(port/safe-capture/safe-rebuild)={:?}/{:?}/{:?} health={:?} strategy={:?} policies={:?}",
         summary.episodes,
         summary.winner_counts,
         summary.tick_limits,
@@ -425,6 +445,7 @@ fn print_text_report(report: &RunReport) {
         summary.port_departures,
         summary.safe_capture_departures,
         summary.safe_rebuild_departures,
+        summary.health,
         summary.strategy,
         summary.policy_metrics,
     );
@@ -461,7 +482,7 @@ mod tests {
             "--baseline",
             "rule-v5",
             "--candidate",
-            "idle",
+            "rule-v6",
             "--comparison-start-seed",
             "100",
             "--comparison-episodes",
@@ -471,9 +492,36 @@ mod tests {
 
         assert!(matches!(args.compare, Some(ComparisonArg::StrategyV1)));
         assert!(matches!(args.baseline, Some(ControllerArg::RuleV5)));
-        assert!(matches!(args.candidate, Some(ControllerArg::Idle)));
+        assert!(matches!(args.candidate, Some(ControllerArg::RuleV6)));
         assert_eq!(args.comparison_start_seed, Some(100));
         assert_eq!(args.comparison_episodes, Some(20));
+    }
+
+    #[test]
+    fn navigation_comparison_and_explicit_v6_are_selectable() {
+        let args = Args::try_parse_from([
+            "engine-agent",
+            "--compare",
+            "navigation-v1",
+            "--candidate",
+            "rule-v6",
+        ])
+        .unwrap();
+
+        assert!(matches!(args.compare, Some(ComparisonArg::NavigationV1)));
+        assert!(matches!(args.candidate, Some(ControllerArg::RuleV6)));
+        assert_eq!(
+            ControllerKind::from(args.candidate.unwrap()),
+            ControllerKind::RuleV6
+        );
+    }
+
+    #[test]
+    fn explicit_v7_is_selectable() {
+        let args = Args::try_parse_from(["engine-agent", "--player-2", "rule-v7"]).unwrap();
+
+        assert!(matches!(args.player_2, ControllerArg::RuleV7));
+        assert_eq!(ControllerKind::from(args.player_2), ControllerKind::RuleV7);
     }
 
     #[test]

--- a/crates/spacewars-ai/src/lib.rs
+++ b/crates/spacewars-ai/src/lib.rs
@@ -27,6 +27,10 @@ pub struct ShipBrainDescriptor {
 
 /// Stable policy identity stored in episode artifacts for rule brain v5.
 pub const RULE_SHIP_BRAIN_V5_POLICY_ID: &str = "rule_ship_v5";
+/// Stable policy identity stored in episode artifacts for rule brain v6.
+pub const RULE_SHIP_BRAIN_V6_POLICY_ID: &str = "rule_ship_v6";
+/// Stable policy identity stored in episode artifacts for rule brain v7.
+pub const RULE_SHIP_BRAIN_V7_POLICY_ID: &str = "rule_ship_v7";
 
 /// Built-in, reproducible ship policies.
 ///
@@ -36,6 +40,8 @@ pub const RULE_SHIP_BRAIN_V5_POLICY_ID: &str = "rule_ship_v5";
 #[serde(rename_all = "snake_case")]
 pub enum BuiltInPolicy {
     RuleV5,
+    RuleV6,
+    RuleV7,
 }
 
 /// Policy used by interactive hosts that request the unversioned rule bot.
@@ -45,12 +51,18 @@ pub enum BuiltInPolicy {
 pub const DEFAULT_BUILT_IN_POLICY: BuiltInPolicy = BuiltInPolicy::RuleV5;
 
 impl BuiltInPolicy {
-    pub const ALL: &'static [Self] = &[Self::RuleV5];
+    pub const ALL: &'static [Self] = &[Self::RuleV5, Self::RuleV6, Self::RuleV7];
 
     pub const fn descriptor(self) -> ShipBrainDescriptor {
         match self {
             Self::RuleV5 => ShipBrainDescriptor {
                 policy_id: RULE_SHIP_BRAIN_V5_POLICY_ID,
+            },
+            Self::RuleV6 => ShipBrainDescriptor {
+                policy_id: RULE_SHIP_BRAIN_V6_POLICY_ID,
+            },
+            Self::RuleV7 => ShipBrainDescriptor {
+                policy_id: RULE_SHIP_BRAIN_V7_POLICY_ID,
             },
         }
     }
@@ -65,6 +77,8 @@ impl BuiltInPolicy {
     pub fn create(self) -> Box<dyn ShipBrain> {
         match self {
             Self::RuleV5 => Box::new(RuleShipBrainV5::default()),
+            Self::RuleV6 => Box::new(RuleShipBrainV6::default()),
+            Self::RuleV7 => Box::new(RuleShipBrainV7::default()),
         }
     }
 }
@@ -129,6 +143,7 @@ pub enum StrategySelectionReason {
     Invalidated,
     HigherUtility,
     DockingContact,
+    TargetCooldown,
 }
 
 /// Best utility currently available for each strategic goal class.
@@ -185,7 +200,7 @@ pub enum PortNavigationPhase {
     Depart,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AvoidanceBody {
     Sun,
@@ -200,6 +215,16 @@ pub struct BrainTelemetry {
     pub target: Option<PlayerId>,
     pub target_planet: Option<PlanetId>,
     pub port_phase: Option<PortNavigationPhase>,
+    pub port_attempt_age_ticks: u64,
+    pub port_attempt_stalled_ticks: u64,
+    pub port_attempt_obstructed_ticks: u64,
+    pub port_replan_count: u64,
+    pub cooled_port_planet: Option<PlanetId>,
+    pub port_cooldown_remaining_ticks: u64,
+    pub multi_body_escape_active: bool,
+    pub multi_body_escape_age_ticks: u64,
+    pub multi_body_escape_body_count: u32,
+    pub multi_body_escape_activations: u64,
     pub hazard: Option<DebrisId>,
     pub avoided_body: Option<AvoidanceBody>,
     pub avoidance_surface_clearance: Option<f32>,
@@ -226,6 +251,16 @@ impl Default for BrainTelemetry {
             target: None,
             target_planet: None,
             port_phase: None,
+            port_attempt_age_ticks: 0,
+            port_attempt_stalled_ticks: 0,
+            port_attempt_obstructed_ticks: 0,
+            port_replan_count: 0,
+            cooled_port_planet: None,
+            port_cooldown_remaining_ticks: 0,
+            multi_body_escape_active: false,
+            multi_body_escape_age_ticks: 0,
+            multi_body_escape_body_count: 0,
+            multi_body_escape_activations: 0,
             hazard: None,
             avoided_body: None,
             avoidance_surface_clearance: None,
@@ -289,6 +324,50 @@ fn steering_safe_brake(form: ShipForm, heading: HeadingGuidance, requested_brake
     } else {
         requested_brake
     }
+}
+
+fn body_escape_controls(
+    config: RuleShipBrainConfig,
+    observation: &ShipObservationV1,
+    direction: Vec2,
+    predictive: bool,
+    escape_assist: bool,
+    emergency_escape_assist: bool,
+) -> (ShipIntent, HeadingGuidance) {
+    let heading = guide_heading(direction, observation.own_ship.angular_velocity);
+    let heading_error = heading.error_radians.abs();
+    // A forecast maneuver should shed velocity while establishing its
+    // tangent instead of accelerating merely because the desired heading is
+    // within the broader emergency-escape cone.
+    let forward_aligned = heading_error < if predictive { 0.2 } else { 0.65 };
+    let reverse_escape = observation.own_ship.form == ShipForm::Ship
+        && emergency_escape_assist
+        && PI - heading_error < 0.65;
+    let requested_brake = if forward_aligned || reverse_escape {
+        0.0
+    } else if predictive || escape_assist {
+        config.body_avoidance_turn_brake.clamp(0.0, 0.9)
+    } else {
+        1.0
+    };
+    let intent = ShipIntent {
+        turn: heading.turn,
+        thrust: if forward_aligned {
+            1.0
+        } else if reverse_escape {
+            -1.0
+        } else {
+            0.0
+        },
+        // A stalled escape drops to a partial brake so the turn command can
+        // build angular velocity. A low-health emergency also uses a
+        // rear-aligned reverse burn immediately rather than waiting to point
+        // the nose outward. Pods suppress braking whenever they steer because
+        // releasing their brake is also their thrust.
+        brake: steering_safe_brake(observation.own_ship.form, heading, requested_brake),
+        ..ShipIntent::default()
+    };
+    (intent, heading)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -625,6 +704,65 @@ impl Default for RuleShipBrainConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RuleShipBrainV6Config {
+    pub core: RuleShipBrainConfig,
+    /// Cumulative target-distance improvement that resets the stall timer.
+    pub port_attempt_progress_distance: f32,
+    /// A port phase with no meaningful progress fails after this many ticks.
+    pub port_attempt_stall_ticks: u64,
+    /// Avoiding the target planet must occupy this many phase ticks before
+    /// the attempt is considered obstructed.
+    pub port_attempt_obstruction_ticks: u64,
+    /// Approach and ingress receive this bounded total time when obstruction
+    /// has been observed, even if the moving port occasionally gets closer.
+    pub port_attempt_phase_timeout_ticks: u64,
+    /// A failed target remains unavailable long enough to try another port.
+    pub port_target_cooldown_ticks: u64,
+}
+
+impl Default for RuleShipBrainV6Config {
+    fn default() -> Self {
+        Self {
+            core: RuleShipBrainConfig::default(),
+            port_attempt_progress_distance: 20.0,
+            port_attempt_stall_ticks: 1_800,
+            port_attempt_obstruction_ticks: 600,
+            port_attempt_phase_timeout_ticks: 1_800,
+            port_target_cooldown_ticks: 3_600,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RuleShipBrainV7Config {
+    pub core: RuleShipBrainV6Config,
+    /// Distance used to compare possible exits from overlapping body zones.
+    pub multi_body_escape_lookahead_distance: f32,
+    /// Extra clearance required before a latched escape maneuver is released.
+    pub multi_body_escape_release_margin: f32,
+    /// Angular resolution of the deterministic exit-direction search.
+    pub multi_body_escape_direction_samples: u32,
+    /// Time allowed for repeated nearest-body selection changes to prove that
+    /// independent avoidance commands are oscillating.
+    pub multi_body_escape_switch_window_ticks: u64,
+    /// Selection changes required before V7 replaces V6's single-body route.
+    pub multi_body_escape_switch_count: u32,
+}
+
+impl Default for RuleShipBrainV7Config {
+    fn default() -> Self {
+        Self {
+            core: RuleShipBrainV6Config::default(),
+            multi_body_escape_lookahead_distance: 300.0,
+            multi_body_escape_release_margin: 30.0,
+            multi_body_escape_direction_samples: 32,
+            multi_body_escape_switch_window_ticks: 30,
+            multi_body_escape_switch_count: 2,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum StrategicObjective {
     Rebuild(PlanetId),
@@ -766,6 +904,65 @@ struct PortContactLoss {
     started_tick: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PortAttemptProgress {
+    goal: BrainGoal,
+    planet: PlanetId,
+    phase: PortNavigationPhase,
+    attempt_started_tick: u64,
+    phase_started_tick: u64,
+    last_progress_tick: u64,
+    progress_reference_distance: f32,
+    obstructed_ticks: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PortTargetCooldown {
+    goal: BrainGoal,
+    planet: PlanetId,
+    until_tick: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct MultiBodyThreat {
+    body: AvoidanceBody,
+    local_position: Vec2,
+    surface_clearance: f32,
+    required_clearance: f32,
+}
+
+impl MultiBodyThreat {
+    fn clearance_deficit(self) -> f32 {
+        self.surface_clearance - self.required_clearance
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct MultiBodyEscapePlan {
+    anchors: [AvoidanceBody; 2],
+    direction_offset_radians: f32,
+    started_tick: u64,
+    body_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MultiBodySwitchTracker {
+    started_tick: u64,
+    last_body: AvoidanceBody,
+    switches: u32,
+}
+
+impl PortTargetCooldown {
+    const fn objective(self) -> Option<StrategicObjective> {
+        match self.goal {
+            BrainGoal::Capture => Some(StrategicObjective::Capture(self.planet)),
+            BrainGoal::Repair => Some(StrategicObjective::Repair(self.planet)),
+            BrainGoal::Rebuild => Some(StrategicObjective::Rebuild(self.planet)),
+            _ => None,
+        }
+    }
+}
+
 /// Deterministic first-generation Spacewars opponent.
 ///
 /// It avoids imminent collisions, fights in planet-free worlds, and uses a
@@ -783,6 +980,7 @@ pub struct RuleShipBrainV5 {
     predictive_body_avoidance_plan: Option<PredictiveBodyAvoidancePlan>,
     recent_departure: Option<RecentDeparture>,
     port_contact_loss: Option<PortContactLoss>,
+    objective_exclusions: Vec<StrategicObjective>,
 }
 
 impl RuleShipBrainV5 {
@@ -822,6 +1020,22 @@ impl RuleShipBrainV5 {
     fn weighted_score(utility: f32, weight: f32) -> f32 {
         let score = utility * weight.max(0.0);
         if score.is_finite() { score } else { 0.0 }
+    }
+
+    fn apply_objective_exclusions(
+        &self,
+        candidates: &mut Vec<StrategyCandidate>,
+        scores: &mut StrategyScores,
+    ) {
+        if self.objective_exclusions.is_empty() {
+            return;
+        }
+
+        candidates.retain(|candidate| !self.objective_exclusions.contains(&candidate.objective));
+        *scores = StrategyScores::default();
+        for candidate in candidates {
+            scores.record(candidate.objective.goal(), candidate.score);
+        }
     }
 
     fn opponent_has_neutral_port_priority(
@@ -888,6 +1102,7 @@ impl RuleShipBrainV5 {
                 scores.record(candidate.objective.goal(), candidate.score);
                 candidates.push(candidate);
             }
+            self.apply_objective_exclusions(&mut candidates, &mut scores);
             if candidates.is_empty() {
                 if let Some(opponent) = opponent {
                     let candidate = StrategyCandidate {
@@ -1013,6 +1228,8 @@ impl RuleShipBrainV5 {
             candidates.push(candidate);
         }
 
+        self.apply_objective_exclusions(&mut candidates, &mut scores);
+
         if candidates.is_empty() {
             candidates.push(StrategyCandidate {
                 objective: StrategicObjective::Idle,
@@ -1040,6 +1257,9 @@ impl RuleShipBrainV5 {
         observation: &ShipObservationV1,
         objective: StrategicObjective,
     ) -> bool {
+        if self.objective_exclusions.contains(&objective) {
+            return false;
+        }
         let planet = |target| {
             observation
                 .planets
@@ -1470,6 +1690,31 @@ impl RuleShipBrainV5 {
             && lateral_distance <= self.config.spaceport_corridor_half_width
     }
 
+    fn port_phase_target_distance(
+        &self,
+        observation: &ShipObservationV1,
+        navigation: PortNavigation,
+    ) -> Option<f32> {
+        let planet = observation
+            .planets
+            .iter()
+            .find(|planet| planet.id == navigation.planet)?;
+        let clearance =
+            observation.own_ship.collision_radius + self.config.spaceport_staging_margin;
+        let distance = match navigation.phase {
+            PortNavigationPhase::Rendezvous => planet
+                .moving_surface_approach(-planet.local_position, clearance)
+                .local_position
+                .length(),
+            PortNavigationPhase::Approach => {
+                planet.spaceport_approach(clearance).local_position.length()
+            }
+            PortNavigationPhase::Ingress => planet.local_spaceport_position.length(),
+            PortNavigationPhase::Docked | PortNavigationPhase::Depart => return None,
+        };
+        Some(distance)
+    }
+
     fn body_avoidance(
         &mut self,
         observation: &ShipObservationV1,
@@ -1697,7 +1942,18 @@ impl RuleShipBrainV5 {
         hazard: Option<DebrisId>,
         body_status: Option<BodyAvoidanceStatus>,
     ) -> ShipIntent {
-        let heading = guide_heading(direction, observation.own_ship.angular_velocity);
+        let predictive = body_status.is_some_and(|status| status.avoidance.predictive);
+        let escape_assist = body_status.is_some_and(|status| status.escape_assist);
+        let emergency_escape_assist =
+            body_status.is_some_and(|status| status.emergency_escape_assist);
+        let (intent, heading) = body_escape_controls(
+            self.config,
+            observation,
+            direction,
+            predictive,
+            escape_assist,
+            emergency_escape_assist,
+        );
         let navigation = self.port_navigation;
         self.set_telemetry(
             observation,
@@ -1710,7 +1966,7 @@ impl RuleShipBrainV5 {
                 avoidance_surface_clearance: body_status
                     .map(|status| status.avoidance.surface_clearance),
                 avoidance_outward_speed: body_status.map(|status| status.avoidance.outward_speed),
-                avoidance_predictive: body_status.is_some_and(|status| status.avoidance.predictive),
+                avoidance_predictive: predictive,
                 avoidance_seconds_until_closest: body_status
                     .map(|status| status.avoidance.seconds_until_closest),
                 avoidance_predicted_surface_clearance: body_status
@@ -1721,47 +1977,14 @@ impl RuleShipBrainV5 {
                 avoidance_stalled_ticks: body_status.map_or(0, |status| {
                     observation.tick.saturating_sub(status.last_progress_tick)
                 }),
-                avoidance_escape_assist: body_status.is_some_and(|status| status.escape_assist),
-                avoidance_emergency_escape_assist: body_status
-                    .is_some_and(|status| status.emergency_escape_assist),
+                avoidance_escape_assist: escape_assist,
+                avoidance_emergency_escape_assist: emergency_escape_assist,
                 target_distance: direction.length(),
                 heading_error: heading.error_radians,
                 ..BrainTelemetry::default()
             },
         );
-        let heading_error = heading.error_radians.abs();
-        let predictive = body_status.is_some_and(|status| status.avoidance.predictive);
-        // A forecast maneuver should shed velocity while establishing its
-        // tangent instead of accelerating merely because the desired heading
-        // is within the broader emergency-escape cone.
-        let forward_aligned = heading_error < if predictive { 0.2 } else { 0.65 };
-        let reverse_escape = observation.own_ship.form == ShipForm::Ship
-            && body_status.is_some_and(|status| status.emergency_escape_assist)
-            && PI - heading_error < 0.65;
-        let requested_brake = if forward_aligned || reverse_escape {
-            0.0
-        } else if predictive || body_status.is_some_and(|status| status.escape_assist) {
-            self.config.body_avoidance_turn_brake.clamp(0.0, 0.9)
-        } else {
-            1.0
-        };
-        ShipIntent {
-            turn: heading.turn,
-            thrust: if forward_aligned {
-                1.0
-            } else if reverse_escape {
-                -1.0
-            } else {
-                0.0
-            },
-            // A stalled escape drops to a partial brake so the turn command
-            // can build angular velocity. A low-health emergency also uses a
-            // rear-aligned reverse burn immediately rather than waiting to
-            // point the nose outward. Pods suppress braking whenever they
-            // steer because releasing their brake is also their thrust.
-            brake: steering_safe_brake(observation.own_ship.form, heading, requested_brake),
-            ..ShipIntent::default()
-        }
+        intent
     }
 
     fn docked_intent(
@@ -2089,6 +2312,7 @@ impl ShipBrain for RuleShipBrainV5 {
         self.predictive_body_avoidance_plan = None;
         self.recent_departure = None;
         self.port_contact_loss = None;
+        self.objective_exclusions.clear();
         self.telemetry = BrainTelemetry {
             actor: self.actor,
             ..BrainTelemetry::default()
@@ -2220,6 +2444,604 @@ impl ShipBrain for RuleShipBrainV5 {
 
     fn telemetry(&self) -> BrainTelemetry {
         self.telemetry
+    }
+}
+
+/// Candidate rule policy that adds bounded port-attempt replanning above the
+/// unchanged v5 strategy and guidance implementation.
+#[derive(Debug, Clone)]
+pub struct RuleShipBrainV6 {
+    config: RuleShipBrainV6Config,
+    inner: RuleShipBrainV5,
+    port_attempt: Option<PortAttemptProgress>,
+    port_target_cooldowns: Vec<PortTargetCooldown>,
+    port_replan_count: u64,
+}
+
+impl Default for RuleShipBrainV6 {
+    fn default() -> Self {
+        Self::new(RuleShipBrainV6Config::default())
+    }
+}
+
+impl RuleShipBrainV6 {
+    pub fn new(config: RuleShipBrainV6Config) -> Self {
+        Self {
+            inner: RuleShipBrainV5::new(config.core),
+            config,
+            port_attempt: None,
+            port_target_cooldowns: Vec::new(),
+            port_replan_count: 0,
+        }
+    }
+
+    fn prune_port_target_cooldowns(&mut self, tick: u64) {
+        self.port_target_cooldowns
+            .retain(|cooldown| tick < cooldown.until_tick);
+    }
+
+    fn sync_objective_exclusions(&mut self) {
+        self.inner.objective_exclusions.clear();
+        self.inner.objective_exclusions.extend(
+            self.port_target_cooldowns
+                .iter()
+                .filter_map(|cooldown| cooldown.objective()),
+        );
+    }
+
+    fn sync_port_attempt(
+        &mut self,
+        observation: &ShipObservationV1,
+        preceding_avoided_body: Option<AvoidanceBody>,
+    ) {
+        let Some(navigation) = self.inner.port_navigation.filter(|navigation| {
+            matches!(
+                navigation.phase,
+                PortNavigationPhase::Rendezvous
+                    | PortNavigationPhase::Approach
+                    | PortNavigationPhase::Ingress
+            )
+        }) else {
+            self.port_attempt = None;
+            return;
+        };
+        let Some(target_distance) = self
+            .inner
+            .port_phase_target_distance(observation, navigation)
+        else {
+            self.port_attempt = None;
+            return;
+        };
+
+        let same_target = self.port_attempt.is_some_and(|attempt| {
+            attempt.goal == navigation.goal && attempt.planet == navigation.planet
+        });
+        if !same_target {
+            self.port_attempt = Some(PortAttemptProgress {
+                goal: navigation.goal,
+                planet: navigation.planet,
+                phase: navigation.phase,
+                attempt_started_tick: observation.tick,
+                phase_started_tick: observation.tick,
+                last_progress_tick: observation.tick,
+                progress_reference_distance: target_distance,
+                obstructed_ticks: 0,
+            });
+            return;
+        }
+
+        let attempt = self.port_attempt.as_mut().unwrap();
+        if attempt.phase != navigation.phase {
+            attempt.phase = navigation.phase;
+            attempt.phase_started_tick = observation.tick;
+            attempt.last_progress_tick = observation.tick;
+            attempt.progress_reference_distance = target_distance;
+            attempt.obstructed_ticks = 0;
+            return;
+        }
+
+        let progress_distance = self.config.port_attempt_progress_distance.max(0.0);
+        if target_distance <= attempt.progress_reference_distance - progress_distance {
+            attempt.progress_reference_distance = target_distance;
+            attempt.last_progress_tick = observation.tick;
+        }
+        if preceding_avoided_body == Some(AvoidanceBody::Planet(navigation.planet)) {
+            attempt.obstructed_ticks = attempt.obstructed_ticks.saturating_add(1);
+        }
+    }
+
+    fn best_alternative_port(
+        &self,
+        observation: &ShipObservationV1,
+        failed_attempt: PortAttemptProgress,
+    ) -> Option<(StrategyCandidate, StrategyScores)> {
+        let (mut candidates, _) = self.inner.strategy_candidates(observation);
+        let failed_objective = PortTargetCooldown {
+            goal: failed_attempt.goal,
+            planet: failed_attempt.planet,
+            until_tick: observation.tick,
+        }
+        .objective()?;
+        candidates.retain(|candidate| candidate.objective != failed_objective);
+        let mut scores = StrategyScores::default();
+        for candidate in &candidates {
+            scores.record(candidate.objective.goal(), candidate.score);
+        }
+        let mut best: Option<StrategyCandidate> = None;
+        for candidate in candidates.into_iter().filter(|candidate| {
+            candidate
+                .objective
+                .port_goal()
+                .is_some_and(|(goal, planet)| {
+                    goal == failed_attempt.goal && planet != failed_attempt.planet
+                })
+        }) {
+            let replace = best.is_none_or(|current| {
+                candidate.score.total_cmp(&current.score).is_gt()
+                    || (candidate.score.total_cmp(&current.score).is_eq()
+                        && candidate.objective < current.objective)
+            });
+            if replace {
+                best = Some(candidate);
+            }
+        }
+        best.map(|candidate| (candidate, scores))
+    }
+
+    fn should_replan_port(
+        &self,
+        observation: &ShipObservationV1,
+    ) -> Option<(PortAttemptProgress, StrategyCandidate, StrategyScores)> {
+        let attempt = self.port_attempt?;
+        let repeatedly_obstructed =
+            attempt.obstructed_ticks >= self.config.port_attempt_obstruction_ticks;
+        let stalled = observation.tick.saturating_sub(attempt.last_progress_tick)
+            >= self.config.port_attempt_stall_ticks
+            && repeatedly_obstructed;
+        let terminal_phase_timed_out =
+            matches!(
+                attempt.phase,
+                PortNavigationPhase::Approach | PortNavigationPhase::Ingress
+            ) && observation.tick.saturating_sub(attempt.phase_started_tick)
+                >= self.config.port_attempt_phase_timeout_ticks
+                && repeatedly_obstructed;
+        if !stalled && !terminal_phase_timed_out {
+            return None;
+        }
+        self.best_alternative_port(observation, attempt)
+            .map(|(candidate, scores)| (attempt, candidate, scores))
+    }
+
+    fn replan_port(
+        &mut self,
+        observation: &ShipObservationV1,
+        failed_attempt: PortAttemptProgress,
+        candidate: StrategyCandidate,
+        scores: StrategyScores,
+    ) {
+        let until_tick = observation
+            .tick
+            .saturating_add(self.config.port_target_cooldown_ticks);
+        if let Some(cooldown) = self.port_target_cooldowns.iter_mut().find(|cooldown| {
+            cooldown.goal == failed_attempt.goal && cooldown.planet == failed_attempt.planet
+        }) {
+            cooldown.until_tick = cooldown.until_tick.max(until_tick);
+        } else {
+            self.port_target_cooldowns.push(PortTargetCooldown {
+                goal: failed_attempt.goal,
+                planet: failed_attempt.planet,
+                until_tick,
+            });
+        }
+        self.sync_objective_exclusions();
+        self.inner.strategy = Some(StrategyState {
+            objective: candidate.objective,
+            selected_score: candidate.score,
+            scores,
+            selected_at_tick: observation.tick,
+            last_evaluated_tick: observation.tick,
+            selection_reason: StrategySelectionReason::TargetCooldown,
+        });
+        self.inner.port_navigation = None;
+        self.inner.port_contact_loss = None;
+        self.port_attempt = None;
+        self.port_replan_count = self.port_replan_count.saturating_add(1);
+    }
+
+    fn decorate_telemetry(&mut self, tick: u64) {
+        let mut telemetry = self.inner.telemetry;
+        if let Some(attempt) = self.port_attempt {
+            telemetry.port_attempt_age_ticks = tick.saturating_sub(attempt.attempt_started_tick);
+            telemetry.port_attempt_stalled_ticks = tick.saturating_sub(attempt.last_progress_tick);
+            telemetry.port_attempt_obstructed_ticks = attempt.obstructed_ticks;
+        }
+        telemetry.port_replan_count = self.port_replan_count;
+        if let Some(cooldown) = self
+            .port_target_cooldowns
+            .iter()
+            .max_by_key(|cooldown| cooldown.until_tick)
+        {
+            telemetry.cooled_port_planet = Some(cooldown.planet);
+            telemetry.port_cooldown_remaining_ticks = cooldown.until_tick.saturating_sub(tick);
+        }
+        self.inner.telemetry = telemetry;
+    }
+}
+
+impl ShipBrain for RuleShipBrainV6 {
+    fn descriptor(&self) -> ShipBrainDescriptor {
+        BuiltInPolicy::RuleV6.descriptor()
+    }
+
+    fn reset(&mut self, reset: BrainReset) {
+        self.inner.reset(reset);
+        self.port_attempt = None;
+        self.port_target_cooldowns.clear();
+        self.port_replan_count = 0;
+    }
+
+    fn intent(&mut self, observation: &ShipObservationV1) -> ShipIntent {
+        self.prune_port_target_cooldowns(observation.tick);
+        self.sync_objective_exclusions();
+        let preceding_avoided_body = self.inner.telemetry.avoided_body;
+        self.sync_port_attempt(observation, preceding_avoided_body);
+        if let Some((failed_attempt, candidate, scores)) = self.should_replan_port(observation) {
+            self.replan_port(observation, failed_attempt, candidate, scores);
+        }
+
+        let intent = self.inner.intent(observation);
+        // The core may have selected a target or advanced a phase this tick.
+        // Initialize that state without double-counting the preceding action's
+        // obstruction sample.
+        self.sync_port_attempt(observation, None);
+        self.decorate_telemetry(observation.tick);
+        intent
+    }
+
+    fn telemetry(&self) -> BrainTelemetry {
+        self.inner.telemetry()
+    }
+}
+
+/// Candidate rule policy that keeps v6 strategy and port replanning, then
+/// adds a persistent exit route when multiple celestial bodies demand
+/// contradictory avoidance commands at the same time.
+#[derive(Debug, Clone)]
+pub struct RuleShipBrainV7 {
+    config: RuleShipBrainV7Config,
+    inner: RuleShipBrainV6,
+    multi_body_escape_plan: Option<MultiBodyEscapePlan>,
+    multi_body_switch_tracker: Option<MultiBodySwitchTracker>,
+    multi_body_escape_activations: u64,
+}
+
+impl Default for RuleShipBrainV7 {
+    fn default() -> Self {
+        Self::new(RuleShipBrainV7Config::default())
+    }
+}
+
+impl RuleShipBrainV7 {
+    pub fn new(config: RuleShipBrainV7Config) -> Self {
+        Self {
+            inner: RuleShipBrainV6::new(config.core),
+            config,
+            multi_body_escape_plan: None,
+            multi_body_switch_tracker: None,
+            multi_body_escape_activations: 0,
+        }
+    }
+
+    fn body_local_position(observation: &ShipObservationV1, body: AvoidanceBody) -> Option<Vec2> {
+        match body {
+            AvoidanceBody::Sun => observation.sun.map(|sun| sun.local_position),
+            AvoidanceBody::Planet(id) => observation
+                .planets
+                .iter()
+                .find(|planet| planet.id == id)
+                .map(|planet| planet.local_position),
+        }
+    }
+
+    fn body_threats(
+        &self,
+        observation: &ShipObservationV1,
+        retain_latched_plan: bool,
+    ) -> Vec<MultiBodyThreat> {
+        let core = self.config.core.core;
+        let navigation = self.inner.inner.port_navigation;
+        let release_margin = if retain_latched_plan {
+            self.config.multi_body_escape_release_margin.max(0.0)
+        } else {
+            0.0
+        };
+        let mut threats = Vec::new();
+        let mut consider = |body: AvoidanceBody,
+                            local_position: Vec2,
+                            local_velocity: Vec2,
+                            radius: f32,
+                            required_clearance: f32| {
+            let surface_clearance =
+                local_position.length() - radius - observation.own_ship.collision_radius;
+            let outward_speed = if local_position.length_squared() > TARGET_EPSILON {
+                local_position.normalized().dot(local_velocity)
+            } else {
+                0.0
+            };
+            let relevant = if retain_latched_plan {
+                surface_clearance <= required_clearance + release_margin
+            } else {
+                surface_clearance <= required_clearance
+                    && !(outward_speed >= 0.0 && surface_clearance > required_clearance * 0.35)
+            };
+            if relevant {
+                threats.push(MultiBodyThreat {
+                    body,
+                    local_position,
+                    surface_clearance,
+                    required_clearance,
+                });
+            }
+        };
+
+        if let Some(sun) = observation.sun {
+            consider(
+                AvoidanceBody::Sun,
+                sun.local_position,
+                sun.local_velocity,
+                sun.radius,
+                core.body_clearance,
+            );
+        }
+        for planet in &observation.planets {
+            let target_navigation = navigation.filter(|navigation| navigation.planet == planet.id);
+            let required_clearance = if let Some(target_navigation) = target_navigation {
+                if target_navigation.phase != PortNavigationPhase::Rendezvous
+                    && self
+                        .inner
+                        .inner
+                        .port_corridor_contains_ship(observation, planet)
+                {
+                    continue;
+                }
+                core.spaceport_staging_margin
+            } else {
+                core.body_clearance
+            };
+            consider(
+                AvoidanceBody::Planet(planet.id),
+                planet.local_position,
+                planet.local_velocity,
+                planet.radius,
+                required_clearance,
+            );
+        }
+        threats.sort_by(|left, right| {
+            left.clearance_deficit()
+                .total_cmp(&right.clearance_deficit())
+                .then_with(|| left.body.cmp(&right.body))
+        });
+        threats
+    }
+
+    fn observe_multi_body_switches(
+        &mut self,
+        tick: u64,
+        selected_body: Option<AvoidanceBody>,
+    ) -> bool {
+        let Some(selected_body) = selected_body else {
+            self.multi_body_switch_tracker = None;
+            return false;
+        };
+        let window_ticks = self.config.multi_body_escape_switch_window_ticks.max(1);
+        let mut tracker = self
+            .multi_body_switch_tracker
+            .filter(|tracker| tick.saturating_sub(tracker.started_tick) <= window_ticks)
+            .unwrap_or(MultiBodySwitchTracker {
+                started_tick: tick,
+                last_body: selected_body,
+                switches: 0,
+            });
+        if tracker.last_body != selected_body {
+            tracker.last_body = selected_body;
+            tracker.switches = tracker.switches.saturating_add(1);
+        }
+        let triggered = tracker.switches >= self.config.multi_body_escape_switch_count.max(1);
+        self.multi_body_switch_tracker = if triggered { None } else { Some(tracker) };
+        triggered
+    }
+
+    fn select_escape_plan(
+        &self,
+        observation: &ShipObservationV1,
+        threats: &[MultiBodyThreat],
+    ) -> Option<MultiBodyEscapePlan> {
+        let [first, second, ..] = threats else {
+            return None;
+        };
+        let anchors = [first.body, second.body];
+        let anchor_axis = (second.local_position - first.local_position).normalized();
+        let anchor_axis = if anchor_axis.length_squared() > TARGET_EPSILON {
+            anchor_axis
+        } else {
+            Vec2::X
+        };
+        let lookahead = self.config.multi_body_escape_lookahead_distance.max(1.0);
+        let sample_count = self
+            .config
+            .multi_body_escape_direction_samples
+            .clamp(8, 128);
+        let current_travel =
+            if observation.own_ship.local_velocity.length_squared() > TARGET_EPSILON {
+                observation.own_ship.local_velocity.normalized()
+            } else {
+                Vec2::Y
+            };
+        let mut selected: Option<(f32, f32, f32, u32)> = None;
+        for sample in 0..sample_count {
+            let offset = 2.0 * PI * sample as f32 / sample_count as f32;
+            let direction = anchor_axis.rotate_radians(offset);
+            let mut minimum_margin = f32::INFINITY;
+            let mut margin_sum = 0.0;
+            for threat in threats {
+                let body_and_ship_radius =
+                    threat.local_position.length() - threat.surface_clearance;
+                let predicted_surface_clearance =
+                    (threat.local_position - direction * lookahead).length() - body_and_ship_radius;
+                let margin = predicted_surface_clearance - threat.required_clearance;
+                minimum_margin = minimum_margin.min(margin);
+                margin_sum += margin;
+            }
+            let average_margin = margin_sum / threats.len() as f32;
+            let travel_alignment = direction.dot(current_travel);
+            let candidate = (minimum_margin, average_margin, travel_alignment, sample);
+            let replaces = selected.is_none_or(|best| {
+                candidate
+                    .0
+                    .total_cmp(&best.0)
+                    .then_with(|| candidate.1.total_cmp(&best.1))
+                    .then_with(|| candidate.2.total_cmp(&best.2))
+                    .then_with(|| best.3.cmp(&candidate.3))
+                    .is_gt()
+            });
+            if replaces {
+                selected = Some(candidate);
+            }
+        }
+        let (_, _, _, sample) = selected?;
+        Some(MultiBodyEscapePlan {
+            anchors,
+            direction_offset_radians: 2.0 * PI * sample as f32 / sample_count as f32,
+            started_tick: observation.tick,
+            body_count: u32::try_from(threats.len()).unwrap_or(u32::MAX),
+        })
+    }
+
+    fn escape_direction(
+        observation: &ShipObservationV1,
+        plan: MultiBodyEscapePlan,
+        magnitude: f32,
+    ) -> Option<Vec2> {
+        let first = Self::body_local_position(observation, plan.anchors[0])?;
+        let second = Self::body_local_position(observation, plan.anchors[1])?;
+        let anchor_axis = (second - first).normalized();
+        let anchor_axis = if anchor_axis.length_squared() > TARGET_EPSILON {
+            anchor_axis
+        } else {
+            Vec2::X
+        };
+        Some(anchor_axis.rotate_radians(plan.direction_offset_radians) * magnitude.max(1.0))
+    }
+
+    fn decorate_telemetry(
+        &mut self,
+        observation: &ShipObservationV1,
+        direction: Option<Vec2>,
+        heading: Option<HeadingGuidance>,
+    ) {
+        let telemetry = &mut self.inner.inner.telemetry;
+        telemetry.multi_body_escape_active = self.multi_body_escape_plan.is_some();
+        telemetry.multi_body_escape_age_ticks = self
+            .multi_body_escape_plan
+            .map_or(0, |plan| observation.tick.saturating_sub(plan.started_tick));
+        telemetry.multi_body_escape_body_count = self
+            .multi_body_escape_plan
+            .map_or(0, |plan| plan.body_count);
+        telemetry.multi_body_escape_activations = self.multi_body_escape_activations;
+        if let Some(direction) = direction {
+            telemetry.goal = BrainGoal::AvoidBody;
+            telemetry.target_distance = direction.length();
+        }
+        if let Some(heading) = heading {
+            telemetry.heading_error = heading.error_radians;
+        }
+    }
+}
+
+impl ShipBrain for RuleShipBrainV7 {
+    fn descriptor(&self) -> ShipBrainDescriptor {
+        BuiltInPolicy::RuleV7.descriptor()
+    }
+
+    fn reset(&mut self, reset: BrainReset) {
+        self.inner.reset(reset);
+        self.multi_body_escape_plan = None;
+        self.multi_body_switch_tracker = None;
+        self.multi_body_escape_activations = 0;
+    }
+
+    fn intent(&mut self, observation: &ShipObservationV1) -> ShipIntent {
+        let inherited_intent = self.inner.intent(observation);
+        let inherited_telemetry = self.inner.telemetry();
+        let atomic_port_maneuver = matches!(
+            inherited_telemetry.port_phase,
+            Some(PortNavigationPhase::Docked | PortNavigationPhase::Depart)
+        );
+        if observation.own_ship.eliminated
+            || observation.own_ship.docked_planet.is_some()
+            || atomic_port_maneuver
+        {
+            self.multi_body_escape_plan = None;
+            self.multi_body_switch_tracker = None;
+            self.decorate_telemetry(observation, None, None);
+            return inherited_intent;
+        }
+
+        if let Some(plan) = self.multi_body_escape_plan {
+            let retained = self.body_threats(observation, true);
+            let tracked_body_remains = retained
+                .iter()
+                .any(|threat| plan.anchors.contains(&threat.body));
+            if !tracked_body_remains {
+                self.multi_body_escape_plan = None;
+                self.multi_body_switch_tracker = None;
+            }
+        }
+        if self.multi_body_escape_plan.is_none() && inherited_telemetry.goal == BrainGoal::AvoidBody
+        {
+            let threats = self.body_threats(observation, false);
+            let selected_body = inherited_telemetry
+                .avoided_body
+                .filter(|body| threats.iter().any(|threat| threat.body == *body));
+            let oscillating = threats.len() >= 2
+                && self.observe_multi_body_switches(observation.tick, selected_body);
+            if oscillating && let Some(plan) = self.select_escape_plan(observation, &threats) {
+                self.multi_body_escape_plan = Some(plan);
+                self.multi_body_escape_activations =
+                    self.multi_body_escape_activations.saturating_add(1);
+            }
+        } else if self.multi_body_escape_plan.is_none() {
+            self.multi_body_switch_tracker = None;
+        }
+
+        let Some(plan) = self.multi_body_escape_plan else {
+            self.decorate_telemetry(observation, None, None);
+            return inherited_intent;
+        };
+        let Some(direction) = Self::escape_direction(
+            observation,
+            plan,
+            self.config.multi_body_escape_lookahead_distance,
+        ) else {
+            self.multi_body_escape_plan = None;
+            self.multi_body_switch_tracker = None;
+            self.decorate_telemetry(observation, None, None);
+            return inherited_intent;
+        };
+        let (intent, heading) = body_escape_controls(
+            self.config.core.core,
+            observation,
+            direction,
+            false,
+            inherited_telemetry.avoidance_escape_assist,
+            inherited_telemetry.avoidance_emergency_escape_assist,
+        );
+        self.decorate_telemetry(observation, Some(direction), Some(heading));
+        intent
+    }
+
+    fn telemetry(&self) -> BrainTelemetry {
+        self.inner.telemetry()
     }
 }
 
@@ -4281,6 +5103,308 @@ mod tests {
             "brain did not select another uncaptured planet after departure; final telemetry: {:?}",
             brain.telemetry()
         );
+    }
+
+    #[test]
+    fn v6_preserves_seed_four_slow_but_successful_port_approach() {
+        let mut config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            use_starfield: false,
+            use_sounds: false,
+            ..SpacewarsConfig::default()
+        };
+        for player in &mut config.players {
+            player.health_percent = 100_000;
+        }
+        let mut state = SpacewarsScenario::init(config, 4);
+        let obstructed_planet = PlanetId::from_index(3).unwrap();
+        let mut brain = RuleShipBrainV6::default();
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+        let mut encoder = ShipIntentEncoder::default();
+        let mut saw_approach = false;
+        let mut saw_target_avoidance = false;
+        let mut maximum_avoidance_stall = 0;
+        let mut saw_docked = false;
+
+        for _ in 0..2_300 {
+            let observation = SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap();
+            let intent = brain.intent(&observation);
+            let telemetry = brain.telemetry();
+            saw_approach |= telemetry.target_planet == Some(obstructed_planet)
+                && telemetry.port_phase == Some(PortNavigationPhase::Approach);
+            saw_target_avoidance |=
+                telemetry.avoided_body == Some(AvoidanceBody::Planet(obstructed_planet));
+            maximum_avoidance_stall =
+                maximum_avoidance_stall.max(telemetry.avoidance_stalled_ticks);
+            saw_docked |= telemetry.target_planet == Some(obstructed_planet)
+                && telemetry.port_phase == Some(PortNavigationPhase::Docked);
+            if saw_docked {
+                break;
+            }
+
+            let actions = encoder.encode(PlayerId::PLAYER_2.index(), intent);
+            SpacewarsScenario::step(&mut state, &actions, DT);
+        }
+
+        assert!(saw_approach, "seed 4 never entered the known approach");
+        assert!(
+            saw_target_avoidance,
+            "seed 4 never reproduced target-planet avoidance"
+        );
+        assert!(
+            maximum_avoidance_stall >= 600,
+            "seed 4 did not reproduce the sustained obstruction; maximum stall {maximum_avoidance_stall}"
+        );
+        assert!(saw_docked, "V6 abandoned an approach that V5 can complete");
+        assert_eq!(brain.telemetry().port_replan_count, 0);
+        assert_eq!(brain.telemetry().cooled_port_planet, None);
+    }
+
+    #[test]
+    fn v6_cools_a_repeatedly_obstructed_capture_target() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 8);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.sun = None;
+        observation.opponent = None;
+        observation.hazards.clear();
+        observation.planets.truncate(2);
+        let collision_radius = observation.own_ship.collision_radius;
+        for (index, planet) in observation.planets.iter_mut().enumerate() {
+            planet.owner = None;
+            planet.local_velocity = Vec2::ZERO;
+            planet.local_spaceport_velocity = Vec2::ZERO;
+            let distance = if index == 0 {
+                planet.radius + collision_radius + 5.0
+            } else {
+                2_000.0
+            };
+            planet.local_position = Vec2::X * distance;
+            planet.local_spaceport_position = planet.local_position + Vec2::Y * planet.radius;
+        }
+        let obstructed_planet = observation.planets[0].id;
+        let alternative_planet = observation.planets[1].id;
+        let brain_config = RuleShipBrainV6Config {
+            port_attempt_stall_ticks: 3,
+            port_attempt_obstruction_ticks: 2,
+            port_attempt_phase_timeout_ticks: 3,
+            port_target_cooldown_ticks: 20,
+            ..RuleShipBrainV6Config::default()
+        };
+        let mut brain = RuleShipBrainV6::new(brain_config);
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        for tick in 0..=3 {
+            observation.tick = tick;
+            let _ = brain.intent(&observation);
+        }
+
+        let telemetry = brain.telemetry();
+        assert_eq!(telemetry.port_replan_count, 1);
+        assert_eq!(telemetry.cooled_port_planet, Some(obstructed_planet));
+        assert_eq!(
+            telemetry.strategy.selection_reason,
+            Some(StrategySelectionReason::TargetCooldown)
+        );
+        assert_eq!(telemetry.strategy.target_planet, Some(alternative_planet));
+    }
+
+    #[test]
+    fn v6_does_not_abandon_the_only_rebuild_port() {
+        let config = SpacewarsConfig {
+            asteroid_probability_per_sec: 0.0,
+            ..SpacewarsConfig::default()
+        };
+        let state = SpacewarsScenario::init(config, 4);
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.sun = None;
+        observation.opponent = None;
+        observation.hazards.clear();
+        observation.planets.truncate(1);
+        observation.planets[0].owner = Some(PlayerId::PLAYER_2);
+        observation.own_ship.form = ShipForm::EscapePod;
+        let only_port = observation.planets[0].id;
+        let brain_config = RuleShipBrainV6Config {
+            port_attempt_stall_ticks: 1,
+            ..RuleShipBrainV6Config::default()
+        };
+        let mut brain = RuleShipBrainV6::new(brain_config);
+        brain.reset(BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        });
+
+        let _ = brain.intent(&observation);
+        observation.tick += 1;
+        let _ = brain.intent(&observation);
+
+        let telemetry = brain.telemetry();
+        assert_eq!(telemetry.strategy.goal, StrategicGoal::Rebuild);
+        assert_eq!(telemetry.strategy.target_planet, Some(only_port));
+        assert_eq!(telemetry.port_replan_count, 0);
+        assert_eq!(telemetry.cooled_port_planet, None);
+    }
+
+    #[test]
+    fn v7_latches_one_exit_route_across_alternating_overlapping_bodies() {
+        let state = SpacewarsScenario::init(
+            SpacewarsConfig {
+                asteroid_probability_per_sec: 0.0,
+                ..SpacewarsConfig::default()
+            },
+            52,
+        );
+        let mut observation = SpacewarsScenario::observe_ship(
+            &state,
+            PlayerId::PLAYER_2,
+            ShipSensorProfile::FullMapRadar,
+        )
+        .unwrap();
+        observation.hazards.clear();
+        observation.planets.truncate(1);
+        observation.own_ship.local_velocity = Vec2::ZERO;
+        observation.own_ship.angular_velocity = 0.0;
+        let ship_radius = observation.own_ship.collision_radius;
+        let body_radius = 100.0;
+        let planet_id = observation.planets[0].id;
+        let planet = &mut observation.planets[0];
+        planet.radius = body_radius;
+        planet.owner = Some(PlayerId::PLAYER_1);
+        planet.capturing_player = None;
+        planet.local_velocity = Vec2::ZERO;
+        planet.local_spaceport_velocity = Vec2::ZERO;
+        let sun = observation
+            .sun
+            .as_mut()
+            .expect("standard worlds have a sun");
+        sun.radius = body_radius;
+        sun.local_velocity = Vec2::ZERO;
+
+        let mut v6 = RuleShipBrainV6::default();
+        let mut v7 = RuleShipBrainV7::default();
+        let reset = BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        };
+        v6.reset(reset);
+        v7.reset(reset);
+        let mut preceding_body = None;
+        let mut v6_body_switches = 0;
+        let mut v7_turn = None;
+
+        for tick in 0..8 {
+            observation.tick = tick;
+            let (sun_clearance, planet_clearance) = if tick % 2 == 0 {
+                (5.0, 6.0)
+            } else {
+                (6.0, 5.0)
+            };
+            observation.sun.as_mut().unwrap().local_position =
+                -Vec2::X * (body_radius + ship_radius + sun_clearance);
+            let planet = &mut observation.planets[0];
+            planet.local_position = Vec2::X * (body_radius + ship_radius + planet_clearance);
+            planet.local_spaceport_position = planet.local_position + Vec2::Y * body_radius;
+
+            let _ = v6.intent(&observation);
+            let avoided_body = v6.telemetry().avoided_body;
+            if preceding_body.is_some() && preceding_body != avoided_body {
+                v6_body_switches += 1;
+            }
+            preceding_body = avoided_body;
+
+            let v7_intent = v7.intent(&observation);
+            let telemetry = v7.telemetry();
+            if tick < 2 {
+                assert!(!telemetry.multi_body_escape_active);
+                assert_eq!(telemetry.multi_body_escape_activations, 0);
+            } else {
+                assert!(telemetry.multi_body_escape_active);
+                assert_eq!(telemetry.multi_body_escape_body_count, 2);
+                assert_eq!(telemetry.multi_body_escape_activations, 1);
+                if let Some(expected_turn) = v7_turn {
+                    assert_close(v7_intent.turn, expected_turn);
+                } else {
+                    v7_turn = Some(v7_intent.turn);
+                }
+                assert_eq!(v7_intent.thrust, 1.0);
+            }
+        }
+
+        assert_eq!(v6_body_switches, 7);
+        assert_eq!(preceding_body, Some(AvoidanceBody::Planet(planet_id)));
+
+        observation.tick = 8;
+        let released_clearance = RuleShipBrainConfig::default().body_clearance
+            + RuleShipBrainV7Config::default().multi_body_escape_release_margin
+            + 1.0;
+        observation.sun.as_mut().unwrap().local_position =
+            -Vec2::X * (body_radius + ship_radius + released_clearance);
+        let _ = v7.intent(&observation);
+
+        assert!(v7.telemetry().multi_body_escape_active);
+
+        observation.tick = 9;
+        observation.planets[0].local_position =
+            Vec2::X * (body_radius + ship_radius + released_clearance);
+        let _ = v7.intent(&observation);
+
+        assert!(!v7.telemetry().multi_body_escape_active);
+        assert_eq!(v7.telemetry().multi_body_escape_activations, 1);
+    }
+
+    #[test]
+    fn v7_delegates_exactly_to_v6_without_multi_body_oscillation() {
+        let mut state = SpacewarsScenario::init(SpacewarsConfig::deathmatch(), 53);
+        let reset = BrainReset {
+            actor: PlayerId::PLAYER_2,
+            episode_seed: state.seed,
+        };
+        let mut v6 = RuleShipBrainV6::default();
+        let mut v7 = RuleShipBrainV7::default();
+        let mut encoder = ShipIntentEncoder::default();
+        v6.reset(reset);
+        v7.reset(reset);
+
+        for _ in 0..300 {
+            let observation = SpacewarsScenario::observe_ship(
+                &state,
+                PlayerId::PLAYER_2,
+                ShipSensorProfile::FullMapRadar,
+            )
+            .unwrap();
+            let v6_intent = v6.intent(&observation);
+            let v7_intent = v7.intent(&observation);
+
+            assert_eq!(v7_intent, v6_intent);
+            assert_eq!(v7.telemetry(), v6.telemetry());
+
+            let actions = encoder.encode(PlayerId::PLAYER_2.index(), v6_intent);
+            SpacewarsScenario::step(&mut state, &actions, DT);
+        }
     }
 
     #[test]

--- a/docs/design/ship-ai.md
+++ b/docs/design/ship-ai.md
@@ -65,8 +65,9 @@ version.
 - `intent(&ShipObservationV1)` produces one normalized controller intent;
 - `telemetry()` reports the current goal, target, hazard, avoided celestial
   body, surface clearance, outward speed, predicted closest approach,
-  avoidance age/stall state, range, and heading error without granting state
-  access.
+  avoidance age/stall state, port-attempt progress and cooldown state,
+  multi-body escape state and cumulative activations, range, and heading error
+  without granting state access.
 
 When a host changes between human, rule-bot, or benchmark control, it forwards
 one neutral intent before the new source. This releases held thrust and weapons
@@ -77,16 +78,20 @@ clears the encoder, brain context, and active source.
 
 `BuiltInPolicy` is the common registry used by interactive and headless hosts.
 Each entry creates a boxed `ShipBrain`, and every concrete brain reports its
-own `ShipBrainDescriptor`. The first retained implementation is
-`RuleShipBrainV5`, registered as `rule_ship_v5`. Adding v6 means adding a new
-type and registry entry while leaving v5 constructible; it does not mean adding
-version switches inside v5.
+own `ShipBrainDescriptor`. The retained implementations are
+`RuleShipBrainV5`, registered as `rule_ship_v5`, and the bounded port-replanning
+candidate `RuleShipBrainV6`, registered as `rule_ship_v6`, plus the persistent
+multi-body escape candidate `RuleShipBrainV7`, registered as `rule_ship_v7`.
+V6 composes V5, and V7 in turn composes V6; each layer adds state above its
+predecessor. Older versions remain independently constructible and have no
+runtime version switch.
 
 The interactive launcher follows `DEFAULT_BUILT_IN_POLICY`, which is the
-meaning of the convenient `rule` selection. Reproducible evaluator inputs use
-the explicit `rule-v5` selection. Named suites such as `navigation-v1` and
-`strategy-v1` are permanently pinned to that concrete version and never follow
-the default alias. Episode artifacts obtain their policy ID from the
+meaning of the convenient `rule` selection. It remains pinned to V5 while V6
+and V7 are evaluated. Reproducible evaluator inputs use the explicit
+`rule-v5`, `rule-v6`, or `rule-v7` selection. Named suites such as
+`navigation-v1` and `strategy-v1` are permanently pinned to V5 and never
+follow the default alias. Episode artifacts obtain their policy ID from the
 instantiated brain, so the recorded identity cannot silently drift away from
 the implementation that emitted the actions.
 
@@ -105,12 +110,12 @@ policy IDs, workload settings, canonical actions, terminal tick, and selected
 terminal state. Wall time is deliberately excluded.
 
 `PolicyComparisonProfile` separates a reusable world workload from the
-controllers installed in it. The strategy-v1 profile runs every seed twice,
-swapping baseline and candidate seats, and aggregates results by comparison
-role rather than player number or policy ID. Keeping the roles separate also
-makes a v5-versus-v5 run a useful symmetry check. Once v6 exists, the same path
-can compare v5 and v6 without altering either historical suite or assembling a
-manual command matrix.
+controllers installed in it. The navigation-v1 and strategy-v1 profiles run
+every seed twice, swapping baseline and candidate seats, and aggregate results
+by comparison role rather than player number or policy ID. Keeping the roles
+separate also makes a v5-versus-v5 run a useful symmetry check. The same path
+compares V5, V6, and V7 without altering either historical suite or assembling
+a manual command matrix.
 
 The intended contribution loop for a behavior-changing candidate is:
 
@@ -119,9 +124,10 @@ The intended contribution loop for a behavior-changing candidate is:
    and explicit CLI spelling;
 3. run both named suites with `--verify` to prove the baseline still behaves
    exactly as recorded;
-4. run `--compare strategy-v1 --baseline rule-v5 --candidate <new-policy>`;
+4. run both named comparison profiles against the candidate's direct
+   predecessor;
 5. use `--comparison-start-seed` and `--comparison-episodes` for a larger
-   disjoint seed set after the four-seed smoke comparison;
+   disjoint seed set after the fixed smoke comparison;
 6. attach the JSON comparison report to the review when per-seed evidence is
    useful.
 
@@ -224,6 +230,50 @@ known port corridor first, then enables ordinary avoidance and the bounded
 origin re-entry guard. If the full ship is destroyed before that transition,
 its pod invalidates `Depart` and immediately reselects an owned rebuild port.
 
+Rule policy `rule_ship_v6` is an explicit candidate layered over the unchanged
+V5 core. It measures progress toward the active moving rendezvous, approach,
+or ingress target and separately counts ticks spent avoiding that target
+planet. A phase can fail only after a long no-progress interval or bounded
+terminal-phase timeout, repeated target-planet obstruction, and the presence
+of another valid port for the same capture, repair, or rebuild purpose. The
+failed target is then excluded for a bounded cooldown and the selection reason
+is reported as `target_cooldown`. It never abandons the only owned repair or
+rebuild port. A synthetic permanently obstructed port is the positive
+regression; seed 4's roughly 1,500-tick slow approach is a false-positive guard
+that must still dock without replanning.
+
+Rule policy `rule_ship_v7` composes that complete V6 controller and addresses
+a narrower guidance failure. V6 deliberately chooses one most urgent body per
+tick; where sun and planet clearance zones overlap, tiny clearance changes can
+make that choice alternate and reverse the commanded turn before the ship
+escapes either body. V7 first requires at least two simultaneously reactive
+bodies and two selected-body changes inside a 30-tick window. It therefore
+does not replace an ordinary one-frame encounter merely because two bodies are
+nearby.
+
+Once that oscillation is proven, V7 evaluates 32 deterministic directions 300
+world units ahead and chooses the route that maximizes the worst projected
+clearance across all current threats. The direction is stored relative to the
+two most constrained body centers, so it remains stable as the ship turns
+without requiring hidden world orientation in the observation. The route is
+latched until both anchor bodies exceed their ordinary clearance plus a
+30-unit release margin. Docked and atomic departure maneuvers remain owned by
+V6. Telemetry reports whether the route is active, its age and initial body
+count, and the cumulative activation count.
+
+The focused regression places a sun and planet on opposite sides of the ship
+and alternates their clearance by one unit. V6 switches bodies on every tick;
+V7 proves the oscillation, chooses one shared exit, and holds its steering
+until both bodies are clear. Paired evaluation keeps V7 explicit rather than
+changing the V5 interactive default. On 10 fresh navigation seed-pairs V7
+recorded 100 captures and 17 losses versus V6's 87 and 25. Its incident count
+was slightly higher (339 versus 318), but sustained body-contact time fell from
+51,871 to 46,506 ticks. On the fixed six-seed profile V7 recorded 65 captures,
+eight losses, 243 incidents, and 22,609 contact ticks versus V6's 58, 14, 277,
+and 56,774. On 20 fresh strategy seed-pairs it recorded 116 captures and 34
+losses versus V6's 106 and 35. Those results justify the two-switch trigger
+while leaving promotion of the default as a separate decision.
+
 The initial deterministic priorities are:
 
 - an escape pod must rebuild at an owned port, or evade if none exists;
@@ -255,15 +305,17 @@ redefining normal gameplay.
 
 The named `navigation-v1` suite turns that baseline into a reproducible
 contract: seeds 0 through 5, rule-brain self-play, a 36,000-tick ceiling, no
-random asteroids, and deliberately high ship health. Collisions and docking
-physics remain active. This keeps accidental destruction from truncating the
-experiment while preserving the contacts that navigation guidance must avoid.
+random asteroids, and 200 ship health (twice normal). Collisions and docking
+physics remain active. This gives navigation failures additional time to
+resolve without making the ships effectively immortal, while preserving the
+contacts that navigation guidance must avoid.
 
 The named `strategy-v1` suite uses ordinary health and no random asteroids. For
 each of four seeds it runs the rule policy in both sides against an idle seat
 and then in self-play. Episode and aggregate reports count objective selections
-and ticks spent idle, surviving, attacking, capturing, repairing, defending,
-and rebuilding. The first run exposed a policy that chased an enemy escape pod
+and port replans, plus ticks spent idle, surviving, attacking, capturing,
+repairing, defending, and rebuilding. The first run exposed a policy that
+chased an enemy escape pod
 for the remainder of a 300-second episode; the resulting focused regression
 now requires territorial capture to outrank that chase.
 
@@ -275,6 +327,14 @@ aggregate these metrics by versioned controller policy so side-swapped suites
 remain interpretable. Body and ship collision incidents re-arm after 30
 contact-free ticks, preventing a sustained or briefly flickering scrape from
 dominating the count; debris and laser hits are already discrete events.
+Separate normalized health metrics accumulate damage and healing in full-health
+bar units, including damage observed while a mechanical body contact is active.
+They retain minimum and ship-tick-weighted mean health, separate ship and pod
+exposure, and count both total and longest continuous damaged and critical
+periods. Mechanical body-contact ticks and the longest continuous contact
+complement incident counts, distinguishing a harmless tap from one long scrape.
+Pod rebuild progress and the pod-to-ship transition are excluded from ship
+healing and mean ship health.
 Docking contact transitions count port sessions, while each capture or rebuild
 opens its own pending departure window. A window completes only after the
 craft reaches 90 world units of surface clearance beyond its collision hull. Keeping these
@@ -294,7 +354,9 @@ An opt-in per-player navigation trace sits on the evaluator side of the same
 boundary. It samples semantic brain and docking transitions immediately, then
 adds a heartbeat every 300 ticks while a post-capture departure is unfinished.
 The sample combines `BrainTelemetry`, the emitted `ShipIntent`, dock/contact
-state, planet surface clearance, and outward velocity. Collecting it does not
+state, planet surface clearance, outward velocity, port-attempt age/stall and
+target-obstruction counts, cumulative replans, active cooldown, and V7
+multi-body escape state/age/body count/activations. Collecting it does not
 alter controller actions or the deterministic episode fingerprint, and normal
 untraced batches do not pay its extra observation cost.
 
@@ -406,26 +468,36 @@ recovery, the current run records 52 captures and 52 safe departures. Neither
 previously observed navigation deadlock returned.
 
 With the final v5 contact authority, physical docking hold, and bounded
-departure re-entry guard, the same six-seed suite records 77 captures, all 77
-followed by safe capture departure. It also records one planet-impact ship
-loss and one successful rebuild. That is substantially more throughput than
-the v3 baseline and no unfinished capture departure, but it is not a zero-loss
-claim. The exact policy ID is part of every result so this comparison does not
-silently replace the v4 baseline.
+departure re-entry guard, the current double-health six-seed suite records 69
+captures, 68 followed by safe capture departure. It also records 15 ship
+losses—eight coincident with planet impacts and seven with sun impacts—and ten
+successful rebuilds. The lower health ceiling deliberately stops hiding these
+survival failures; three episodes now reach a winner before the tick limit. The
+exact policy ID is part of every result so this comparison does not silently
+replace the v4 baseline.
 
 The ordinary-health `strategy-v1` result is deliberately less flattering. The
-final v5 run records 40 rule-policy captures, nine ship losses—three coincident
-with planet impacts and six with sun impacts—and six rebuilds. The targeted
+current v5 run records 35 rule-policy captures, eight ship losses—two
+coincident with planet impacts and six with sun impacts—and five rebuilds. The
 interactive planet trap and stale post-destruction departure are now preserved
 as regressions, while this suite makes clear that total body survival and sun
 avoidance remain unsolved. Capture throughput and recovery improved during the
 slice, but those are not substitutes for reducing the measured loss count.
 
+V6 remains a candidate rather than the default because the paired evidence is
+mixed. On the fixed double-health navigation profile it recorded 63 captures,
+15 losses, and 320 body-contact incidents versus V5's 66, 13, and 281; contact
+duration was likewise slightly worse at 58,538 versus 55,577 ticks. Fresh
+ordinary-health seeds 100 through 119 were nearly neutral: 103 captures to 104,
+34 losses to 32, and 550 contacts to 584. These runs validate the bounded
+outcome and evaluator plumbing, but do not justify moving
+`DEFAULT_BUILT_IN_POLICY` away from V5.
+
 ## Next slices
 
-1. Give a repeatedly obstructed rendezvous/ingress a bounded failure outcome
-   and target cooldown, then measure the seed-4 sun/port overlap rather than
-   letting tactical avoidance and strategic capture alternate indefinitely.
+1. Broaden V6 comparisons and interactive traces, then improve path choice or
+   sun escape where cooldown replans trade capture throughput for fewer body
+   contacts.
 2. Tune strategy weights and thresholds through `strategy-v1` plus interactive
    play-testing, preserving explicit policy versions and comparison artifacts.
 3. Add declared personality configurations only after the default policy has


### PR DESCRIPTION
## Summary

- add explicit `rule-v6` and `rule-v7` policies while retaining V5 as the interactive default and historical suite baseline
- make V6 replan persistently obstructed port approaches with bounded failure criteria and target cooldowns
- make V7 detect repeated threat-selection oscillation and latch a deterministic shared escape route through overlapping body hazards
- extend navigation traces and paired evaluation reports with port-replan and multi-body escape telemetry
- lower the navigation workload from effectively immortal health to 200 health, twice normal, so survival and recovery failures affect outcomes
- add normalized health, ship/pod exposure, damage, repair, critical-state, and sustained-contact metrics at episode, batch, policy, and comparison levels
- update the navigation baseline fingerprints and contributor documentation

## Evaluation

V6 versus V7 on the fixed six-seed, side-swapped navigation profile:

- captures: 58 -> 65
- ship losses: 14 -> 8
- body-contact incidents: 277 -> 243
- body-contact ticks: 56,774 -> 22,609
- longest body contact: 29,256 -> 2,916 ticks
- pod exposure: 51,411 -> 12,478 ticks
- normalized damage: 18.69 -> 14.47 health bars

On ten fresh navigation seed pairs, V7 recorded 100 captures and 17 losses versus V6 at 87 captures and 25 losses. Contact incidents rose slightly from 318 to 339, while contact duration fell from 51,871 to 46,506 ticks, demonstrating why both incident and duration metrics are retained.

The ordinary-health strategy profile recorded 26 captures and 3 losses for V7 versus 24 captures and 8 losses for V6. V5 remains the default pending broader evaluation and play-testing.

## Validation

- `cargo test --locked --workspace --all-targets`
- `cargo +1.89.0 clippy --locked -p engine-agent -p spacewars-ai --all-targets --no-deps -- -D warnings`
- `cargo run --locked --release -p engine-agent -- --suite navigation-v1 --verify`
- `cargo run --locked --release -p engine-agent -- --suite strategy-v1 --verify`
- `cargo fmt --all`
- fixed V6/V7 navigation and strategy comparisons
- fresh navigation seed comparison
