### PR TITLE
Add deterministic Clock scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,7 @@ dependencies = [
 name = "engine-client"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "cpal",
  "directories",
@@ -1480,6 +1481,7 @@ dependencies = [
  "engine-nes",
  "gilrs",
  "png 0.17.16",
+ "scenario-clock",
  "scenario-falling",
  "scenario-nes",
  "scenario-null",
@@ -4571,6 +4573,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scenario-clock"
+version = "0.1.0"
+dependencies = [
+ "engine-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/spacewars-cli",
     "crates/engine-agent",
     "crates/engine-os-manager",
+    "scenarios/clock",
     "scenarios/falling",
     "scenarios/nes",
     "scenarios/null",
@@ -33,6 +34,7 @@ rust-version = "1.89"
 [workspace.dependencies]
 # External.
 bincode = "1"
+chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 cpal = "0.18.2"
 directories = "6"
@@ -65,6 +67,7 @@ engine-nes = { path = "crates/engine-nes" }
 engine-rapier = { path = "crates/engine-rapier" }
 spacewars-ai = { path = "crates/spacewars-ai" }
 spacewars-control = { path = "crates/spacewars-control" }
+scenario-clock = { path = "scenarios/clock" }
 scenario-falling = { path = "scenarios/falling" }
 scenario-nes = { path = "scenarios/nes" }
 scenario-null = { path = "scenarios/null" }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Below is a zoomed out view of a CTF game mode.
 
 ## Status
 
-The local launcher currently hosts five playable scenarios:
+The local launcher currently hosts six playable scenarios:
 
 - **Spacewars** — the two-player arcade reboot. Its ships, escape pods,
   asteroids, physical debris, projectiles, celestial bodies, spaceport sensors,
@@ -19,6 +19,10 @@ The local launcher currently hosts five playable scenarios:
   Rapier owns rigid-body motion and contacts while the scenario supplies mutual
   gravity and gameplay damage. Click empty space to make a ball, or grab and
   fling an existing one.
+- **Clock** — a responsive low-resolution local-time display built from stable
+  seven-segment square cells. The deterministic scenario receives versioned
+  clock readings from its client adapter, leaving the face ready for later
+  falling-segment and meltdown events.
 - **Rover Lab** — a Rapier 2D feasibility scenario for a three-body rover with
   independently driven pin-slot suspension wheels on a rotating circular planet.
 - **Falling** — the pinned MIT-licensed NES homebrew running on this repository's
@@ -70,6 +74,7 @@ Or start a scenario directly:
 
 ```sh
 cargo run -p engine-client -- --scenario pizza
+cargo run -p engine-client -- --scenario clock
 cargo run -p engine-client -- --scenario rover-lab
 cargo run -p engine-client -- --scenario spacewars
 cargo run -p engine-client -- --scenario falling

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -11,11 +11,13 @@ name = "engine-client"
 path = "src/main.rs"
 
 [dependencies]
+chrono = { workspace = true }
 engine-common = { workspace = true }
 engine-core = { workspace = true }
 engine-nes = { workspace = true }
 spacewars-ai = { workspace = true }
 spacewars-control = { workspace = true }
+scenario-clock = { workspace = true }
 scenario-falling = { workspace = true }
 scenario-nes = { workspace = true }
 scenario-null = { workspace = true }

--- a/crates/engine-client/src/client_scenarios/clock.rs
+++ b/crates/engine-client/src/client_scenarios/clock.rs
@@ -1,0 +1,172 @@
+use std::cell::Cell;
+use std::time::Duration;
+
+use chrono::{Local, Timelike};
+use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
+use scenario_clock::{ClockAction, ClockConfig, ClockReading, ClockScenario, ClockState};
+
+use super::{
+    ClientScenario, RenderBackend, ScenarioAsset, ScenarioCapabilities, ScenarioCreateError,
+    ScenarioRegistration, ScenarioStartMode,
+};
+use crate::input::ClientInput;
+use crate::render::{FrameLayout, Viewport};
+
+pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
+    id: "clock",
+    launcher_visible: true,
+    capabilities: ScenarioCapabilities {
+        benchmark: false,
+        pointer_input: false,
+        player_zoom: false,
+        game_over: false,
+        native_video: false,
+        captures_gamepad_start: false,
+        captures_gamepad_select: false,
+    },
+    controls_help: "Clock follows the device's local time and needs no in-scenario controls. Use the host pause menu to restart it or return to the launcher.",
+    create,
+};
+
+pub(crate) struct ClockClientScenario {
+    pub(crate) state: ClockState,
+    last_emitted_reading: Cell<Option<ClockReading>>,
+}
+
+impl ClockClientScenario {
+    fn actions_for_reading(&self, reading: ClockReading) -> Vec<Action> {
+        if self.last_emitted_reading.replace(Some(reading)) == Some(reading) {
+            Vec::new()
+        } else {
+            vec![ClockAction::set_reading(reading)]
+        }
+    }
+}
+
+fn create(
+    seed: u64,
+    settings: &Settings,
+    viewport: Viewport,
+    _mode: ScenarioStartMode,
+    _asset: &ScenarioAsset,
+) -> Result<Box<dyn ClientScenario>, ScenarioCreateError> {
+    let mut state = ClockScenario::init(
+        ClockConfig {
+            aspect_ratio: viewport.aspect_ratio(),
+            time_format: settings.clock.time_format,
+        },
+        seed,
+    );
+    let reading = local_clock_reading();
+    ClockScenario::step(
+        &mut state,
+        &[ClockAction::set_reading(reading)],
+        Duration::ZERO,
+    );
+    Ok(Box::new(ClockClientScenario {
+        state,
+        last_emitted_reading: Cell::new(Some(reading)),
+    }))
+}
+
+impl ClientScenario for ClockClientScenario {
+    fn registration(&self) -> &'static ScenarioRegistration {
+        &REGISTRATION
+    }
+
+    fn tick_model(&self) -> TickModel {
+        ClockScenario::tick_model()
+    }
+
+    fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult {
+        ClockScenario::step(&mut self.state, actions, dt)
+    }
+
+    fn map_input(&self, _input: &mut ClientInput, _benchmark_active: bool) -> Vec<Action> {
+        self.actions_for_reading(local_clock_reading())
+    }
+
+    fn render_frames(&self, _renderer: RenderBackend, _viewport: Viewport) -> Vec<RenderFrame> {
+        vec![ClockScenario::render_frame(&self.state)]
+    }
+
+    fn frame_layout(&self) -> FrameLayout {
+        FrameLayout::EqualHorizontal
+    }
+
+    fn set_viewport(&mut self, viewport: Viewport) {
+        self.state.set_aspect_ratio(viewport.aspect_ratio());
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+fn local_clock_reading() -> ClockReading {
+    let now = Local::now();
+    ClockReading::new(now.hour() as u8, now.minute() as u8, now.second() as u8)
+        .expect("chrono always returns a valid local clock reading")
+}
+
+#[cfg(test)]
+mod tests {
+    use engine_common::ClockTimeFormat;
+
+    use super::*;
+
+    #[test]
+    fn factory_applies_a_valid_initial_local_reading_and_settings() {
+        let mut settings = Settings::default();
+        settings.clock.time_format = ClockTimeFormat::TwelveHour;
+        let scenario = create(
+            17,
+            &settings,
+            Viewport::new(800.0, 480.0),
+            ScenarioStartMode::Normal,
+            &ScenarioAsset::None,
+        )
+        .unwrap();
+        let scenario = scenario
+            .as_any()
+            .downcast_ref::<ClockClientScenario>()
+            .unwrap();
+
+        assert!(scenario.state.reading().is_some());
+        assert_eq!(scenario.state.time_format(), ClockTimeFormat::TwelveHour);
+        assert_eq!(scenario.state.aspect_ratio(), 800.0 / 480.0);
+    }
+
+    #[test]
+    fn adapter_suppresses_duplicate_readings() {
+        let scenario = create(
+            0,
+            &Settings::default(),
+            Viewport::new(800.0, 480.0),
+            ScenarioStartMode::Normal,
+            &ScenarioAsset::None,
+        )
+        .unwrap();
+        let scenario = scenario
+            .as_any()
+            .downcast_ref::<ClockClientScenario>()
+            .unwrap();
+        let first = ClockReading::new(10, 20, 30).unwrap();
+        let second = ClockReading::new(10, 20, 31).unwrap();
+        scenario.last_emitted_reading.set(Some(first));
+        assert!(scenario.actions_for_reading(first).is_empty());
+
+        let actions = scenario.actions_for_reading(second);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(
+            ClockAction::decode(&actions[0]),
+            Some(ClockAction::SetReading(second))
+        );
+    }
+}

--- a/crates/engine-client/src/client_scenarios/mod.rs
+++ b/crates/engine-client/src/client_scenarios/mod.rs
@@ -11,6 +11,7 @@ use crate::input::ClientInput;
 use crate::nes_realtime::{RealtimeTelemetry, RealtimeVideoConsumer};
 use crate::render::{FrameLayout, Viewport};
 
+mod clock;
 mod falling;
 mod nes;
 mod null;
@@ -354,6 +355,7 @@ impl std::error::Error for ScenarioCreateError {}
 
 static SCENARIOS: &[ScenarioRegistration] = &[
     null::REGISTRATION,
+    clock::REGISTRATION,
     falling::REGISTRATION,
     nes::REGISTRATION,
     pizza::REGISTRATION,
@@ -417,7 +419,7 @@ mod tests {
             launcher_registrations()
                 .map(|registration| registration.id)
                 .collect::<Vec<_>>(),
-            vec!["falling", "nes", "pizza", "rover-lab", "spacewars"]
+            vec!["clock", "falling", "nes", "pizza", "rover-lab", "spacewars"]
         );
     }
 

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -651,6 +651,7 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
             spacewars_player_2: window.get_launcher_p2_controller().to_string(),
             pizza_desired_balls: window.get_launcher_pizza_desired_balls_text().to_string(),
             pizza_spawn_rate: window.get_launcher_pizza_spawn_rate_text().to_string(),
+            clock_time_format: window.get_launcher_clock_time_format().to_string(),
             nes_cartridge_name: window.get_launcher_nes_rom_name().to_string(),
         },
     );

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -1,7 +1,8 @@
 //! Scenario client: Slint UI, input, rendering, settings, and scenario host.
 //!
-//! The compile-time registry currently hosts Pizza, Rover Lab, and Spacewars
-//! from the launcher, with Null retained as a hidden test scenario.
+//! The compile-time registry hosts Clock, Falling, NES Library, Pizza, Rover
+//! Lab, and Spacewars from the launcher, with Null retained as a hidden test
+//! scenario.
 
 mod client_scenarios;
 mod gamepad;
@@ -27,9 +28,10 @@ use std::sync::{Arc, RwLock};
 
 use clap::{Parser, ValueEnum};
 use engine_common::{
-    CrashBehavior, MAX_PIZZA_BALL_SPAWN_RATE, MAX_PIZZA_DESIRED_BALLS,
-    MAX_SPACEWARS_ASTEROID_PROBABILITY_PER_SEC, MAX_SPACEWARS_PLAYER_HEALTH_PERCENT,
-    MAX_SPACEWARS_PLAYER_VIEW_HEIGHT, MAX_SPACEWARS_UNIVERSE_RADIUS, MIN_PIZZA_BALL_SPAWN_RATE,
+    ClockSettings, ClockTimeFormat, CrashBehavior, MAX_PIZZA_BALL_SPAWN_RATE,
+    MAX_PIZZA_DESIRED_BALLS, MAX_SPACEWARS_ASTEROID_PROBABILITY_PER_SEC,
+    MAX_SPACEWARS_PLAYER_HEALTH_PERCENT, MAX_SPACEWARS_PLAYER_VIEW_HEIGHT,
+    MAX_SPACEWARS_UNIVERSE_RADIUS, MIN_PIZZA_BALL_SPAWN_RATE,
     MIN_SPACEWARS_ASTEROID_PROBABILITY_PER_SEC, MIN_SPACEWARS_PLAYER_HEALTH_PERCENT,
     MIN_SPACEWARS_PLAYER_VIEW_HEIGHT, MIN_SPACEWARS_UNIVERSE_RADIUS, PizzaSettings,
     RendererSetting, Settings, SpacewarsController, SpacewarsSettings,
@@ -588,6 +590,9 @@ fn show_launcher(
     window.set_launcher_pizza_spawn_rate_text(SharedString::from(format_float_setting(
         pizza.ball_spawn_rate,
     )));
+    window.set_launcher_clock_time_format(SharedString::from(clock_time_format_label(
+        settings.clock.time_format,
+    )));
     refresh_nes_rom_library(window, settings, rom_catalog);
     window.set_launcher_error_text(SharedString::from(""));
     window.set_launcher_focus_index(0);
@@ -1106,6 +1111,7 @@ fn launcher_settings_item_count(window: &MainWindow) -> i32 {
     match window.get_launcher_scenario().as_str() {
         "spacewars" => 8,
         "pizza" => 5,
+        "clock" => 4,
         "falling" => 1,
         "nes" => 2,
         _ => 3,
@@ -1145,6 +1151,7 @@ fn adjust_launcher_setting(window: &MainWindow, delta: i32) {
     match window.get_launcher_scenario().as_str() {
         "spacewars" => adjust_spacewars_launcher_setting(window, focus, delta),
         "pizza" => adjust_pizza_launcher_setting(window, focus, delta),
+        "clock" => adjust_clock_launcher_setting(window, focus, delta),
         _ => {}
     }
 }
@@ -1229,6 +1236,18 @@ fn adjust_pizza_launcher_setting(window: &MainWindow, focus: i32, delta: i32) {
         }
         _ => {}
     }
+}
+
+fn adjust_clock_launcher_setting(window: &MainWindow, focus: i32, delta: i32) {
+    if focus != 2 {
+        return;
+    }
+    let next = cycle_label(
+        window.get_launcher_clock_time_format().as_str(),
+        &["24-hour", "12-hour"],
+        delta,
+    );
+    window.set_launcher_clock_time_format(SharedString::from(next));
 }
 
 fn cycle_label<'a>(current: &str, values: &'a [&'a str], delta: i32) -> &'a str {
@@ -1428,6 +1447,7 @@ fn hide_launcher_surfaces(window: &MainWindow) {
 struct LauncherSelections {
     launch: EffectiveLaunch,
     nes_rom_id: Option<String>,
+    clock: ClockSettings,
     spacewars: SpacewarsSettings,
     pizza: PizzaSettings,
 }
@@ -1443,6 +1463,7 @@ fn persist_launcher_settings(
     let raster_scale = normalize_raster_scale(launch.raster_scale);
     let spacewars = selections.spacewars.normalized();
     let pizza = selections.pizza.normalized();
+    let clock = selections.clock.clone();
     let nes_rom_id = selections.nes_rom_id.clone();
     let mut changed = false;
 
@@ -1468,6 +1489,10 @@ fn persist_launcher_settings(
     }
     if settings.nes.selected_rom_id != nes_rom_id {
         settings.nes.selected_rom_id = nes_rom_id;
+        changed = true;
+    }
+    if settings.clock != clock {
+        settings.clock = clock;
         changed = true;
     }
     if settings.spacewars != spacewars {
@@ -1615,16 +1640,24 @@ fn launcher_selections_from_window(
     current_settings: &Settings,
 ) -> Result<LauncherSelections, String> {
     let launch = launch_options_from_window(window)?;
-    let (spacewars, pizza) = match launch.scenario.as_str() {
+    let (clock, spacewars, pizza) = match launch.scenario.as_str() {
         "spacewars" => (
+            current_settings.clock.clone(),
             spacewars_setup_from_window(window)?,
             current_settings.pizza.clone(),
         ),
         "pizza" => (
+            current_settings.clock.clone(),
             current_settings.spacewars.clone(),
             pizza_setup_from_window(window)?,
         ),
+        "clock" => (
+            clock_setup_from_window(window)?,
+            current_settings.spacewars.clone(),
+            current_settings.pizza.clone(),
+        ),
         _ => (
+            current_settings.clock.clone(),
             current_settings.spacewars.clone(),
             current_settings.pizza.clone(),
         ),
@@ -1638,6 +1671,7 @@ fn launcher_selections_from_window(
     Ok(LauncherSelections {
         launch,
         nes_rom_id,
+        clock,
         spacewars,
         pizza,
     })
@@ -1672,6 +1706,14 @@ fn pizza_setup_from_window(window: &MainWindow) -> Result<PizzaSettings, String>
         window.get_launcher_pizza_desired_balls_text().as_str(),
         window.get_launcher_pizza_spawn_rate_text().as_str(),
     )
+}
+
+fn clock_setup_from_window(window: &MainWindow) -> Result<ClockSettings, String> {
+    Ok(ClockSettings {
+        time_format: clock_time_format_from_label(
+            window.get_launcher_clock_time_format().as_str(),
+        )?,
+    })
 }
 
 fn launch_options_from_values(
@@ -1764,6 +1806,21 @@ fn spacewars_controller_from_label(label: &str) -> Result<SpacewarsController, S
         "human" => Ok(SpacewarsController::Human),
         "rule bot" => Ok(SpacewarsController::RuleBot),
         other => Err(format!("Unknown Spacewars controller {other:?}.")),
+    }
+}
+
+fn clock_time_format_label(format: ClockTimeFormat) -> &'static str {
+    match format {
+        ClockTimeFormat::TwelveHour => "12-hour",
+        ClockTimeFormat::TwentyFourHour => "24-hour",
+    }
+}
+
+fn clock_time_format_from_label(label: &str) -> Result<ClockTimeFormat, String> {
+    match label.trim() {
+        "12-hour" => Ok(ClockTimeFormat::TwelveHour),
+        "24-hour" => Ok(ClockTimeFormat::TwentyFourHour),
+        other => Err(format!("Unknown clock time format {other:?}.")),
     }
 }
 
@@ -2415,6 +2472,9 @@ mod tests {
                 raster_scale: 2.0,
             },
             nes_rom_id: Some("abc123".into()),
+            clock: ClockSettings {
+                time_format: ClockTimeFormat::TwelveHour,
+            },
             spacewars: SpacewarsSettings {
                 universe_radius: 2400,
                 use_planets: false,
@@ -2441,6 +2501,7 @@ mod tests {
         assert_eq!(stored.launch.raster_scale, 2.0);
         assert_eq!(stored.spacewars, selections.spacewars);
         assert_eq!(stored.pizza, selections.pizza);
+        assert_eq!(stored.clock, selections.clock);
         assert_eq!(stored.last_scenario.as_deref(), Some("spacewars"));
         assert_eq!(stored.nes.selected_rom_id.as_deref(), Some("abc123"));
         drop(stored);
@@ -2452,6 +2513,7 @@ mod tests {
         assert_eq!(reloaded.settings.launch.raster_scale, 2.0);
         assert_eq!(reloaded.settings.spacewars, selections.spacewars);
         assert_eq!(reloaded.settings.pizza, selections.pizza);
+        assert_eq!(reloaded.settings.clock, selections.clock);
         assert_eq!(
             reloaded.settings.nes.selected_rom_id.as_deref(),
             Some("abc123")
@@ -2585,6 +2647,17 @@ mod tests {
         );
         assert!(pizza_setup_from_values("many", "0.42").is_err());
         assert!(pizza_setup_from_values("24", "often").is_err());
+    }
+
+    #[test]
+    fn clock_format_labels_parse_and_round_trip() {
+        for format in [ClockTimeFormat::TwelveHour, ClockTimeFormat::TwentyFourHour] {
+            assert_eq!(
+                clock_time_format_from_label(clock_time_format_label(format)).unwrap(),
+                format
+            );
+        }
+        assert!(clock_time_format_from_label("many-hours").is_err());
     }
 
     #[test]

--- a/crates/engine-client/src/settings.rs
+++ b/crates/engine-client/src/settings.rs
@@ -251,8 +251,8 @@ mod tests {
     use std::sync::Mutex;
 
     use engine_common::{
-        AudioSettings, LaunchSettings, NesSettings, RendererSetting, SpacewarsController,
-        SpacewarsSettings, VideoSettings,
+        AudioSettings, ClockTimeFormat, LaunchSettings, NesSettings, RendererSetting,
+        SpacewarsController, SpacewarsSettings, VideoSettings,
     };
 
     use super::*;
@@ -275,6 +275,10 @@ mod tests {
         assert_eq!(loaded.settings.launch.renderer, RendererSetting::Vector);
         assert_eq!(loaded.settings.launch.raster_scale, 1.0);
         assert_eq!(loaded.settings.spacewars, SpacewarsSettings::default());
+        assert_eq!(
+            loaded.settings.clock.time_format,
+            ClockTimeFormat::TwentyFourHour
+        );
         assert!(!path.exists(), "load should not create the file.");
     }
 
@@ -303,6 +307,7 @@ mod tests {
         assert!(migrated.contains("[audio]"));
         assert!(migrated.contains("[launch]"));
         assert!(migrated.contains("[spacewars]"));
+        assert!(migrated.contains("[clock]"));
         assert!(migrated.contains("[runtime]"));
     }
 
@@ -390,6 +395,10 @@ mod tests {
             80.0
         );
         assert_eq!(reloaded.settings.spacewars.player_health_percent, 250);
+        assert_eq!(
+            reloaded.settings.clock.time_format,
+            ClockTimeFormat::TwentyFourHour
+        );
         assert_eq!(
             reloaded.settings.spacewars.player_2_controller,
             SpacewarsController::RuleBot

--- a/crates/engine-client/src/ui_activation.rs
+++ b/crates/engine-client/src/ui_activation.rs
@@ -99,7 +99,9 @@ fn launcher_setting_target(control_id: &str) -> Option<ActivationTarget> {
     let focus_index = match setting_id {
         "launcher.settings.renderer" | "launcher.settings.nes.cartridge" => 0,
         "launcher.settings.raster-scale" => 1,
-        "launcher.settings.spacewars.preset" | "launcher.settings.pizza.desired-balls" => 2,
+        "launcher.settings.spacewars.preset"
+        | "launcher.settings.pizza.desired-balls"
+        | "launcher.settings.clock.time-format" => 2,
         "launcher.settings.spacewars.planets" | "launcher.settings.pizza.spawn-rate" => 3,
         "launcher.settings.spacewars.asteroids" => 4,
         "launcher.settings.spacewars.player-health" => 5,

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -56,6 +56,7 @@ pub(crate) struct UiInventoryContext {
     pub(crate) spacewars_player_2: String,
     pub(crate) pizza_desired_balls: String,
     pub(crate) pizza_spawn_rate: String,
+    pub(crate) clock_time_format: String,
     pub(crate) nes_cartridge_name: String,
 }
 
@@ -236,6 +237,29 @@ fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
                 "launcher.settings.back",
             ]
         }
+        "clock" => {
+            push_choice(
+                &mut controls,
+                "launcher.settings.renderer",
+                &context.renderer,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.raster-scale",
+                &format!("{}×", context.raster_scale),
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.clock.time-format",
+                &context.clock_time_format,
+            );
+            &[
+                "launcher.settings.renderer",
+                "launcher.settings.raster-scale",
+                "launcher.settings.clock.time-format",
+                "launcher.settings.back",
+            ]
+        }
         "falling" => &["launcher.settings.back"],
         "nes" => {
             push_choice(
@@ -356,6 +380,7 @@ mod tests {
             spacewars_player_2: "rule bot".into(),
             pizza_desired_balls: "75".into(),
             pizza_spawn_rate: "0.10".into(),
+            clock_time_format: "24-hour".into(),
             nes_cartridge_name: "Demo Cartridge".into(),
             ..Default::default()
         }
@@ -502,6 +527,7 @@ mod tests {
         let cases = [
             ("spacewars", 16, "launcher.settings.spacewars.player-2"),
             ("pizza", 10, "launcher.settings.pizza.spawn-rate"),
+            ("clock", 8, "launcher.settings.clock.time-format"),
             ("rover-lab", 6, "launcher.settings.raster-scale"),
             ("falling", 2, "launcher.settings.back"),
             ("nes", 4, "launcher.settings.nes.cartridge"),
@@ -512,6 +538,7 @@ mod tests {
             context.launcher_settings_focus_index = match scenario {
                 "spacewars" => 6,
                 "pizza" => 3,
+                "clock" => 2,
                 "rover-lab" => 1,
                 "falling" => 0,
                 "nes" => 0,
@@ -663,7 +690,7 @@ mod tests {
 
     #[test]
     fn every_enabled_control_has_a_semantic_activation_mapping() {
-        for scenario in ["spacewars", "pizza", "rover-lab", "falling", "nes"] {
+        for scenario in ["spacewars", "pizza", "clock", "rover-lab", "falling", "nes"] {
             let context = context(scenario);
             for screen in [
                 UiScreen::LauncherMain,

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -172,6 +172,105 @@ fn launcher_navigation_uses_the_public_control_api() {
 
 #[test]
 #[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn launcher_can_run_the_clock_menu_lifecycle() {
+    run_functional_test("launcher-clock-menu-lifecycle", |harness| {
+        let mut state = harness.wait_until_ready();
+        assert_launcher_main(&state);
+        state = harness.activate_until_scenario("clock", state);
+        assert_eq!(state.selected_scenario, "clock");
+
+        state = harness.activate_guarded("launcher.settings", &state);
+        assert_eq!(state.screen, UiScreen::LauncherSettings);
+        assert_eq!(
+            control_value(&state, "launcher.settings.clock.time-format.next"),
+            Some("24-hour")
+        );
+        state = harness.activate_guarded("launcher.settings.clock.time-format.next", &state);
+        assert_eq!(
+            control_value(&state, "launcher.settings.clock.time-format.next"),
+            Some("12-hour")
+        );
+        state = harness.activate_guarded("launcher.settings.clock.time-format.previous", &state);
+        assert_eq!(
+            control_value(&state, "launcher.settings.clock.time-format.next"),
+            Some("24-hour")
+        );
+        state = harness.activate_guarded("launcher.settings.back", &state);
+        harness.capture_screenshot("clock-launcher.png");
+
+        let launch_revision = state.revision;
+        harness.activate_guarded("launcher.start", &state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                scenario: Some("clock".into()),
+                revision_after: Some(launch_revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert_eq!(state.active_scenario.as_deref(), Some("clock"));
+        assert!(!state.paused);
+        assert!(!state.benchmark_active);
+        let first_scenario_revision = state
+            .scenario_revision
+            .expect("Clock gameplay must report a scenario revision");
+        harness.capture_screenshot("clock-gameplay.png");
+
+        let pause_requested = harness.pause_guarded(&state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::PauseMain),
+                scenario: Some("clock".into()),
+                revision_after: Some(pause_requested.revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert!(state.paused);
+        assert_eq!(
+            control_ids(&state),
+            [
+                "pause.resume",
+                "pause.restart",
+                "pause.controls",
+                "pause.return-to-launcher",
+            ]
+        );
+
+        let return_revision = state.revision;
+        harness.activate_guarded("pause.return-to-launcher", &state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::LauncherMain),
+                scenario: None,
+                revision_after: Some(return_revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert_eq!(state.screen, UiScreen::LauncherMain);
+        assert_eq!(state.active_scenario, None);
+        assert_eq!(selected_control(&state), "launcher.scenario");
+        assert_eq!(state.selected_scenario, "clock");
+        assert_eq!(state.scenario_revision, None);
+
+        let relaunch_revision = state.revision;
+        harness.activate_guarded("launcher.start", &state);
+        state = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                scenario: Some("clock".into()),
+                revision_after: Some(relaunch_revision),
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert_ne!(state.scenario_revision, Some(first_scenario_revision));
+        assert!(!state.paused);
+        assert!(!state.benchmark_active);
+        harness.capture_screenshot("clock-relaunched-gameplay.png");
+    });
+}
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
 fn launcher_can_run_the_spacewars_menu_lifecycle() {
     run_functional_test("launcher-spacewars-menu-lifecycle", |harness| {
         let mut state = harness.wait_until_ready();

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -286,6 +286,7 @@ export component MainWindow inherits Window {
     in-out property <string> launcher-p2-zoom-text: "320";
     in-out property <string> launcher-pizza-desired-balls-text: "24";
     in-out property <string> launcher-pizza-spawn-rate-text: "0.10";
+    in-out property <string> launcher-clock-time-format: "24-hour";
     in-out property <string> launcher-nes-rom-id: "";
     in-out property <string> launcher-nes-rom-name: "No cartridges found";
     in-out property <string> launcher-nes-rom-status: "Copy a .nes file into the ROM library.";
@@ -999,7 +1000,7 @@ export component MainWindow inherits Window {
                             y: 9px;
                             width: parent.width - 28px;
                             height: 24px;
-                            text: root.launcher-scenario == "spacewars" ? "Two-player orbital combat and planet capture" : root.launcher-scenario == "pizza" ? "Interactive many-body collision sandbox" : root.launcher-scenario == "falling" ? "Rust-native NES homebrew game" : root.launcher-scenario == "nes" ? "User-supplied NES cartridge library" : "Rapier rover and wheel mechanics lab";
+                            text: root.launcher-scenario == "spacewars" ? "Two-player orbital combat and planet capture" : root.launcher-scenario == "pizza" ? "Interactive many-body collision sandbox" : root.launcher-scenario == "clock" ? "Low-resolution clock driven by local device time" : root.launcher-scenario == "falling" ? "Rust-native NES homebrew game" : root.launcher-scenario == "nes" ? "User-supplied NES cartridge library" : "Rapier rover and wheel mechanics lab";
                             color: #e6edf7;
                             font-size: 15px;
                         }
@@ -1009,7 +1010,7 @@ export component MainWindow inherits Window {
                             y: 38px;
                             width: parent.width - 28px;
                             height: 22px;
-                            text: root.launcher-scenario == "spacewars" ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled + "  ·  P2 " + root.launcher-p2-controller) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : root.launcher-scenario == "falling" ? "256×224 native video  ·  bounded 48 kHz audio" : root.launcher-scenario == "nes" ? (root.launcher-nes-rom-name + "  ·  " + root.launcher-nes-rom-status) : "A semi-interactive mechanics scenario";
+                            text: root.launcher-scenario == "spacewars" ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled + "  ·  P2 " + root.launcher-p2-controller) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : root.launcher-scenario == "clock" ? (root.launcher-clock-time-format + "  ·  local device time  ·  square-cell digits") : root.launcher-scenario == "falling" ? "256×224 native video  ·  bounded 48 kHz audio" : root.launcher-scenario == "nes" ? (root.launcher-nes-rom-name + "  ·  " + root.launcher-nes-rom-status) : "A semi-interactive mechanics scenario";
                             color: #9fb4cc;
                             font-size: 13px;
                         }
@@ -1249,6 +1250,25 @@ export component MainWindow inherits Window {
                     }
 
                     ChoiceRow {
+                        visible: root.launcher-scenario == "clock";
+                        x: 0px;
+                        y: 104px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Time Format";
+                        value: root.launcher-clock-time-format;
+                        selected: root.launcher-settings-focus-index == 2;
+                        previous => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
                         visible: root.launcher-scenario == "nes";
                         x: 0px;
                         y: 0px;
@@ -1319,7 +1339,7 @@ export component MainWindow inherits Window {
                         width: 150px;
                         height: 44px;
                         text: "Back";
-                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 7 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : 2);
+                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 7 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "clock" ? 3 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : 2);
                         activated => {
                             root.launcher-settings-visible = false;
                         }

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -123,6 +123,7 @@ pub struct Settings {
     pub audio: AudioSettings,
     pub controls: ControlBindings,
     pub launch: LaunchSettings,
+    pub clock: ClockSettings,
     pub nes: NesSettings,
     pub spacewars: SpacewarsSettings,
     pub pizza: PizzaSettings,
@@ -177,6 +178,21 @@ pub struct ControlBindings {
 pub struct NesSettings {
     /// SHA-256 identity of the last user cartridge selected in the launcher.
     pub selected_rom_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClockTimeFormat {
+    #[serde(rename = "12-hour")]
+    TwelveHour,
+    #[default]
+    #[serde(rename = "24-hour")]
+    TwentyFourHour,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ClockSettings {
+    pub time_format: ClockTimeFormat,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -30,7 +30,10 @@ The initial workflows verify:
 - starting a real deterministic Spacewars scenario, pausing through the guarded
   host API, observing the conditional Benchmark menu control, and activating it
   to start a new benchmark scenario revision; then restarting into a normal
-  round, returning to the launcher, and launching Spacewars again.
+  round, returning to the launcher, and launching Spacewars again; and
+- selecting Clock, changing its 12/24-hour setting through stable control IDs,
+  launching and pausing the scenario, returning to the launcher, and relaunching
+  a fresh Clock scenario revision.
 
 These are semantic UI tests. They do not validate physical touchscreen hit
 testing, LinuxKMS coordinate transforms, or panel rotation.

--- a/scenarios/clock/Cargo.toml
+++ b/scenarios/clock/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "scenario-clock"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+engine-common = { workspace = true }

--- a/scenarios/clock/src/digits.rs
+++ b/scenarios/clock/src/digits.rs
@@ -1,0 +1,263 @@
+use engine_common::ClockTimeFormat;
+
+use crate::ClockReading;
+
+pub const DIGIT_SLOT_COUNT: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum SegmentKind {
+    Top,
+    UpperRight,
+    LowerRight,
+    Bottom,
+    LowerLeft,
+    UpperLeft,
+    Middle,
+}
+
+impl SegmentKind {
+    pub const ALL: [Self; 7] = [
+        Self::Top,
+        Self::UpperRight,
+        Self::LowerRight,
+        Self::Bottom,
+        Self::LowerLeft,
+        Self::UpperLeft,
+        Self::Middle,
+    ];
+
+    const fn bit(self) -> u8 {
+        1 << self as u8
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SegmentId {
+    pub digit_slot: u8,
+    pub kind: SegmentKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentRepresentation {
+    Anchored,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SegmentState {
+    pub id: SegmentId,
+    pub lit: bool,
+    pub representation: SegmentRepresentation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GridCell {
+    pub x: i8,
+    pub y: i8,
+}
+
+const TOP_CELLS: [GridCell; 4] = horizontal_cells(8);
+const MIDDLE_CELLS: [GridCell; 4] = horizontal_cells(4);
+const BOTTOM_CELLS: [GridCell; 4] = horizontal_cells(0);
+const UPPER_LEFT_CELLS: [GridCell; 3] = vertical_cells(0, 5);
+const UPPER_RIGHT_CELLS: [GridCell; 3] = vertical_cells(5, 5);
+const LOWER_LEFT_CELLS: [GridCell; 3] = vertical_cells(0, 1);
+const LOWER_RIGHT_CELLS: [GridCell; 3] = vertical_cells(5, 1);
+
+const fn horizontal_cells(y: i8) -> [GridCell; 4] {
+    [
+        GridCell { x: 1, y },
+        GridCell { x: 2, y },
+        GridCell { x: 3, y },
+        GridCell { x: 4, y },
+    ]
+}
+
+const fn vertical_cells(x: i8, first_y: i8) -> [GridCell; 3] {
+    [
+        GridCell { x, y: first_y },
+        GridCell { x, y: first_y + 1 },
+        GridCell { x, y: first_y + 2 },
+    ]
+}
+
+pub fn cells(kind: SegmentKind) -> &'static [GridCell] {
+    match kind {
+        SegmentKind::Top => &TOP_CELLS,
+        SegmentKind::UpperRight => &UPPER_RIGHT_CELLS,
+        SegmentKind::LowerRight => &LOWER_RIGHT_CELLS,
+        SegmentKind::Bottom => &BOTTOM_CELLS,
+        SegmentKind::LowerLeft => &LOWER_LEFT_CELLS,
+        SegmentKind::UpperLeft => &UPPER_LEFT_CELLS,
+        SegmentKind::Middle => &MIDDLE_CELLS,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DisplaySnapshot {
+    pub digits: [Option<u8>; DIGIT_SLOT_COUNT],
+    pub colon_lit: bool,
+    pub meridiem: Option<&'static str>,
+}
+
+impl DisplaySnapshot {
+    pub const fn unsynchronized() -> Self {
+        Self {
+            digits: [None; DIGIT_SLOT_COUNT],
+            colon_lit: false,
+            meridiem: None,
+        }
+    }
+}
+
+pub fn snapshot(reading: ClockReading, format: ClockTimeFormat) -> DisplaySnapshot {
+    let (display_hour, leading_zero, meridiem) = match format {
+        ClockTimeFormat::TwentyFourHour => (reading.hour(), true, None),
+        ClockTimeFormat::TwelveHour => {
+            let display_hour = match reading.hour() % 12 {
+                0 => 12,
+                hour => hour,
+            };
+            let meridiem = if reading.hour() < 12 { "AM" } else { "PM" };
+            (display_hour, false, Some(meridiem))
+        }
+    };
+    let leading_hour = display_hour / 10;
+
+    DisplaySnapshot {
+        digits: [
+            (leading_zero || leading_hour != 0).then_some(leading_hour),
+            Some(display_hour % 10),
+            Some(reading.minute() / 10),
+            Some(reading.minute() % 10),
+        ],
+        colon_lit: reading.second().is_multiple_of(2),
+        meridiem,
+    }
+}
+
+pub fn create_segments() -> Vec<SegmentState> {
+    (0..DIGIT_SLOT_COUNT)
+        .flat_map(|digit_slot| {
+            SegmentKind::ALL.map(move |kind| SegmentState {
+                id: SegmentId {
+                    digit_slot: digit_slot as u8,
+                    kind,
+                },
+                lit: false,
+                representation: SegmentRepresentation::Anchored,
+            })
+        })
+        .collect()
+}
+
+pub fn apply_snapshot(segments: &mut [SegmentState], snapshot: DisplaySnapshot) {
+    for segment in segments {
+        let digit = snapshot.digits[usize::from(segment.id.digit_slot)];
+        segment.lit = digit.is_some_and(|digit| digit_mask(digit) & segment.id.kind.bit() != 0);
+    }
+}
+
+const fn digit_mask(digit: u8) -> u8 {
+    use SegmentKind::{Bottom, LowerLeft, LowerRight, Middle, Top, UpperLeft, UpperRight};
+
+    match digit {
+        0 => {
+            Top.bit()
+                | UpperRight.bit()
+                | LowerRight.bit()
+                | Bottom.bit()
+                | LowerLeft.bit()
+                | UpperLeft.bit()
+        }
+        1 => UpperRight.bit() | LowerRight.bit(),
+        2 => Top.bit() | UpperRight.bit() | Middle.bit() | LowerLeft.bit() | Bottom.bit(),
+        3 => Top.bit() | UpperRight.bit() | Middle.bit() | LowerRight.bit() | Bottom.bit(),
+        4 => UpperLeft.bit() | Middle.bit() | UpperRight.bit() | LowerRight.bit(),
+        5 => Top.bit() | UpperLeft.bit() | Middle.bit() | LowerRight.bit() | Bottom.bit(),
+        6 => {
+            Top.bit()
+                | UpperLeft.bit()
+                | Middle.bit()
+                | LowerLeft.bit()
+                | LowerRight.bit()
+                | Bottom.bit()
+        }
+        7 => Top.bit() | UpperRight.bit() | LowerRight.bit(),
+        8 => {
+            Top.bit()
+                | UpperRight.bit()
+                | LowerRight.bit()
+                | Bottom.bit()
+                | LowerLeft.bit()
+                | UpperLeft.bit()
+                | Middle.bit()
+        }
+        9 => {
+            Top.bit()
+                | UpperRight.bit()
+                | LowerRight.bit()
+                | Bottom.bit()
+                | UpperLeft.bit()
+                | Middle.bit()
+        }
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reading(hour: u8, minute: u8, second: u8) -> ClockReading {
+        ClockReading::new(hour, minute, second).unwrap()
+    }
+
+    #[test]
+    fn twenty_four_hour_display_keeps_leading_zero() {
+        assert_eq!(
+            snapshot(reading(4, 7, 2), ClockTimeFormat::TwentyFourHour),
+            DisplaySnapshot {
+                digits: [Some(0), Some(4), Some(0), Some(7)],
+                colon_lit: true,
+                meridiem: None,
+            }
+        );
+    }
+
+    #[test]
+    fn twelve_hour_display_handles_midnight_noon_and_blank_leading_slot() {
+        assert_eq!(
+            snapshot(reading(0, 5, 1), ClockTimeFormat::TwelveHour),
+            DisplaySnapshot {
+                digits: [Some(1), Some(2), Some(0), Some(5)],
+                colon_lit: false,
+                meridiem: Some("AM"),
+            }
+        );
+        assert_eq!(
+            snapshot(reading(12, 5, 2), ClockTimeFormat::TwelveHour),
+            DisplaySnapshot {
+                digits: [Some(1), Some(2), Some(0), Some(5)],
+                colon_lit: true,
+                meridiem: Some("PM"),
+            }
+        );
+        assert_eq!(
+            snapshot(reading(13, 5, 2), ClockTimeFormat::TwelveHour).digits,
+            [None, Some(1), Some(0), Some(5)]
+        );
+    }
+
+    #[test]
+    fn segments_have_stable_unique_ids_and_owned_cell_patterns() {
+        let segments = create_segments();
+        assert_eq!(segments.len(), DIGIT_SLOT_COUNT * SegmentKind::ALL.len());
+        for (index, segment) in segments.iter().enumerate() {
+            assert!(!segment.lit);
+            assert_eq!(segment.representation, SegmentRepresentation::Anchored);
+            assert!(!cells(segment.id.kind).is_empty());
+            assert!(!segments[..index].iter().any(|other| other.id == segment.id));
+        }
+    }
+}

--- a/scenarios/clock/src/lib.rs
+++ b/scenarios/clock/src/lib.rs
@@ -1,0 +1,312 @@
+//! Deterministic low-resolution clock scenario.
+
+mod digits;
+mod render;
+
+use std::time::Duration;
+
+pub use digits::{
+    DIGIT_SLOT_COUNT, DisplaySnapshot, GridCell, SegmentId, SegmentKind, SegmentRepresentation,
+    SegmentState,
+};
+
+use engine_common::{
+    Action, ClockTimeFormat, Observation, RenderFrame, Scenario, StepResult, TickModel,
+};
+
+pub const CLOCK_ACTION_VERSION: u16 = 1;
+pub const CLOCK_ACTION_SET_READING: u32 = 1;
+pub const CLOCK_OBSERVATION_VERSION: u16 = 1;
+
+const DEFAULT_ASPECT_RATIO: f32 = 800.0 / 480.0;
+const MIN_ASPECT_RATIO: f32 = 0.25;
+const MAX_ASPECT_RATIO: f32 = 4.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClockReading {
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+impl ClockReading {
+    pub const fn new(hour: u8, minute: u8, second: u8) -> Option<Self> {
+        if hour < 24 && minute < 60 && second < 60 {
+            Some(Self {
+                hour,
+                minute,
+                second,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub const fn hour(self) -> u8 {
+        self.hour
+    }
+
+    pub const fn minute(self) -> u8 {
+        self.minute
+    }
+
+    pub const fn second(self) -> u8 {
+        self.second
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockAction {
+    SetReading(ClockReading),
+}
+
+impl ClockAction {
+    pub fn set_reading(reading: ClockReading) -> Action {
+        let mut payload = Vec::with_capacity(5);
+        payload.extend_from_slice(&CLOCK_ACTION_VERSION.to_le_bytes());
+        payload.extend_from_slice(&[reading.hour, reading.minute, reading.second]);
+        Action::scenario(CLOCK_ACTION_SET_READING, payload)
+    }
+
+    pub fn decode(action: &Action) -> Option<Self> {
+        let Action::Scenario { kind, payload } = action else {
+            return None;
+        };
+        if *kind != CLOCK_ACTION_SET_READING || payload.len() != 5 {
+            return None;
+        }
+        let version = u16::from_le_bytes(payload[0..2].try_into().ok()?);
+        if version != CLOCK_ACTION_VERSION {
+            return None;
+        }
+        ClockReading::new(payload[2], payload[3], payload[4]).map(Self::SetReading)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClockConfig {
+    pub aspect_ratio: f32,
+    pub time_format: ClockTimeFormat,
+}
+
+impl Default for ClockConfig {
+    fn default() -> Self {
+        Self {
+            aspect_ratio: DEFAULT_ASPECT_RATIO,
+            time_format: ClockTimeFormat::TwentyFourHour,
+        }
+    }
+}
+
+impl ClockConfig {
+    fn normalized(self) -> Self {
+        Self {
+            aspect_ratio: normalize_aspect_ratio(self.aspect_ratio),
+            time_format: self.time_format,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ClockState {
+    config: ClockConfig,
+    reading: Option<ClockReading>,
+    display: DisplaySnapshot,
+    segments: Vec<SegmentState>,
+}
+
+impl ClockState {
+    pub fn reading(&self) -> Option<ClockReading> {
+        self.reading
+    }
+
+    pub fn display(&self) -> DisplaySnapshot {
+        self.display
+    }
+
+    pub fn segments(&self) -> &[SegmentState] {
+        &self.segments
+    }
+
+    pub fn time_format(&self) -> ClockTimeFormat {
+        self.config.time_format
+    }
+
+    pub fn aspect_ratio(&self) -> f32 {
+        self.config.aspect_ratio
+    }
+
+    pub fn set_aspect_ratio(&mut self, aspect_ratio: f32) {
+        self.config.aspect_ratio = normalize_aspect_ratio(aspect_ratio);
+    }
+
+    fn apply_reading(&mut self, reading: ClockReading) {
+        self.reading = Some(reading);
+        self.display = digits::snapshot(reading, self.config.time_format);
+        digits::apply_snapshot(&mut self.segments, self.display);
+    }
+}
+
+pub struct ClockScenario;
+
+impl Scenario for ClockScenario {
+    type State = ClockState;
+    type Config = ClockConfig;
+
+    fn init(config: Self::Config, _seed: u64) -> Self::State {
+        ClockState {
+            config: config.normalized(),
+            reading: None,
+            display: DisplaySnapshot::unsynchronized(),
+            segments: digits::create_segments(),
+        }
+    }
+
+    fn step(state: &mut Self::State, actions: &[Action], _dt: Duration) -> StepResult {
+        if let Some(ClockAction::SetReading(reading)) =
+            actions.iter().filter_map(ClockAction::decode).next_back()
+        {
+            state.apply_reading(reading);
+        }
+        StepResult::default()
+    }
+
+    fn observe(state: &Self::State) -> Observation {
+        let mut payload = Vec::with_capacity(8);
+        payload.extend_from_slice(&CLOCK_OBSERVATION_VERSION.to_le_bytes());
+        payload.push(u8::from(state.reading.is_some()));
+        if let Some(reading) = state.reading {
+            payload.extend_from_slice(&[reading.hour, reading.minute, reading.second]);
+        } else {
+            payload.extend_from_slice(&[u8::MAX; 3]);
+        }
+        payload.push(match state.config.time_format {
+            ClockTimeFormat::TwelveHour => 12,
+            ClockTimeFormat::TwentyFourHour => 24,
+        });
+        Observation { payload }
+    }
+
+    fn render_frame(state: &Self::State) -> RenderFrame {
+        render::render_frame(state)
+    }
+
+    fn tick_model() -> TickModel {
+        TickModel::FixedTimestep { hz: 60 }
+    }
+}
+
+fn normalize_aspect_ratio(aspect_ratio: f32) -> f32 {
+    if aspect_ratio.is_finite() && aspect_ratio > 0.0 {
+        aspect_ratio.clamp(MIN_ASPECT_RATIO, MAX_ASPECT_RATIO)
+    } else {
+        DEFAULT_ASPECT_RATIO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reading(hour: u8, minute: u8, second: u8) -> ClockReading {
+        ClockReading::new(hour, minute, second).unwrap()
+    }
+
+    #[test]
+    fn reading_action_round_trips_and_rejects_invalid_payloads() {
+        let action = ClockAction::set_reading(reading(19, 42, 7));
+        assert_eq!(
+            ClockAction::decode(&action),
+            Some(ClockAction::SetReading(reading(19, 42, 7)))
+        );
+
+        assert_eq!(
+            ClockAction::decode(&Action::scenario(
+                CLOCK_ACTION_SET_READING,
+                vec![1, 0, 24, 0, 0],
+            )),
+            None
+        );
+        assert_eq!(
+            ClockAction::decode(&Action::scenario(
+                CLOCK_ACTION_SET_READING,
+                vec![2, 0, 19, 42, 7],
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn latest_valid_reading_wins_without_advancing_wall_time() {
+        let mut state = ClockScenario::init(ClockConfig::default(), 9);
+        let original_ids = state
+            .segments()
+            .iter()
+            .map(|segment| segment.id)
+            .collect::<Vec<_>>();
+        ClockScenario::step(
+            &mut state,
+            &[
+                ClockAction::set_reading(reading(10, 11, 12)),
+                Action::scenario(CLOCK_ACTION_SET_READING, vec![1, 0, 99, 0, 0]),
+                ClockAction::set_reading(reading(10, 12, 13)),
+            ],
+            Duration::from_secs(30),
+        );
+
+        assert_eq!(state.reading(), Some(reading(10, 12, 13)));
+        assert_eq!(state.display().digits, [Some(1), Some(0), Some(1), Some(2)]);
+        assert!(!state.display().colon_lit);
+        assert_eq!(
+            state
+                .segments()
+                .iter()
+                .map(|segment| segment.id)
+                .collect::<Vec<_>>(),
+            original_ids
+        );
+
+        ClockScenario::step(&mut state, &[], Duration::from_secs(60));
+        assert_eq!(state.reading(), Some(reading(10, 12, 13)));
+    }
+
+    #[test]
+    fn observation_reports_sync_state_reading_and_format() {
+        let mut state = ClockScenario::init(
+            ClockConfig {
+                aspect_ratio: 16.0 / 9.0,
+                time_format: ClockTimeFormat::TwelveHour,
+            },
+            0,
+        );
+        assert_eq!(
+            ClockScenario::observe(&state).payload,
+            vec![1, 0, 0, 255, 255, 255, 12]
+        );
+        ClockScenario::step(
+            &mut state,
+            &[ClockAction::set_reading(reading(23, 59, 58))],
+            Duration::ZERO,
+        );
+        assert_eq!(
+            ClockScenario::observe(&state).payload,
+            vec![1, 0, 1, 23, 59, 58, 12]
+        );
+    }
+
+    #[test]
+    fn aspect_ratio_is_normalized_on_init_and_resize() {
+        let mut state = ClockScenario::init(
+            ClockConfig {
+                aspect_ratio: f32::NAN,
+                ..ClockConfig::default()
+            },
+            0,
+        );
+        assert_eq!(state.aspect_ratio(), DEFAULT_ASPECT_RATIO);
+        state.set_aspect_ratio(100.0);
+        assert_eq!(state.aspect_ratio(), MAX_ASPECT_RATIO);
+        state.set_aspect_ratio(0.0);
+        assert_eq!(state.aspect_ratio(), DEFAULT_ASPECT_RATIO);
+    }
+}

--- a/scenarios/clock/src/render.rs
+++ b/scenarios/clock/src/render.rs
@@ -1,0 +1,264 @@
+use engine_common::{
+    Camera2, Fill, RenderColor, RenderFrame, RenderPoint, RenderPolygon, RenderPrimitive,
+    RenderText, Stroke, TextAnchor,
+};
+
+use crate::{ClockState, digits};
+
+const CAMERA_HEIGHT: f32 = 480.0;
+const BACKGROUND_LAYER: i32 = 0;
+const ARENA_LAYER: i32 = 1;
+const INACTIVE_CELL_LAYER: i32 = 2;
+const ACTIVE_CELL_LAYER: i32 = 3;
+const LABEL_LAYER: i32 = 4;
+
+const BACKGROUND_COLOR: RenderColor = RenderColor::rgb(0.018, 0.025, 0.055);
+const FLOOR_COLOR: RenderColor = RenderColor::rgb(0.075, 0.105, 0.145);
+const FLOOR_EDGE_COLOR: RenderColor = RenderColor::rgb(0.19, 0.40, 0.52);
+const INACTIVE_CELL_COLOR: RenderColor = RenderColor::rgb(0.045, 0.105, 0.135);
+const ACTIVE_CELL_COLOR: RenderColor = RenderColor::rgb(0.33, 0.94, 0.91);
+const ACTIVE_CELL_EDGE_COLOR: RenderColor = RenderColor::rgb(0.72, 1.0, 0.96);
+const LABEL_COLOR: RenderColor = RenderColor::rgb(0.52, 0.72, 0.77);
+
+const DIGIT_ORIGINS: [f32; 4] = [0.0, 7.0, 17.0, 24.0];
+const FACE_WIDTH_UNITS: f32 = 30.0;
+const FACE_HEIGHT_UNITS: f32 = 9.0;
+const COLON_X_UNITS: f32 = 14.5;
+const COLON_Y_UNITS: [f32; 2] = [2.25, 5.75];
+
+#[derive(Debug, Clone, Copy)]
+struct Layout {
+    bounds_min: RenderPoint,
+    bounds_max: RenderPoint,
+    pitch: f32,
+    face_origin: RenderPoint,
+    floor_y: f32,
+}
+
+impl Layout {
+    fn new(aspect_ratio: f32) -> Self {
+        let world_width = CAMERA_HEIGHT * aspect_ratio;
+        let bounds_min = RenderPoint::new(-world_width * 0.5, -CAMERA_HEIGHT * 0.5);
+        let bounds_max = RenderPoint::new(world_width * 0.5, CAMERA_HEIGHT * 0.5);
+        let floor_y = bounds_min.y + CAMERA_HEIGHT * 0.16;
+        let horizontal_margin = (world_width * 0.06).max(16.0);
+        let face_bottom = floor_y + CAMERA_HEIGHT * 0.08;
+        let face_top = bounds_max.y - CAMERA_HEIGHT * 0.10;
+        let pitch = ((world_width - horizontal_margin * 2.0) / FACE_WIDTH_UNITS)
+            .min((face_top - face_bottom) / (FACE_HEIGHT_UNITS + 1.0))
+            .max(2.0);
+        let face_origin = RenderPoint::new(
+            -FACE_WIDTH_UNITS * pitch * 0.5,
+            (face_bottom + face_top - FACE_HEIGHT_UNITS * pitch) * 0.5,
+        );
+
+        Self {
+            bounds_min,
+            bounds_max,
+            pitch,
+            face_origin,
+            floor_y,
+        }
+    }
+
+    fn digit_origin(self, slot: usize) -> RenderPoint {
+        RenderPoint::new(
+            self.face_origin.x + DIGIT_ORIGINS[slot] * self.pitch,
+            self.face_origin.y,
+        )
+    }
+}
+
+pub fn render_frame(state: &ClockState) -> RenderFrame {
+    let layout = Layout::new(state.aspect_ratio());
+    let mut frame = RenderFrame::new(Camera2::new(RenderPoint::ZERO, CAMERA_HEIGHT));
+    frame.push_primitive(
+        BACKGROUND_LAYER,
+        rectangle(layout.bounds_min, layout.bounds_max, BACKGROUND_COLOR, None),
+    );
+    render_floor(&mut frame, layout);
+    render_segments(&mut frame, state, layout);
+    render_colon(&mut frame, state, layout);
+    render_meridiem(&mut frame, state, layout);
+    frame
+}
+
+fn render_floor(frame: &mut RenderFrame, layout: Layout) {
+    let drain_half_width = (layout.pitch * 0.85).max(10.0);
+    let left_max = RenderPoint::new(-drain_half_width, layout.floor_y);
+    let right_min = RenderPoint::new(drain_half_width, layout.bounds_min.y);
+    frame.push_primitive(
+        ARENA_LAYER,
+        rectangle(layout.bounds_min, left_max, FLOOR_COLOR, None),
+    );
+    frame.push_primitive(
+        ARENA_LAYER,
+        rectangle(
+            right_min,
+            RenderPoint::new(layout.bounds_max.x, layout.floor_y),
+            FLOOR_COLOR,
+            None,
+        ),
+    );
+
+    let edge_height = (layout.pitch * 0.10).clamp(1.5, 3.0);
+    frame.push_primitive(
+        ARENA_LAYER,
+        rectangle(
+            RenderPoint::new(layout.bounds_min.x, layout.floor_y - edge_height),
+            RenderPoint::new(-drain_half_width, layout.floor_y),
+            FLOOR_EDGE_COLOR,
+            None,
+        ),
+    );
+    frame.push_primitive(
+        ARENA_LAYER,
+        rectangle(
+            RenderPoint::new(drain_half_width, layout.floor_y - edge_height),
+            RenderPoint::new(layout.bounds_max.x, layout.floor_y),
+            FLOOR_EDGE_COLOR,
+            None,
+        ),
+    );
+}
+
+fn render_segments(frame: &mut RenderFrame, state: &ClockState, layout: Layout) {
+    for segment in state.segments() {
+        let origin = layout.digit_origin(usize::from(segment.id.digit_slot));
+        for cell in digits::cells(segment.id.kind) {
+            render_cell(
+                frame,
+                RenderPoint::new(
+                    origin.x + f32::from(cell.x) * layout.pitch,
+                    origin.y + f32::from(cell.y) * layout.pitch,
+                ),
+                layout.pitch,
+                segment.lit,
+            );
+        }
+    }
+}
+
+fn render_colon(frame: &mut RenderFrame, state: &ClockState, layout: Layout) {
+    for y in COLON_Y_UNITS {
+        render_cell(
+            frame,
+            RenderPoint::new(
+                layout.face_origin.x + COLON_X_UNITS * layout.pitch,
+                layout.face_origin.y + y * layout.pitch,
+            ),
+            layout.pitch,
+            state.display().colon_lit,
+        );
+    }
+}
+
+fn render_meridiem(frame: &mut RenderFrame, state: &ClockState, layout: Layout) {
+    let Some(meridiem) = state.display().meridiem else {
+        return;
+    };
+    let mut label = RenderText::new(
+        RenderPoint::new(
+            layout.face_origin.x + FACE_WIDTH_UNITS * layout.pitch,
+            layout.face_origin.y - layout.pitch * 0.20,
+        ),
+        meridiem,
+    );
+    label.color = LABEL_COLOR;
+    label.size = (layout.pitch * 0.68).clamp(10.0, 20.0);
+    label.anchor = TextAnchor::TopLeft;
+    frame.push_primitive(LABEL_LAYER, RenderPrimitive::Text(label));
+}
+
+fn render_cell(frame: &mut RenderFrame, lower_left: RenderPoint, pitch: f32, lit: bool) {
+    let size = pitch * 0.80;
+    let inset = (pitch - size) * 0.5;
+    let min = RenderPoint::new(lower_left.x + inset, lower_left.y + inset);
+    let max = RenderPoint::new(min.x + size, min.y + size);
+    let layer = if lit {
+        ACTIVE_CELL_LAYER
+    } else {
+        INACTIVE_CELL_LAYER
+    };
+    let color = if lit {
+        ACTIVE_CELL_COLOR
+    } else {
+        INACTIVE_CELL_COLOR
+    };
+    let stroke = lit.then(|| Stroke::new(ACTIVE_CELL_EDGE_COLOR, (pitch * 0.045).max(0.8)));
+    frame.push_primitive(layer, rectangle(min, max, color, stroke));
+}
+
+fn rectangle(
+    min: RenderPoint,
+    max: RenderPoint,
+    color: RenderColor,
+    stroke: Option<Stroke>,
+) -> RenderPrimitive {
+    RenderPrimitive::Polygon(RenderPolygon {
+        points: vec![
+            min,
+            RenderPoint::new(max.x, min.y),
+            max,
+            RenderPoint::new(min.x, max.y),
+        ],
+        fill: Some(Fill::new(color)),
+        stroke,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use engine_common::{ClockTimeFormat, RenderPrimitive, Scenario};
+
+    use super::*;
+    use crate::{ClockAction, ClockConfig, ClockReading, ClockScenario};
+
+    fn rendered_at(aspect_ratio: f32) -> RenderFrame {
+        let mut state = ClockScenario::init(
+            ClockConfig {
+                aspect_ratio,
+                time_format: ClockTimeFormat::TwentyFourHour,
+            },
+            7,
+        );
+        ClockScenario::step(
+            &mut state,
+            &[ClockAction::set_reading(
+                ClockReading::new(23, 58, 2).unwrap(),
+            )],
+            std::time::Duration::ZERO,
+        );
+        ClockScenario::render_frame(&state)
+    }
+
+    #[test]
+    fn cells_remain_inside_landscape_and_portrait_cameras() {
+        for aspect_ratio in [5.0 / 3.0, 16.0 / 9.0, 3.0 / 4.0] {
+            let frame = rendered_at(aspect_ratio);
+            let bounds = frame.camera.world_bounds(aspect_ratio);
+            for polygon in frame.layers.iter().flat_map(|layer| &layer.primitives) {
+                let RenderPrimitive::Polygon(polygon) = polygon else {
+                    continue;
+                };
+                for point in &polygon.points {
+                    assert!(point.x >= bounds.min.x - f32::EPSILON);
+                    assert!(point.x <= bounds.max.x + f32::EPSILON);
+                    assert!(point.y >= bounds.min.y - f32::EPSILON);
+                    assert!(point.y <= bounds.max.y + f32::EPSILON);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn normal_face_has_a_small_bounded_primitive_count() {
+        let frame = rendered_at(5.0 / 3.0);
+        let primitive_count = frame
+            .layers
+            .iter()
+            .map(|layer| layer.primitives.len())
+            .sum::<usize>();
+        assert_eq!(primitive_count, 103);
+    }
+}

--- a/yocto/kas-spacewars.yml
+++ b/yocto/kas-spacewars.yml
@@ -56,6 +56,7 @@ local_conf_header:
     INIT_MANAGER = "systemd"
     PACKAGECONFIG:append:pn-systemd = " coredump"
     hostname:pn-base-files = "spacewars"
+    DEFAULT_TIMEZONE = "America/Los_Angeles"
 
     IMAGE_FSTYPES = "wic.gz wic.bmap ext4.gz"
     WKS_FILE = "sdimage-ab.wks.in"

--- a/yocto/meta-spacewars/recipes-core/images/spacewars-image.bb
+++ b/yocto/meta-spacewars/recipes-core/images/spacewars-image.bb
@@ -115,6 +115,7 @@ IMAGE_INSTALL:append = " \
     rsync \
     screen \
     strace \
+    tzdata-core \
     tree \
     vim \
 "


### PR DESCRIPTION
## Summary

- add a deterministic, responsive seven-segment Clock scenario driven by typed device-local time actions
- integrate Clock into launcher discovery, persisted 12/24-hour settings, semantic UI controls, and the functional lifecycle suite
- configure the Raspberry Pi image for NTP-synchronized `America/Los_Angeles` time with daylight-saving data
- document the new scenario and its functional-test workflow

This is the useful-clock first milestone; physics events and the event-profile setting remain follow-up work.

Part of #19

## Verification

- `cargo test -p scenario-clock`
- `cargo check -p engine-client --all-targets`
- `cargo test -p engine-client`
- `cargo test --locked --workspace --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p scenario-clock --all-targets -- -D warnings`
- full three-case external UI functional suite on `DISPLAY=:0`
- Yocto image build and A/B deployment to the Raspberry Pi
- device verification: Clock active, kiosk service healthy, timezone `America/Los_Angeles`, NTP synchronized