### PR TITLE
Add Surface Sortie with spaceling boarding and physical landing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,6 +4651,7 @@ dependencies = [
  "engine-rapier",
  "image",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The local launcher currently hosts seven playable scenarios:
 - **Spaceling Lab** — a single-body character walking and jumping on a rotating
   planet, with gravity-relative upright control and visible contact diagnostics.
   See [Spaceling Lab](docs/spaceling-lab.md).
+- **Surface Sortie** — an opt-in Spacewars pilot/vehicle experiment: land
+  rear-first with flight assistance, walk/jump on the planet, and reboard the
+  same physical ship. Includes a translucent minimap and landing diagnostics.
+  See [Surface Sortie](docs/surface-sortie.md) for controls and scope.
 - **Falling** — the pinned MIT-licensed NES homebrew running on this repository's
   Rust-native mapper-0 emulator, with pixel-perfect native video, exact-rational
   realtime pacing, and bounded 48 kHz device audio.
@@ -86,6 +90,7 @@ cargo run -p engine-client -- --scenario pizza
 cargo run -p engine-client -- --scenario clock
 cargo run -p engine-client -- --scenario rover-lab
 cargo run -p engine-client -- --scenario spaceling-lab
+cargo run -p engine-client -- --scenario surface-sortie
 cargo run -p engine-client -- --scenario spacewars
 cargo run -p engine-client -- --scenario falling
 ```

--- a/crates/engine-client/src/client_scenarios/mod.rs
+++ b/crates/engine-client/src/client_scenarios/mod.rs
@@ -19,6 +19,7 @@ mod pizza;
 mod rover_lab;
 mod spaceling_lab;
 mod spacewars;
+mod surface_sortie;
 
 #[cfg(test)]
 pub(crate) use pizza::PizzaClientScenario;
@@ -372,6 +373,7 @@ static SCENARIOS: &[ScenarioRegistration] = &[
     rover_lab::REGISTRATION,
     spaceling_lab::REGISTRATION,
     spacewars::REGISTRATION,
+    surface_sortie::REGISTRATION,
 ];
 
 pub fn registrations() -> &'static [ScenarioRegistration] {
@@ -437,7 +439,8 @@ mod tests {
                 "pizza",
                 "rover-lab",
                 "spaceling-lab",
-                "spacewars"
+                "spacewars",
+                "surface-sortie"
             ]
         );
     }

--- a/crates/engine-client/src/client_scenarios/spaceling_lab.rs
+++ b/crates/engine-client/src/client_scenarios/spaceling_lab.rs
@@ -81,7 +81,7 @@ impl ClientScenario for SpacelingLabClientScenario {
     }
 }
 
-fn spaceling_controls(input: &ClientInput) -> (f32, bool, bool) {
+pub(super) fn spaceling_controls(input: &ClientInput) -> (f32, bool, bool) {
     let (gamepad_walk, gamepad_jump, gamepad_shove) = input.spaceling_gamepad_input();
     let left = input.is_pressed(GameKey::P1TurnLeft) || input.is_pressed(GameKey::NesLeft);
     let right = input.is_pressed(GameKey::P1TurnRight) || input.is_pressed(GameKey::NesRight);

--- a/crates/engine-client/src/client_scenarios/surface_sortie.rs
+++ b/crates/engine-client/src/client_scenarios/surface_sortie.rs
@@ -1,0 +1,269 @@
+use std::time::Duration;
+
+use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
+use scenario_spacewars::surface_sortie::{
+    SurfaceSortieAction, SurfaceSortieScenario, SurfaceSortieState,
+};
+
+use super::{
+    ClientScenario, RenderBackend, ScenarioAsset, ScenarioCapabilities, ScenarioCreateError,
+    ScenarioRegistration, ScenarioStartMode, spaceling_lab::spaceling_controls,
+};
+use crate::{
+    input::ClientInput,
+    render::{FrameLayout, Viewport},
+};
+
+pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
+    id: "surface-sortie",
+    launcher_visible: true,
+    capabilities: ScenarioCapabilities {
+        benchmark: false,
+        pointer_input: false,
+        player_zoom: false,
+        game_over: false,
+        native_video: false,
+        captures_gamepad_start: false,
+        captures_gamepad_select: false,
+    },
+    controls_help: "Surface Sortie (experimental): left/right or A/D turns aboard, walks on foot. A / Space thrusts aboard and jumps on foot. Down / S brakes. Point the nose away from the planet for landing assist; settle on both rear feet. B / X exits a landed ship or boards at its cyan hatch. Release controls after transferring. Start / Esc pauses; R restarts. North-up minimap: red ship, orange spaceling, cyan planet. No weapons or capture.",
+    create,
+};
+
+struct SurfaceSortieClientScenario {
+    state: SurfaceSortieState,
+}
+
+fn create(
+    seed: u64,
+    _settings: &Settings,
+    _viewport: Viewport,
+    _mode: ScenarioStartMode,
+    _asset: &ScenarioAsset,
+) -> Result<Box<dyn ClientScenario>, ScenarioCreateError> {
+    Ok(Box::new(SurfaceSortieClientScenario {
+        state: SurfaceSortieScenario::init((), seed),
+    }))
+}
+
+impl ClientScenario for SurfaceSortieClientScenario {
+    fn registration(&self) -> &'static ScenarioRegistration {
+        &REGISTRATION
+    }
+    fn tick_model(&self) -> TickModel {
+        SurfaceSortieScenario::tick_model()
+    }
+    fn step(&mut self, actions: &[Action], dt: Duration) -> StepResult {
+        SurfaceSortieScenario::step(&mut self.state, actions, dt)
+    }
+    fn map_input(&self, input: &mut ClientInput, _benchmark: bool) -> Vec<Action> {
+        let (horizontal, primary_held, interact_held) = spaceling_controls(input);
+        vec![
+            SurfaceSortieAction {
+                horizontal,
+                primary_held,
+                interact_held,
+                brake_held: input.surface_sortie_brake_held(),
+            }
+            .encode(),
+        ]
+    }
+    fn render_frames(&self, _renderer: RenderBackend, viewport: Viewport) -> Vec<RenderFrame> {
+        vec![
+            SurfaceSortieScenario::render_frame(&self.state),
+            SurfaceSortieScenario::minimap_frame(&self.state, viewport.aspect_ratio()),
+        ]
+    }
+    fn frame_layout(&self) -> FrameLayout {
+        FrameLayout::SinglePlayerWithMinimap
+    }
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::{GameKey, GamepadInput, GamepadSeatInput};
+    use std::{cell::RefCell, rc::Rc};
+
+    #[test]
+    fn keyboard_and_nes_pad_produce_the_same_context_neutral_intent() {
+        let scenario = SurfaceSortieClientScenario {
+            state: SurfaceSortieScenario::init((), 0),
+        };
+        let mut keyboard = ClientInput::default();
+        for key in [
+            GameKey::P1TurnLeft,
+            GameKey::P1Laser,
+            GameKey::P1Reverse,
+            GameKey::P1Brake,
+        ] {
+            keyboard.press(key);
+        }
+        let pads = Rc::new(RefCell::new(GamepadInput::default()));
+        pads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                dpad_left: true,
+                dpad_down: true,
+                south: true,
+                east: true,
+                ..GamepadSeatInput::default()
+            },
+        );
+        let mut input = ClientInput::new(Rc::clone(&pads));
+        assert_eq!(
+            scenario.map_input(&mut keyboard, false),
+            scenario.map_input(&mut input, false)
+        );
+        pads.borrow_mut().set_seat(0, GamepadSeatInput::default());
+        assert_eq!(
+            scenario.map_input(&mut input, false),
+            vec![SurfaceSortieAction::default().encode()]
+        );
+    }
+
+    #[test]
+    fn registered_fixture_renders_and_restarts_in_both_backends() {
+        let viewport = Viewport::new(1280.0, 720.0);
+        let mut scenario = REGISTRATION
+            .create(0, &Settings::default(), viewport, ScenarioStartMode::Normal)
+            .unwrap();
+        let initial = scenario.render_frames(RenderBackend::Vector, viewport);
+        for tick in 0..90 {
+            scenario.step(
+                &[SurfaceSortieAction {
+                    interact_held: tick == 60,
+                    ..SurfaceSortieAction::default()
+                }
+                .encode()],
+                Duration::from_secs_f64(1.0 / 60.0),
+            );
+            if tick == 59 {
+                check_render(&*scenario, viewport, "aboard");
+                check_render(&*scenario, Viewport::new(1280.0, 1400.0), "aboard-portrait");
+            }
+        }
+        let frames = scenario.render_frames(RenderBackend::Vector, viewport);
+        assert_eq!(
+            frames,
+            scenario.render_frames(RenderBackend::Raster, viewport)
+        );
+        assert_ne!(frames, initial);
+        check_render(&*scenario, viewport, "on-foot");
+        check_render(
+            &*scenario,
+            Viewport::new(1280.0, 1400.0),
+            "on-foot-portrait",
+        );
+        assert!(matches!(
+            scenario
+                .as_any()
+                .downcast_ref::<SurfaceSortieClientScenario>()
+                .unwrap()
+                .state
+                .location(),
+            scenario_spacewars::surface_sortie::PilotLocation::OnFoot
+        ));
+        let fresh = REGISTRATION
+            .create(0, &Settings::default(), viewport, ScenarioStartMode::Normal)
+            .unwrap();
+        assert_eq!(
+            initial,
+            fresh.render_frames(RenderBackend::Vector, viewport)
+        );
+    }
+
+    fn check_render(scenario: &dyn ClientScenario, viewport: Viewport, name: &str) {
+        use crate::raster::{RasterOptions, RasterRenderer};
+        let frames = scenario.render_frames(RenderBackend::Vector, viewport);
+        let presentation = crate::render::scene_presentation_from_frames_with_layout(
+            &frames,
+            viewport,
+            scenario.frame_layout(),
+        );
+        assert!(!presentation.main_primitives.is_empty());
+        assert_eq!(presentation.minimaps.len(), 1);
+        assert!(!presentation.minimaps[0].primitives.is_empty());
+        let overlay =
+            crate::render::raster_text_overlay(&frames, viewport, scenario.frame_layout());
+        let label = if name.starts_with("on-foot") {
+            "ON FOOT"
+        } else {
+            "ABOARD"
+        };
+        assert!(overlay.iter().any(|p| p.text.starts_with(label)));
+        let image = RasterRenderer::new().image_from_frames_with_layout(
+            &frames,
+            viewport,
+            scenario.frame_layout(),
+            RasterOptions::default(),
+        );
+        let pixels = image.to_rgb8().unwrap();
+        let ship_pixels = pixels
+            .as_slice()
+            .iter()
+            .filter(|p| p.r > 200 && p.g < 80 && p.b < 80)
+            .count();
+        assert!(ship_pixels > 100, "missing ship in {name}: {ship_pixels}");
+        if name.starts_with("on-foot") {
+            let position = scenario
+                .as_any()
+                .downcast_ref::<SurfaceSortieClientScenario>()
+                .unwrap()
+                .state
+                .observation()
+                .position;
+            let projected = frames[0].camera.world_to_viewport(
+                engine_common::RenderPoint::new(position.x, position.y),
+                viewport.aspect_ratio(),
+            );
+            let center_x = projected.x * pixels.width() as f32;
+            let center_y = projected.y * pixels.height() as f32;
+            let suit_pixels = pixels
+                .as_slice()
+                .iter()
+                .enumerate()
+                .filter(|(i, p)| {
+                    let x = i % pixels.width() as usize;
+                    let y = i / pixels.width() as usize;
+                    (x as f32 - center_x).abs() < 60.0
+                        && (y as f32 - center_y).abs() < 60.0
+                        && p.r > 200
+                        && p.g > 80
+                        && p.g < 190
+                        && p.b < 100
+                })
+                .count();
+            assert!(suit_pixels > 20, "missing on-foot actor: {suit_pixels}");
+        }
+        if let Some(directory) = std::env::var_os("SPACEWARS_SORTIE_ARTIFACTS") {
+            let directory = std::path::PathBuf::from(directory);
+            let directory = if directory.is_absolute() {
+                directory
+            } else {
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../..")
+                    .join(directory)
+            };
+            std::fs::create_dir_all(&directory).unwrap();
+            let file = std::fs::File::create(directory.join(format!("{name}.png"))).unwrap();
+            let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
+            encoder.set_color(png::ColorType::Rgb);
+            encoder.set_depth(png::BitDepth::Eight);
+            encoder
+                .write_header()
+                .unwrap()
+                .write_image_data(pixels.as_bytes())
+                .unwrap();
+        }
+    }
+}

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -1468,23 +1468,23 @@ fn set_vector_presentation(window: &MainWindow, presentation: render::VectorPres
     window.set_minimap_opacity(render::SPACEWARS_MINIMAP_OPACITY);
 
     let mut minimaps = presentation.minimaps.into_iter();
+    // Clear the unused group when switching from two player maps to one (or none).
+    window.set_p2_minimap_size(0.0);
+    window.set_p2_minimap_primitives(ModelRc::default());
     let Some(player_1) = minimaps.next() else {
         window.set_vector_minimaps_visible(false);
         return;
     };
-    let Some(player_2) = minimaps.next() else {
-        window.set_vector_minimaps_visible(false);
-        return;
-    };
-
     window.set_p1_minimap_x(player_1.viewport.x);
     window.set_p1_minimap_y(player_1.viewport.y);
     window.set_p1_minimap_size(player_1.viewport.width);
     window.set_p1_minimap_primitives(ModelRc::new(VecModel::from(player_1.primitives)));
-    window.set_p2_minimap_x(player_2.viewport.x);
-    window.set_p2_minimap_y(player_2.viewport.y);
-    window.set_p2_minimap_size(player_2.viewport.width);
-    window.set_p2_minimap_primitives(ModelRc::new(VecModel::from(player_2.primitives)));
+    if let Some(player_2) = minimaps.next() {
+        window.set_p2_minimap_x(player_2.viewport.x);
+        window.set_p2_minimap_y(player_2.viewport.y);
+        window.set_p2_minimap_size(player_2.viewport.width);
+        window.set_p2_minimap_primitives(ModelRc::new(VecModel::from(player_2.primitives)));
+    }
     window.set_vector_minimaps_visible(true);
 }
 
@@ -2219,6 +2219,46 @@ mod tests {
     use crate::input::ScreenPointerEvent;
 
     const TEST_VIEWPORT: Viewport = Viewport::new(1280.0, 720.0);
+
+    #[test]
+    fn vector_minimap_groups_switch_between_two_one_and_none_without_stale_maps() {
+        use slint::Model;
+        use slint::platform::software_renderer::{MinimalSoftwareWindow, RepaintBufferType};
+        use slint::platform::{Platform, PlatformError, WindowAdapter};
+        struct TestPlatform;
+        impl Platform for TestPlatform {
+            fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+                Ok(MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer))
+            }
+        }
+        slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+        let window = MainWindow::new().unwrap();
+        for count in [2, 1, 0, 2] {
+            let presentation = render::VectorPresentation {
+                main_primitives: Vec::new(),
+                minimaps: (0..count)
+                    .map(|index| render::VectorMinimap {
+                        viewport: Viewport::with_origin(index as f32 * 100.0, 10.0, 80.0, 80.0),
+                        primitives: vec![crate::ScenePrimitive::default()],
+                    })
+                    .collect(),
+            };
+            set_vector_presentation(&window, presentation);
+            assert_eq!(window.get_vector_minimaps_visible(), count > 0);
+            if count > 0 {
+                assert_eq!(window.get_p1_minimap_size(), 80.0);
+                assert_eq!(window.get_p1_minimap_primitives().row_count(), 1);
+            }
+            assert_eq!(
+                window.get_p2_minimap_size(),
+                if count == 2 { 80.0 } else { 0.0 }
+            );
+            assert_eq!(
+                window.get_p2_minimap_primitives().row_count(),
+                usize::from(count == 2)
+            );
+        }
+    }
 
     fn hosted_scenario(name: &str, seed: u64) -> Result<HostedScenario, HostError> {
         HostedScenario::new(

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -296,6 +296,16 @@ impl ClientInput {
         (walk, gamepad.south, gamepad.east)
     }
 
+    pub(crate) fn surface_sortie_brake_held(&self) -> bool {
+        self.is_pressed(GameKey::P1Brake)
+            || self.is_pressed(GameKey::NesDown)
+            || self
+                .gamepads
+                .borrow()
+                .seat(0)
+                .is_some_and(|pad| pad.connected && pad.dpad_down)
+    }
+
     pub(crate) fn nes_controller_buttons(&self, player: usize) -> ControllerButtons {
         let mut buttons = ControllerButtons::NONE;
         let pressed = self.pressed.borrow();

--- a/crates/engine-client/src/raster.rs
+++ b/crates/engine-client/src/raster.rs
@@ -216,6 +216,19 @@ impl RasterRenderer {
                     starfield_cache,
                     &mut timings,
                 );
+            } else if layout == FrameLayout::SinglePlayerWithMinimap && frames.len() == 2 {
+                let viewports =
+                    render::frame_viewports(Viewport::new(width as f32, height as f32), 2, layout);
+                let started = Instant::now();
+                canvas.draw_frame(&frames[0], viewports[0]);
+                timings.other_frames += started.elapsed();
+                draw_uncached_overview(
+                    &mut canvas,
+                    &frames[1],
+                    viewports[1],
+                    overview_buffers,
+                    &mut timings,
+                );
             } else if !frames.is_empty() {
                 let viewports = render::frame_viewports(
                     Viewport::new(width as f32, height as f32),
@@ -405,6 +418,39 @@ fn draw_cached_overview(
         overlay.pixels.as_slice(),
         overlay.width,
         overlay.height,
+        viewport.x.round() as i32,
+        viewport.y.round() as i32,
+        render::SPACEWARS_MINIMAP_OPACITY,
+    );
+    timings.overview_blit += started.elapsed();
+}
+
+/// Small scenario-defined overviews have no Spacewars layer/cache conventions.
+/// Composite the complete opaque backing and scene once, just like vector groups.
+fn draw_uncached_overview(
+    canvas: &mut Canvas<'_>,
+    frame: &RenderFrame,
+    viewport: Viewport,
+    buffers: &mut OverviewBuffers,
+    timings: &mut RasterTimings,
+) {
+    let width = viewport.width.ceil().max(1.0) as u32;
+    let height = viewport.height.ceil().max(1.0) as u32;
+    let overlay = buffers.composite[0].get_or_insert_with(|| CachedRaster::new(width, height));
+    if overlay.width != width || overlay.height != height {
+        *overlay = CachedRaster::new(width, height);
+    }
+    let started = Instant::now();
+    let pixels = overlay.pixels.make_mut_slice();
+    clear_pixels(pixels);
+    Canvas::new(width, height, pixels)
+        .draw_frame(frame, Viewport::new(width as f32, height as f32));
+    timings.overview_live += started.elapsed();
+    let started = Instant::now();
+    canvas.blit_circle_with_opacity(
+        overlay.pixels.as_slice(),
+        width,
+        height,
         viewport.x.round() as i32,
         viewport.y.round() as i32,
         render::SPACEWARS_MINIMAP_OPACITY,
@@ -1983,6 +2029,58 @@ mod tests {
 
         assert_eq!(left_overview_center, BACKGROUND);
         assert!(right_overview_center.b > BACKGROUND.b);
+    }
+
+    #[test]
+    fn single_player_minimap_has_one_translucent_backing_and_keeps_its_corners_clear() {
+        let camera = Camera2::new(RenderPoint::ZERO, 100.0);
+        let mut player = RenderFrame::new(camera);
+        player.push_primitive(
+            0,
+            RenderPrimitive::Circle(RenderCircle::filled(
+                RenderPoint::ZERO,
+                100.0,
+                RenderColor::RED,
+            )),
+        );
+        let mut minimap = RenderFrame::new(camera);
+        let frames = [player.clone(), minimap.clone()];
+        let viewport = Viewport::new(100.0, 100.0);
+        let layout = FrameLayout::SinglePlayerWithMinimap;
+        let pane = render::frame_viewports(viewport, 2, layout)[1];
+        let x = (pane.x + pane.width * 0.5).round() as usize;
+        let y = (pane.y + pane.height * 0.5).round() as usize;
+        let mut renderer = RasterRenderer::new();
+        let empty = renderer
+            .image_from_frames_with_layout(&frames, viewport, layout, RasterOptions::default())
+            .to_rgb8()
+            .unwrap();
+        let backing = empty.as_slice()[y * 100 + x];
+        assert!(backing.r > BACKGROUND.r && backing.r < 255);
+        assert_eq!(
+            empty.as_slice()[pane.y as usize * 100 + pane.x as usize].r,
+            255
+        );
+        // Opaque overlapping items are composited within the map, not individually
+        // faded over the player. The top item completely hides the lower one.
+        for color in [RenderColor::GREEN, RenderColor::BLUE] {
+            minimap.push_primitive(
+                0,
+                RenderPrimitive::Circle(RenderCircle::filled(RenderPoint::ZERO, 15.0, color)),
+            );
+        }
+        let layered = renderer
+            .image_from_frames_with_layout(
+                &[player, minimap],
+                viewport,
+                layout,
+                RasterOptions::default(),
+            )
+            .to_rgb8()
+            .unwrap();
+        let center = layered.as_slice()[y * 100 + x];
+        assert!(center.r > 0 && center.b > 150);
+        assert_eq!(center.g, 0);
     }
 
     #[test]

--- a/crates/engine-client/src/render.rs
+++ b/crates/engine-client/src/render.rs
@@ -32,6 +32,8 @@ pub(crate) const MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER: f32 = 2.0;
 pub enum FrameLayout {
     EqualHorizontal,
     SpacewarsLocalPlay,
+    /// One full-window camera with a translucent overview below the top HUD.
+    SinglePlayerWithMinimap,
 }
 
 pub struct VectorPresentation {
@@ -147,14 +149,17 @@ pub fn scene_presentation_from_frames_with_layout(
         main_primitives: Vec::new(),
         minimaps: Vec::new(),
     };
-    let uses_minimap_groups = layout == FrameLayout::SpacewarsLocalPlay && frames.len() >= 4;
-
     for (index, (frame, frame_viewport)) in frames
         .iter()
         .zip(frame_viewports(viewport, frames.len(), layout))
         .enumerate()
     {
-        if uses_minimap_groups && (2..4).contains(&index) {
+        let is_minimap = match layout {
+            FrameLayout::SpacewarsLocalPlay => frames.len() >= 4 && (2..4).contains(&index),
+            FrameLayout::SinglePlayerWithMinimap => frames.len() == 2 && index == 1,
+            FrameLayout::EqualHorizontal => false,
+        };
+        if is_minimap {
             let minimum_object_diameter = (layout == FrameLayout::SpacewarsLocalPlay
                 && (2..4).contains(&index))
             .then_some(MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER);
@@ -184,6 +189,22 @@ pub(crate) fn frame_viewports(
 ) -> Vec<Viewport> {
     match layout {
         FrameLayout::EqualHorizontal => viewport.split_horizontally(count),
+        FrameLayout::SinglePlayerWithMinimap => {
+            if count != 2 {
+                return viewport.split_horizontally(count);
+            }
+            let size = viewport.height.min(viewport.width) * 0.25;
+            let margin = (viewport.height * 0.02).clamp(4.0, 16.0).min(size * 0.2);
+            vec![
+                viewport,
+                Viewport::with_origin(
+                    viewport.x + viewport.width - size - margin,
+                    viewport.y + viewport.height * 0.25,
+                    size,
+                    size,
+                ),
+            ]
+        }
         FrameLayout::SpacewarsLocalPlay => {
             if count < 4 {
                 return viewport.split_horizontally(count);
@@ -248,13 +269,20 @@ pub(crate) fn raster_text_overlay(
     viewport: Viewport,
     layout: FrameLayout,
 ) -> Vec<ScenePrimitive> {
-    if layout != FrameLayout::EqualHorizontal {
+    if layout == FrameLayout::SpacewarsLocalPlay {
         return Vec::new();
     }
     let mut output = Vec::new();
     for (frame, pane) in frames
         .iter()
         .zip(frame_viewports(viewport, frames.len(), layout))
+        .take(
+            if layout == FrameLayout::SinglePlayerWithMinimap && frames.len() == 2 {
+                1
+            } else {
+                frames.len()
+            },
+        )
     {
         for layer in frame.ordered_layers() {
             for primitive in &layer.primitives {
@@ -867,6 +895,38 @@ mod tests {
         assert_close(primitives[1].y, 0.0);
         assert_close(primitives[1].width, 100.0);
         assert_close(primitives[1].height, 100.0);
+    }
+
+    #[test]
+    fn single_player_overview_keeps_the_main_camera_full_size_and_groups_only_the_map() {
+        let frames = [
+            frame_with_triangle(RenderColor::RED),
+            frame_with_triangle(RenderColor::BLUE),
+        ];
+        for viewport in [
+            Viewport::new(1280.0, 720.0),
+            Viewport::with_origin(12.0, 20.0, 720.0, 1280.0),
+        ] {
+            let layout = FrameLayout::SinglePlayerWithMinimap;
+            let panes = frame_viewports(viewport, 2, layout);
+            assert_eq!(panes[0], viewport);
+            let presentation =
+                scene_presentation_from_frames_with_layout(&frames, viewport, layout);
+            assert_eq!(presentation.main_primitives.len(), 1);
+            assert_eq!(presentation.minimaps.len(), 1);
+            let minimap = &presentation.minimaps[0];
+            assert_eq!(minimap.viewport, panes[1]);
+            assert_eq!(minimap.viewport.width, minimap.viewport.height);
+            assert!(minimap.viewport.x >= viewport.x);
+            assert!(minimap.viewport.x + minimap.viewport.width <= viewport.x + viewport.width);
+            assert!(minimap.viewport.y > viewport.y + viewport.height * 0.23);
+            assert!(
+                minimap.viewport.y + minimap.viewport.height < viewport.y + viewport.height * 0.72
+            );
+            assert_eq!(minimap.primitives[0].x, 0.0);
+            assert_eq!(minimap.primitives[0].y, 0.0);
+            assert_eq!(minimap.primitives[0].width, panes[1].width);
+        }
     }
 
     #[test]

--- a/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
+++ b/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
@@ -3,9 +3,27 @@ use super::*;
 #[test]
 #[ignore = "requires an explicit display; CI runs this test under Xvfb"]
 fn spaceling_lab_launch_pause_restart_and_both_renderers() {
-    run_functional_test("spaceling-lab-lifecycle", |harness| {
+    lab_lifecycle(
+        "spaceling-lab",
+        "spaceling-lab-lifecycle",
+        assert_raster_lab_visible,
+    );
+}
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn surface_sortie_launch_pause_restart_and_both_renderers() {
+    lab_lifecycle(
+        "surface-sortie",
+        "surface-sortie-lifecycle",
+        assert_raster_sortie_visible,
+    );
+}
+
+fn lab_lifecycle(scenario: &str, test_name: &'static str, assert_visible: fn(&Path)) {
+    run_functional_test(test_name, |harness| {
         let ready = harness.wait_until_ready();
-        let mut state = harness.activate_until_scenario("spaceling-lab", ready);
+        let mut state = harness.activate_until_scenario(scenario, ready);
         for renderer in ["vector", "raster"] {
             state = harness.activate_guarded("launcher.settings", &state);
             if control_value(&state, "launcher.settings.renderer.next") != Some(renderer) {
@@ -21,22 +39,22 @@ fn spaceling_lab_launch_pause_restart_and_both_renderers() {
             state = harness.wait_for(
                 UiStatePredicate {
                     screen: Some(UiScreen::Gameplay),
-                    scenario: Some("spaceling-lab".into()),
+                    scenario: Some(scenario.into()),
                     revision_after: Some(revision),
                 },
                 TRANSITION_TIMEOUT,
             );
             assert!(!state.benchmark_active);
-            let screenshot = harness.capture_screenshot(&format!("spaceling-lab-{renderer}.png"));
+            let screenshot = harness.capture_screenshot(&format!("{scenario}-{renderer}.png"));
             if renderer == "raster" {
-                assert_raster_lab_visible(&screenshot);
+                assert_visible(&screenshot);
             }
             let first_instance = state.scenario_revision;
             let pause = harness.pause_guarded(&state);
             state = harness.wait_for(
                 UiStatePredicate {
                     screen: Some(UiScreen::PauseMain),
-                    scenario: Some("spaceling-lab".into()),
+                    scenario: Some(scenario.into()),
                     revision_after: Some(pause.revision),
                 },
                 TRANSITION_TIMEOUT,
@@ -47,7 +65,7 @@ fn spaceling_lab_launch_pause_restart_and_both_renderers() {
             state = harness.wait_for(
                 UiStatePredicate {
                     screen: Some(UiScreen::Gameplay),
-                    scenario: Some("spaceling-lab".into()),
+                    scenario: Some(scenario.into()),
                     revision_after: Some(revision),
                 },
                 TRANSITION_TIMEOUT,
@@ -57,7 +75,7 @@ fn spaceling_lab_launch_pause_restart_and_both_renderers() {
             state = harness.wait_for(
                 UiStatePredicate {
                     screen: Some(UiScreen::PauseMain),
-                    scenario: Some("spaceling-lab".into()),
+                    scenario: Some(scenario.into()),
                     revision_after: Some(pause.revision),
                 },
                 TRANSITION_TIMEOUT,
@@ -72,9 +90,61 @@ fn spaceling_lab_launch_pause_restart_and_both_renderers() {
                 },
                 TRANSITION_TIMEOUT,
             );
-            assert_eq!(state.selected_scenario, "spaceling-lab");
+            assert_eq!(state.selected_scenario, scenario);
         }
     });
+}
+
+fn assert_raster_sortie_visible(path: &Path) {
+    let mut decoder = png::Decoder::new(File::open(path).unwrap());
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().unwrap();
+    let mut buffer = vec![0; reader.output_buffer_size()];
+    let frame = reader.next_frame(&mut buffer).unwrap();
+    let channels = match frame.color_type {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        other => panic!("unexpected screenshot color type {other:?}"),
+    };
+    let width = frame.width as usize;
+    let height = frame.height as usize;
+    let mut ship_pixels = 0;
+    let mut diagnostics_pixels = 0;
+    let mut minimap_planet_pixels = 0;
+    for (index, pixel) in buffer[..frame.buffer_size()]
+        .chunks_exact(channels)
+        .enumerate()
+    {
+        let y = index / width;
+        let x = index % width;
+        if y > height / 5 && y < height * 4 / 5 && pixel[0] > 200 && pixel[1] < 80 && pixel[2] < 80
+        {
+            ship_pixels += 1;
+        }
+        if y > height * 4 / 5 && pixel[0] < 150 && pixel[1] > 175 && pixel[2] > 140 {
+            diagnostics_pixels += 1;
+        }
+        // The overview sits below the top HUD at the right. Its planet stays
+        // cyan even though the main scene uses a dark-blue surface.
+        if x > width * 3 / 4
+            && y >= height / 4
+            && y <= height / 2
+            && pixel[0] < 100
+            && pixel[1] > 140
+            && pixel[2] > 110
+        {
+            minimap_planet_pixels += 1;
+        }
+    }
+    assert!(ship_pixels > 100, "missing parked ship: {ship_pixels}");
+    assert!(
+        minimap_planet_pixels > 40,
+        "missing minimap planet: {minimap_planet_pixels}"
+    );
+    assert!(
+        diagnostics_pixels > 40,
+        "missing sortie HUD: {diagnostics_pixels}"
+    );
 }
 
 fn assert_raster_lab_visible(path: &Path) {

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -442,7 +442,7 @@ export component MainWindow inherits Window {
     }
 
     MinimapPanel {
-        visible: root.vector-minimaps-visible;
+        visible: root.vector-minimaps-visible && root.p1-minimap-size > 0px;
         x: root.p1-minimap-x;
         y: root.p1-minimap-y;
         width: root.p1-minimap-size;
@@ -453,7 +453,7 @@ export component MainWindow inherits Window {
     }
 
     MinimapPanel {
-        visible: root.vector-minimaps-visible;
+        visible: root.vector-minimaps-visible && root.p2-minimap-size > 0px;
         x: root.p2-minimap-x;
         y: root.p2-minimap-y;
         width: root.p2-minimap-size;

--- a/crates/engine-rapier/src/spaceling.rs
+++ b/crates/engine-rapier/src/spaceling.rs
@@ -3,12 +3,13 @@
 use engine_core::Vec2;
 
 use crate::world::{
-    BodyId, BodyMotion, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec, PhysicsId,
-    PhysicsWorld, SurfaceContact,
+    BodyId, BodyMotion, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec,
+    CollisionGroups, PhysicsId, PhysicsWorld, SurfaceContact,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SpacelingSpec {
+    pub collision_groups: CollisionGroups,
     pub radius: f32,
     pub half_segment: f32,
     pub walk_speed: f32,
@@ -68,6 +69,7 @@ pub struct SpacelingDisturbance {
 impl Default for SpacelingSpec {
     fn default() -> Self {
         Self {
+            collision_groups: CollisionGroups::ALL,
             radius: 0.3,
             half_segment: 0.6,
             walk_speed: 5.0,
@@ -177,6 +179,8 @@ impl SpacelingAssembly {
         let body = BodyId::new(entity, BodyRole::PRIMARY);
         let collider = ColliderId::new(entity, ColliderRole::PRIMARY, 0);
         let mut shape = ColliderSpec::capsule(collider, spec.half_segment, spec.radius);
+        shape.collision_groups = spec.collision_groups;
+        shape.solver_groups = spec.collision_groups;
         // Traction is the bounded controller, not a large passive friction torque.
         shape.friction = 0.0;
         if !physics.insert_body(

--- a/crates/engine-rapier/src/world.rs
+++ b/crates/engine-rapier/src/world.rs
@@ -1070,6 +1070,42 @@ impl PhysicsWorld {
             })
     }
 
+    /// Test placement against solid colliders in the last completed physics
+    /// step's spatial index. Call before mutating scene poses for the next step.
+    /// Malformed capsules fail closed. Intended for infrequent spawn/entry
+    /// checks, not a replacement for the narrow-phase support iterator.
+    pub fn capsule_is_clear(
+        &self,
+        position: Vec2,
+        angle: f32,
+        half_segment: f32,
+        radius: f32,
+        groups: CollisionGroups,
+    ) -> bool {
+        if !finite_vec2(position)
+            || !angle.is_finite()
+            || !half_segment.is_finite()
+            || half_segment < 0.0
+            || !radius.is_finite()
+            || radius <= 0.0
+        {
+            return false;
+        }
+        let capsule = ColliderBuilder::capsule_y(half_segment, radius).build();
+        self.raw
+            .intersect_shape(
+                Pose::new(to_rapier(position), angle),
+                capsule.shape(),
+                QueryFilter {
+                    flags: QueryFilterFlags::EXCLUDE_SENSORS,
+                    groups: Some(groups.to_rapier()),
+                    ..QueryFilter::default()
+                },
+            )
+            .next()
+            .is_none()
+    }
+
     pub fn cast_ray(
         &self,
         origin: Vec2,
@@ -1756,6 +1792,48 @@ mod tests {
         let intersection = world.sensor_intersections()[0];
         assert!(intersection.collider_a < intersection.collider_b);
         assert!([intersection.collider_a, intersection.collider_b].contains(&sensor_id));
+    }
+
+    #[test]
+    fn capsule_clearance_respects_solids_groups_rotation_and_invalid_input() {
+        let mut world = PhysicsWorld::new(PhysicsWorldConfig::default());
+        let (_, body, collider) = ball_ids(10);
+        let mut shape = ColliderSpec::ball(collider, 1.0);
+        shape.collision_groups = CollisionGroups::new(1, 2);
+        assert!(world.insert_body(
+            body,
+            BodySpec {
+                kind: BodyKind::Fixed,
+                ..BodySpec::default()
+            },
+            &[shape]
+        ));
+        world.step(1.0 / 60.0);
+        let groups = CollisionGroups::new(2, 1);
+        assert!(!world.capsule_is_clear(Vec2::new(0.0, 1.5), 0.0, 0.6, 0.3, groups));
+        assert!(world.capsule_is_clear(
+            Vec2::new(0.0, 1.5),
+            std::f32::consts::FRAC_PI_2,
+            0.6,
+            0.3,
+            groups
+        ));
+        assert!(world.capsule_is_clear(Vec2::ZERO, 0.0, 0.6, 0.3, CollisionGroups::NONE));
+        assert!(!world.capsule_is_clear(Vec2::ZERO, f32::NAN, 0.6, 0.3, groups));
+        assert!(!world.capsule_is_clear(Vec2::ZERO, 0.0, 0.6, -0.3, groups));
+        world.remove_entity(body.entity);
+        let mut sensor = ColliderSpec::ball(collider, 4.0);
+        sensor.sensor = true;
+        assert!(world.insert_body(
+            body,
+            BodySpec {
+                kind: BodyKind::Fixed,
+                ..BodySpec::default()
+            },
+            &[sensor]
+        ));
+        world.step(1.0 / 60.0);
+        assert!(world.capsule_is_clear(Vec2::ZERO, 0.0, 0.6, 0.3, CollisionGroups::ALL));
     }
 
     #[test]

--- a/docs/design/reboot-rust-slint.md
+++ b/docs/design/reboot-rust-slint.md
@@ -585,3 +585,12 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - M26d: ✅ Separate physical support from balanced/knocked-down/recovering control. Add a physical off-center lab shove, bounded supported recovery, zero-gravity momentum preservation, balance diagnostics, and deterministic impact/recovery regressions. Manual knockback/recovery playtesting passed.
 - Follow-ups: population measurements, destructible terrain support, NPC intent, and exterior-base/ship interaction. Physical limbs and Spacewars integration are not part of the first slice.
 - Design: [spacelings and natural surface support](spacelings.md).
+
+### M27: Shared-world surface sortie
+
+- M27a: ✅ Add opt-in `surface-sortie` using Spacewars' existing world, gravity solve, and physics step. Keep pilot identity and vehicle occupancy separate, with one external capsule only while on foot.
+- M27b: ✅ Add collider-checked exit, surface-relative velocity inheritance, nearby supported boarding, control-context neutral gating, and visible feedback. The initial elevated-berth round trip passed manual playtesting.
+- M27c: ✅ Replace that temporary berth in the fixture with physical rear landing feet, nose-outward bounded flight assistance, contact-based settling, and physical takeoff. Add a translucent north-up minimap and landing diagnostics. Refined landing feel passed manual playtesting.
+- M27d: ✅ Add deterministic round-trip, eight-bearing flown landing, takeoff/return, blocked/unsafe transition, repeated body lifecycle, gravity, renderer/compositing, keyboard/gamepad mapping, and launcher workflow regressions.
+- Follow-ups: an intact surface-outpost capture/reward loop; explicit damage/rescue/pod rules; accelerating orbital supports; ordinary Spacewars integration and bot intent. Normal capture gameplay is unchanged by this fixture.
+- Guide: [Surface Sortie](../surface-sortie.md).

--- a/docs/design/spacelings.md
+++ b/docs/design/spacelings.md
@@ -88,6 +88,52 @@ vehicle entry/exit, and useful surface interactions. Population measurements
 remain necessary before expanding to crowds; articulated ragdolls are optional
 follow-up work.
 
+## Third slice: opt-in surface sortie
+
+Implemented on `spaceling-surface-sortie`; the first-pass round trip and assisted
+physical landing/minimap refinements passed manual playtesting.
+The [fixture guide](../surface-sortie.md) documents its boundaries.
+
+Start with `surface-sortie`, a single-player fixture inside the Spacewars scenario
+crate. It uses the existing Spacewars world, ship assemblies, gravity pass, and
+physics step, not a second lab physics pipeline. A pilot has a stable identity
+and owner independent of the ship, and is either aboard that ship or represented
+by one physical spaceling outside it. Boarding removes only the external body;
+it does not recreate or heal the ship. An unoccupied ship remains in the world.
+
+Use a fresh interaction press to disembark from a physically landed ship, and to reboard
+near its surface access point while supported and settled. Reject unsafe exits,
+blocked placement, remote boarding, and unavailable vehicles with visible
+feedback. Require controls to return to neutral after a successful transfer.
+The fixture no longer uses the old elevated berth. Two rear feet on the dynamic
+ship body establish landing through actual contacts, alignment, low relative
+speed/spin, and a short settling interval. Nearby nose-outward flight assistance
+damps sideways motion/spin and bounds descent without auto-pointing or hovering.
+There is no kinematic hold, radial snapping, or hidden takeoff impulse. The hatch
+follows the landed ship, not the old pad marker; clearance uses actual colliders.
+A translucent north-up minimap preserves world context when flying away.
+
+The fixture starts parked on a slowly rotating planet with a stationary center.
+The spaceling inherits the local surface velocity at spawn; after that only
+gravity and Rapier contacts move it. Do not copy the rover's scripted-orbit
+transport into this controller. Accelerating orbital supports need their own
+regressions before enabling this in ordinary generated Spacewars worlds.
+
+This slice disables capture/services, weapons, and asteroid spawning in the
+fixture. It leaves the ordinary Spacewars game and bot observations unchanged.
+Pilot damage, ship destruction while unoccupied, rescue/pods/elimination, NPC
+policy, and the contested outpost reward loop require explicit later policy;
+the fixture reports a lost vehicle and offers restart rather than inventing
+those rules. The next gameplay slice can make walking useful through an intact
+outpost capture and repair/rebuild service.
+
+Acceptance: rear-first landing at multiple bearings, physical takeoff/return,
+bounded assist, rejected hover/nose contact, parked exit/walk/jump/reboard,
+moving-surface velocity inheritance,
+actual collider clearance, fresh-input gating, preserved ship state, rejected
+unsafe transitions, deterministic restart/observations, both renderers and the
+standard launcher/pause flow, plus unchanged ordinary-game regressions.
+
 ## Planet and ship direction
 
 The continuous surface and external berth from PR #40 fix the interior-bay
@@ -98,8 +144,9 @@ landing, independently of ownership or services.
 
 Capture, healing, and pod rebuilding remain explicit scenario policies.
 Natural contact anywhere must not automatically provide those services.
-Replace the ship berth in a later slice, with launch/landing, damage, bot, and
-moving-planet regressions; Spaceling Lab does not change those rules.
+Surface Sortie now exercises natural rear-first landing in isolation. Replace
+the ordinary game's berth in a later slice, with launch/landing, damage, bot,
+and moving-planet regressions; neither lab changes those ordinary-game rules.
 
 [Cell-based terrain (#16)](https://github.com/aortez/space-wars/issues/16)
 should start from the continuous exterior, not recreate a cavity or ownership

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -64,6 +64,12 @@ enabled. Character mechanics and deterministic movement are tested headlessly
 in `engine-rapier` and `scenario-spaceling-lab`; physical controller hardware is a
 manual check.
 
+Surface Sortie uses the same launcher/pause/restart workflow with both renderers;
+its raster check requires the landed ship, diagnostics, and minimap planet. The client unit
+tests also render the disembarked spaceling, while `scenario-spacewars` exercises
+the complete physical exit/walk/jump/return/board loop and input gating. See
+[Surface Sortie](surface-sortie.md) for the manual controls and retained images.
+
 The harness uses Slint's software backend, which does not draw vector paths.
 Selecting vector verifies host lifecycle and text there, not vector geometry.
 Spaceling Lab additionally checks that the raster screenshot contains the character

--- a/docs/surface-sortie.md
+++ b/docs/surface-sortie.md
@@ -1,0 +1,141 @@
+# Surface Sortie
+
+An opt-in first Spacewars integration for spacelings. Choose **surface-sortie**
+in the launcher, or run:
+
+```sh
+cargo run -p engine-client -- --scenario surface-sortie
+```
+
+The fixture starts with your ship settling rear-first onto a slowly rotating planet. Press
+**B** on a gamepad or **X** on the keyboard to disembark. Release the controls,
+walk around, and return to the cyan access marker. Once standing and settled,
+press B/X again to reboard the same ship. Boarding does not heal or replace it.
+
+| Control | Aboard | On foot |
+| --- | --- | --- |
+| D-pad/left stick left/right; A/D or arrows | Turn | Walk |
+| Gamepad A; Space | Thrust | Jump (fresh press) |
+| D-pad down; Down/S | Brake | No action |
+| Gamepad B; X | Exit landed ship | Board beside its cyan hatch |
+| Start/Esc | Pause | Pause |
+| R or pause menu | Restart fixture | Restart fixture |
+
+After each successful transfer, all controls must return to neutral before the
+new context accepts them. Holding A while exiting cannot become an unintended
+jump, and holding it while boarding cannot immediately launch the ship. An
+unsuccessful interaction does not repeat until B/X is released and pressed again.
+
+## Flying and landing
+
+Hold A/Space to take off; rotate with left/right. To return, point the nose
+**away from the planet** and approach rear-first. Landing assist fades in below
+25 world units of foot clearance and inside a 50° nose-outward cone; it reaches
+full strength below 8 units and within 15°. It reduces sideways drift and spin
+and targets a gentle 2 units/s descent. It does not turn the ship upright,
+hover indefinitely, or stop an arbitrarily fast fall. Brake with Down/S before
+a fast approach. Assistance releases on thrust so takeoff remains physical.
+
+Both small rear feet must have real planet contact, with angle under 20°,
+normal/lateral surface-relative speeds under 2 units/s, and relative spin under
+0.2 rad/s, for 0.25 seconds. The HUD then says **LANDED**, the feet turn cyan,
+and the hatch marker appears beside the actual ship. Only then can B/X enter
+or exit it. Nose/wing impacts and passing through the old pad area do not count.
+Hard impacts retain ordinary collision damage. There is no landing latch or
+automatic pose correction; the unoccupied ship stays dynamic too.
+
+These are initial feel-tuning values in `surface_sortie/landing.rs`, not changes
+to ordinary Spacewars flight. The fixture uses bounded thrust, braking, and turn
+rate control in the canonical Rapier world. The landing feet add two colliders
+to the existing hull body, not extra bodies, joints, or mass.
+
+The camera follows the active ship or spaceling. A translucent, fixed-scale,
+north-up minimap stays visible at the right below the top HUD: cyan planet, red
+ship with heading, orange spaceling, and a white camera footprint. Its footprint
+uses the actual window aspect ratio, including portrait layouts. The main view
+keeps the whole window; both vector and raster backends composite the circular
+backing and map as one faded layer.
+
+Orange is balanced, red is
+knocked down, yellow is recovering; cyan identifies physical support and surface
+access. The HUD shows landing phase, angle, descent and sideways speed, foot
+contacts, transfer feedback, ship health, body count, and access distance.
+Use raster rendering on software-only backends (including the kiosk).
+
+## Model and boundaries
+
+The pilot has a stable spaceling ID and owning player, separate from its vehicle
+ID. While aboard, the pilot is an occupant without a separately simulated body.
+Outside, the same creature has one dynamic capsule. The unoccupied ship remains
+in the shared world, supported by its physical feet. This is an occupancy transition, not
+ship/pod transformation or character death/respawn.
+
+The fixture lives in `scenario-spacewars::surface_sortie` and shares Spacewars'
+world, ship physics, gravity solve, and physics step. It adds one gravity target
+and one body while on foot. It uses the reusable Spaceling controller, with
+collision groups selecting the existing rough planet surface rather than also
+hitting the coincident ship-only surface. Spawn clearance is an infrequent
+capsule query against the world's spatial index; ordinary support queries stay
+local to the character's contacts.
+
+The former elevated berth/access connection is removed in this fixture. Its
+ship opts out of the port sensor, compact dock collider, and kinematic hold,
+and collides only with the planet's rough surface, not both coincident surfaces.
+The cyan hatch follows the ship, on nearby ground beside its right side.
+Exit requires a physically landed ship and a clear capsule placement.
+Boarding requires that same available ship, proximity to its access point,
+physical support, balance, and low support-relative speed. This is a short hatch
+transition, not remote boarding or a physical door/ladder simulation.
+
+At exit the capsule inherits the rotating surface's point velocity and spin.
+Afterward Rapier and gravity own its motion; no radial snapping or per-tick
+orbital transport is added. The center is stationary on purpose. Accelerating
+scripted orbits need separate regression evidence before ordinary-world use.
+
+This is a noncombat fixture: no weapons, asteroids, capture, healing, rover
+construction, or win condition. Ordinary Spacewars and its bots are unchanged.
+If you lose the ship while experimenting with flight, restart; damage, rescue,
+pod, and elimination policy for an independent pilot are not settled here.
+The next gameplay slice can add an intact surface outpost to capture and a
+repair/rebuild reward. This is not yet that outpost game mode.
+
+## Verification
+
+```sh
+cargo test -p scenario-spacewars surface_sortie
+cargo test -p engine-client client_scenarios::surface_sortie
+cargo test -p engine-rapier capsule_clearance
+```
+
+Headless regressions cover exit/walk/jump/return/reboard without pose shortcuts,
+ship health and creature identity preservation, one-body lifecycle, velocity
+inheritance, no airborne transport, blocked exits, unsafe/remote boarding,
+held-input gating in both directions, and reproducible actions/restarts. Typed
+`SurfaceSortieState::observation()` and version-2 JSON scenario observations
+include landing phase, clearance, angle, relative speeds/spin, foot count,
+assist strength, and settling duration for future runners; this does not add
+a live IPC telemetry API.
+
+Landing regressions fly gentle approaches at eight bearings, verify physical
+takeoff/return, contact-only boarding, the settling interval, sideways damping,
+no automatic pointing, and damage on fast approaches. Ordinary Spacewars' port
+regressions and pinned AI suites remain the compatibility guard.
+
+The client test checks both render paths and on-foot geometry. To retain images:
+
+```sh
+SPACEWARS_SORTIE_ARTIFACTS=target/surface-sortie-poses cargo test -p engine-client \
+  registered_fixture_renders_and_restarts_in_both_backends
+```
+
+The real-window functional test covers launcher selection, both renderers,
+pause, restart, return, and relaunch, with raster ship/HUD/minimap visibility checks:
+
+```sh
+SPACEWARS_KEEP_FUNCTIONAL_ARTIFACTS=1 cargo test -p engine-client \
+  --test ui_control_functional surface_sortie -- --ignored --test-threads=1
+```
+
+Use an existing display or the [Xvfb workflow](functional-tests.md). Physical
+gamepad feel and the complete round trip remain manual acceptance checks; the
+initial sortie and refined assisted landing have both passed manual playtesting.

--- a/scenarios/spacewars/Cargo.toml
+++ b/scenarios/spacewars/Cargo.toml
@@ -12,6 +12,7 @@ engine-core = { workspace = true }
 engine-gravity = { workspace = true }
 engine-rapier = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -5,6 +5,7 @@
 //! escape pods. Sounds, scoring, and final HUD polish land in later slices.
 
 mod physics;
+pub mod surface_sortie;
 
 use std::{
     collections::{BTreeMap, BTreeSet, BinaryHeap},
@@ -178,6 +179,7 @@ const GRAVITY_DEBRIS_TAG: u64 = 3;
 const GRAVITY_PARTICLE_TAG: u64 = 4;
 const GRAVITY_ROVER_TAG: u64 = 5;
 const GRAVITY_ROVER_FRAME_TAG: u64 = 6;
+const GRAVITY_SURFACE_PILOT_TAG: u64 = 7;
 const ROVER_BODY_COUNT: u64 = 3;
 
 pub const SPACEWARS_PLAYER_COUNT: usize = 2;
@@ -1277,6 +1279,34 @@ impl Scenario for SpacewarsScenario {
     }
 
     fn step(state: &mut Self::State, actions: &[Action], dt: Duration) -> StepResult {
+        Self::step_with_surface_pilot(state, actions, dt, None)
+    }
+
+    fn observe(_state: &Self::State) -> Observation {
+        Observation {
+            payload: Vec::new(),
+        }
+    }
+
+    fn render_frame(state: &Self::State) -> RenderFrame {
+        render_state(state)
+    }
+
+    fn tick_model() -> TickModel {
+        TickModel::FixedTimestep { hz: 60 }
+    }
+}
+
+impl SpacewarsScenario {
+    // The opt-in fixture shares this exact physics step. Ordinary Spacewars
+    // passes no pilot and retains its existing services and observation model.
+    fn step_with_surface_pilot(
+        state: &mut SpacewarsState,
+        actions: &[Action],
+        dt: Duration,
+        mut surface_pilot: Option<&mut surface_sortie::SurfacePilot>,
+    ) -> StepResult {
+        let experimental = surface_pilot.is_some();
         state.last_step_metrics = SpacewarsStepMetrics::default();
         if state.winner.is_some() {
             return StepResult::default();
@@ -1293,13 +1323,31 @@ impl Scenario for SpacewarsScenario {
                 planet.update_orbit(sun.position, dt);
             }
         }
-        update_spaceports(state, dt);
-        reconcile_rover_deployments(state, dt);
+        if !experimental {
+            update_spaceports(state, dt);
+            reconcile_rover_deployments(state, dt);
+        }
         update_rover_patrol(state);
 
         let universe_radius = state.config.universe_radius as f32;
-        for ship in &mut state.ships {
-            ship.update(dt, state.seed, state.tick);
+        for (index, ship) in state.ships.iter_mut().enumerate() {
+            if surface_pilot
+                .as_ref()
+                .is_some_and(|pilot| pilot.vehicle_index() == index)
+            {
+                // The fixture's bounded flight controller owns control impulses;
+                // retain visual exhaust without the legacy brake/turn velocity edits.
+                ship.update_exhaust_trails(dt);
+                if ship.thrust > 0.0 {
+                    ship.fire_exhaust(
+                        ship.direction,
+                        &mut exhaust_rng_for_tick(state.seed, state.tick, index),
+                        state.tick,
+                    );
+                }
+            } else {
+                ship.update(dt, state.seed, state.tick);
+            }
             recover_ship_outside_universe(ship, universe_radius);
         }
         finish_spaceport_ejections(state, dt);
@@ -1312,8 +1360,21 @@ impl Scenario for SpacewarsScenario {
         let lifecycle_time = lifecycle_started.elapsed();
 
         let gravity_started = Instant::now();
-        let gravity = apply_world_gravity(state);
+        let gravity = if let Some(pilot) = surface_pilot.as_deref_mut() {
+            apply_world_gravity_with_pilot(state, Some(pilot), dt)
+        } else {
+            apply_world_gravity(state)
+        };
         let gravity_time = gravity_started.elapsed();
+
+        if let Some(pilot) = surface_pilot {
+            pilot.control_vehicle(
+                &mut state.physics,
+                &state.ships[pilot.vehicle_index()],
+                &state.planets[0],
+                dt,
+            );
+        }
 
         let rapier = state.physics.step(dt);
         state
@@ -1327,7 +1388,11 @@ impl Scenario for SpacewarsScenario {
 
         let contacts = state.physics.contacts();
         let port_intersections = state.physics.spaceport_contacts();
-        let accepted_ports = resolve_physics_spaceport_contacts(state, &port_intersections);
+        let accepted_ports = if experimental {
+            BTreeSet::new()
+        } else {
+            resolve_physics_spaceport_contacts(state, &port_intersections)
+        };
         resolve_physics_collisions(state, &contacts, &accepted_ports);
         handle_ship_deaths(state);
         handle_rover_deaths(state);
@@ -1337,7 +1402,9 @@ impl Scenario for SpacewarsScenario {
         remove_finished_debris(state);
         update_particles(state, dt);
         spawn_random_asteroid(state, dt);
-        update_game_over(state);
+        if !experimental {
+            update_game_over(state);
+        }
 
         state.tick += 1;
         let accounted = lifecycle_time + gravity_time + collision_time + rapier.wall_time;
@@ -1353,20 +1420,6 @@ impl Scenario for SpacewarsScenario {
             rapier,
         };
         StepResult::default()
-    }
-
-    fn observe(_state: &Self::State) -> Observation {
-        Observation {
-            payload: Vec::new(),
-        }
-    }
-
-    fn render_frame(state: &Self::State) -> RenderFrame {
-        render_state(state)
-    }
-
-    fn tick_model() -> TickModel {
-        TickModel::FixedTimestep { hz: 60 }
     }
 }
 
@@ -2319,6 +2372,14 @@ fn body_mass(radius: f32) -> f32 {
 }
 
 fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
+    apply_world_gravity_with_pilot(state, None, state.config.delta_time())
+}
+
+fn apply_world_gravity_with_pilot(
+    state: &mut SpacewarsState,
+    mut pilot: Option<&mut surface_sortie::SurfacePilot>,
+    dt: f32,
+) -> GravityStepMetrics {
     let SpacewarsState {
         tick,
         ships,
@@ -2333,6 +2394,9 @@ fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
         ..
     } = state;
     gravity_participants.clear();
+    if let Some(pilot) = pilot.as_deref_mut() {
+        pilot.ship_gravity_delta = Vec2::ZERO;
+    }
 
     if let Some(sun) = *sun {
         gravity_participants.push(GravityParticipant::direct_source(
@@ -2348,6 +2412,13 @@ fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
             planet.mass,
         )
     }));
+    if let Some(snapshot) = pilot.as_deref().and_then(|pilot| pilot.snapshot(physics)) {
+        gravity_participants.push(GravityParticipant::target(
+            tagged_gravity_id(GRAVITY_SURFACE_PILOT_TAG, 0),
+            snapshot.motion.position,
+            1.0,
+        ));
+    }
     gravity_participants.extend(
         ships
             .iter()
@@ -2428,12 +2499,29 @@ fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
         .collect::<BTreeMap<_, _>>();
     for output in outputs {
         let (tag, payload) = split_gravity_id(output.id);
-        if output.velocity_delta == Vec2::ZERO && tag != GRAVITY_ROVER_TAG {
+        if output.velocity_delta == Vec2::ZERO
+            && tag != GRAVITY_ROVER_TAG
+            && tag != GRAVITY_SURFACE_PILOT_TAG
+        {
             continue;
         }
         match tag {
+            GRAVITY_SURFACE_PILOT_TAG => {
+                if let Some(pilot) = pilot.as_deref_mut() {
+                    // Spacewars' historical gravity scale is a per-fixed-tick
+                    // velocity delta. Convert it to acceleration for the
+                    // controller's disturbance reference, then apply it once.
+                    pilot.apply_gravity_and_control(physics, output.velocity_delta, dt);
+                }
+            }
             GRAVITY_SHIP_TAG => {
                 let index = usize::try_from(payload).expect("ship gravity id fits usize");
+                if let Some(pilot) = pilot
+                    .as_deref_mut()
+                    .filter(|pilot| pilot.vehicle_index() == index)
+                {
+                    pilot.ship_gravity_delta = output.velocity_delta;
+                }
                 assert!(physics.apply_velocity_delta(
                     MechanicalEntity::Ship(index),
                     output.velocity_delta,

--- a/scenarios/spacewars/src/physics.rs
+++ b/scenarios/spacewars/src/physics.rs
@@ -34,6 +34,10 @@ const SPACEPORT_SENSOR_ROLE: ColliderRole = ColliderRole::new(3);
 const SHIP_HULL_ROLE: ColliderRole = ColliderRole::new(5);
 const DEBRIS_ROLE: ColliderRole = ColliderRole::new(6);
 const ROVER_SURFACE_ROLE: ColliderRole = ColliderRole::new(7);
+const LANDING_FOOT_ROLE: ColliderRole = ColliderRole::new(8);
+
+pub(super) const LANDING_FOOT_RADIUS: f32 = 0.45;
+pub(super) const LANDING_FEET: [Vec2; 2] = [Vec2::new(-3.0, -5.0), Vec2::new(3.0, -5.0)];
 
 const GROUP_SHIP_0: u32 = 1 << 0;
 const GROUP_SHIP_1: u32 = 1 << 1;
@@ -45,9 +49,17 @@ const GROUP_WORLD: u32 = 1 << 6;
 const GROUP_SPACEPORT_SENSOR: u32 = 1 << 8;
 const GROUP_ROVER: u32 = 1 << 9;
 const GROUP_ROVER_SURFACE: u32 = 1 << 10;
+const GROUP_SPACELING: u32 = 1 << 11;
 const GROUP_ALL_SHIPS: u32 = GROUP_SHIP_0 | GROUP_SHIP_1 | GROUP_POD_0 | GROUP_POD_1;
 const GROUP_ALL_SOLIDS: u32 =
-    GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_BODY | GROUP_WORLD | GROUP_ROVER;
+    GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_BODY | GROUP_WORLD | GROUP_ROVER | GROUP_SPACELING;
+
+pub(super) fn spaceling_collision_groups() -> CollisionGroups {
+    CollisionGroups::new(
+        GROUP_SPACELING,
+        GROUP_ROVER_SURFACE | GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_WORLD,
+    )
+}
 
 const WORLD_SURFACE_SEGMENTS: usize = 192;
 // The full ship silhouette is intentionally broad. Use a body-sized,
@@ -149,10 +161,12 @@ struct RoverPhysicsEntry {
 
 #[derive(Debug, Clone)]
 pub(super) struct SpacewarsPhysics {
-    world: PhysicsWorld,
+    pub(super) world: PhysicsWorld,
     sun_radius: Option<u32>,
     ship_keys: [Option<ShipColliderKey>; 2],
     docked_planets: [Option<usize>; 2],
+    // Opt-in physical landing assembly; ordinary Spacewars retains its berths.
+    surface_ship: Option<usize>,
     tick: u64,
     contact_last_seen: BTreeMap<(MechanicalEntity, MechanicalEntity), u64>,
     pre_step_motions: BTreeMap<MechanicalEntity, BodyMotion>,
@@ -192,6 +206,7 @@ impl SpacewarsPhysics {
             sun_radius: None,
             ship_keys: [None, None],
             docked_planets: [None, None],
+            surface_ship: None,
             tick: 0,
             contact_last_seen: BTreeMap::new(),
             pre_step_motions: BTreeMap::new(),
@@ -272,6 +287,24 @@ impl SpacewarsPhysics {
         }
 
         for (index, ship) in ships.iter_mut().enumerate() {
+            if self.surface_ship == Some(index) {
+                self.docked_planets[index] = None;
+                let key = ShipColliderKey {
+                    form: ship.form,
+                    wing_theta: ship.wing_theta.to_bits(),
+                    docked: false,
+                    compact: false,
+                    constrained: false,
+                };
+                if self.ship_keys[index] != Some(key) {
+                    lifecycle.removed += usize::from(self.world.remove_entity(ship_entity(index)));
+                    lifecycle.added +=
+                        usize::from(self.insert_ship(index, ship, false, false, false));
+                } else {
+                    synchronize_ship_to_physics(&mut self.world, index, ship);
+                }
+                continue;
+            }
             // A pod is captured automatically so it can rebuild. A full ship
             // establishes the stronger docking hold with its brake; otherwise
             // a ship that merely coasts across the pad would be latched there
@@ -361,6 +394,45 @@ impl SpacewarsPhysics {
             .get(index)
             .and_then(|key| *key)
             .is_some_and(|key| key.constrained)
+    }
+
+    pub(super) fn enable_surface_landing(&mut self, index: usize, ship: &ShipState) {
+        self.surface_ship = Some(index);
+        self.docked_planets[index] = None;
+        self.world.remove_entity(ship_entity(index));
+        assert!(self.insert_ship(index, ship, false, false, false));
+    }
+
+    pub(super) fn ship_body(&self, index: usize) -> PhysicsBodyId {
+        primary_body(ship_entity(index))
+    }
+
+    /// Solver-backed rear-foot support within contact slop, not hull or port overlap.
+    pub(super) fn landing_feet_supported(&self, index: usize, planet: usize, up: Vec2) -> usize {
+        let body = self.ship_body(index);
+        let Some(motion) = self.world.motion(body) else {
+            return 0;
+        };
+        (0..LANDING_FEET.len())
+            .filter(|&part| {
+                self.world
+                    .surface_contacts(collider_id(
+                        ship_entity(index),
+                        LANDING_FOOT_ROLE,
+                        part as u16,
+                    ))
+                    .any(|contact| {
+                        let offset = contact.position - motion.position;
+                        let velocity = motion.linear_velocity
+                            + Vec2::new(-offset.y, offset.x) * motion.angular_velocity;
+                        contact.collider.entity == planet_entity(planet)
+                            && contact.collider.role == ROVER_SURFACE_ROLE
+                            && contact.separation <= 0.04
+                            && contact.normal.dot(up) >= 0.7
+                            && (velocity - contact.velocity).dot(contact.normal) <= 1.0
+                    })
+            })
+            .count()
     }
 
     fn capture_pre_step_motions(&mut self) {
@@ -752,8 +824,10 @@ impl SpacewarsPhysics {
         );
         collider.restitution = DEFAULT_ELASTICITY;
         collider.friction = 0.0;
-        collider.collision_groups =
-            CollisionGroups::new(GROUP_WORLD, GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_ROVER);
+        collider.collision_groups = CollisionGroups::new(
+            GROUP_WORLD,
+            GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_ROVER | GROUP_SPACELING,
+        );
         collider.solver_groups = collider.collision_groups;
         let inserted = self.world.insert_body(
             primary_body(entity),
@@ -796,8 +870,8 @@ impl SpacewarsPhysics {
         let entity = planet_entity(index);
         let body_groups = CollisionGroups::new(GROUP_BODY, GROUP_ALL_SHIPS | GROUP_DEBRIS);
         let mut colliders = planet_solid_colliders(entity, planet.radius, body_groups);
-        // Ships use one continuous frictionless, elastic surface. Rovers get a
-        // separate traction surface on the same kinematic body.
+        // Ordinary ships use the elastic surface. Surface vehicles and
+        // spacelings opt into traction instead; never both coincident surfaces.
         let mut rover_surface = ColliderSpec::ball(
             collider_id(entity, ROVER_SURFACE_ROLE, 0),
             planet.radius * BODY_BOUNDS_RADIUS_SCALE,
@@ -805,7 +879,10 @@ impl SpacewarsPhysics {
         rover_surface.density = 0.0;
         rover_surface.friction = 1.25;
         rover_surface.restitution = 0.0;
-        rover_surface.collision_groups = CollisionGroups::new(GROUP_ROVER_SURFACE, GROUP_ROVER);
+        rover_surface.collision_groups = CollisionGroups::new(
+            GROUP_ROVER_SURFACE,
+            GROUP_ROVER | GROUP_SPACELING | GROUP_ALL_SHIPS,
+        );
         rover_surface.solver_groups = rover_surface.collision_groups;
         colliders.push(rover_surface);
 
@@ -847,7 +924,11 @@ impl SpacewarsPhysics {
         constrained: bool,
     ) -> bool {
         let entity = ship_entity(index);
-        let colliders = ship_colliders(entity, ship, docked, compact);
+        let colliders = if self.surface_ship == Some(index) {
+            surface_ship_colliders(entity, ship)
+        } else {
+            ship_colliders(entity, ship, docked, compact)
+        };
         let inserted = self.world.insert_body(
             primary_body(entity),
             BodySpec {
@@ -1008,7 +1089,7 @@ fn ship_collision_groups(ship: &ShipState, docked: bool) -> CollisionGroups {
         ShipForm::EscapePod if ship.owner_id == 0 => GROUP_POD_0,
         ShipForm::EscapePod => GROUP_POD_1,
     };
-    let mut filter = GROUP_WORLD | GROUP_DEBRIS | GROUP_SPACEPORT_SENSOR;
+    let mut filter = GROUP_WORLD | GROUP_DEBRIS | GROUP_SPACEPORT_SENSOR | GROUP_SPACELING;
     if !docked {
         filter |= GROUP_BODY | GROUP_ALL_SHIPS;
     }
@@ -1097,6 +1178,35 @@ fn ship_colliders(
         colliders.push(probe);
     }
 
+    colliders
+}
+
+fn surface_ship_colliders(entity: PhysicsId, ship: &ShipState) -> Vec<ColliderSpec> {
+    let mut colliders = ship_colliders(entity, ship, false, false);
+    let hull = &mut colliders[0];
+    hull.friction = 0.8;
+    hull.restitution = 0.0;
+    hull.collision_groups.filter = (hull.collision_groups.filter
+        & !(GROUP_BODY | GROUP_SPACEPORT_SENSOR))
+        | GROUP_ROVER_SURFACE;
+    hull.solver_groups = hull.collision_groups;
+    let groups = hull.collision_groups;
+    if ship.form == ShipForm::Ship {
+        for (part, position) in LANDING_FEET.into_iter().enumerate() {
+            let mut foot = ColliderSpec::ball(
+                collider_id(entity, LANDING_FOOT_ROLE, part as u16),
+                LANDING_FOOT_RADIUS,
+            );
+            foot.local_position = position;
+            // Small feet extend behind the hull; no overlapping hull pieces,
+            // extra bodies/joints, or changes to the ship's inertial mass.
+            foot.density = 0.0;
+            foot.friction = 1.0;
+            foot.collision_groups = groups;
+            foot.solver_groups = groups;
+            colliders.push(foot);
+        }
+    }
     colliders
 }
 

--- a/scenarios/spacewars/src/surface_sortie.rs
+++ b/scenarios/spacewars/src/surface_sortie.rs
@@ -1,0 +1,491 @@
+//! Opt-in shared-world pilot/vehicle experiment. Not the ordinary capture game.
+
+use super::*;
+use engine_rapier::{
+    spaceling::{
+        SpacelingAssembly, SpacelingBalance, SpacelingControl, SpacelingSnapshot, SpacelingSpec,
+    },
+    world::PhysicsId,
+};
+
+mod landing;
+mod render;
+pub use landing::{LandingPhase, LandingTelemetry};
+#[cfg(test)]
+mod tests;
+
+const CONTROL_V1: u32 = 0x5355_0001;
+const PILOT_PHYSICS_ID: PhysicsId = PhysicsId::new(40_000);
+const SURFACE_RADIUS: f32 = 60.0;
+const BOARDING_RANGE: f32 = 3.0;
+const SETTLED_SPEED: f32 = 2.0;
+
+pub struct SurfaceSortieScenario;
+
+/// Persistent creature identity, including while there is no external body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SpacelingId(pub u64);
+
+/// Vehicle identity is independent of the owning player and occupying creature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct VehicleId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PilotLocation {
+    Aboard(VehicleId),
+    OnFoot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferResult {
+    Ready,
+    Exited,
+    Boarded,
+    ShipNotSettled,
+    ExitBlocked,
+    TooFar,
+    MustBeSupported,
+    VehicleUnavailable,
+}
+
+impl TransferResult {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "Ready for a surface sortie",
+            Self::Exited => "Disembarked; B / X boards at the access marker",
+            Self::Boarded => "Aboard the same ship; ready to pilot",
+            Self::ShipNotSettled => "Land rear-first and settle before entering or exiting",
+            Self::ExitBlocked => "Surface access blocked; no safe exit",
+            Self::TooFar => "Return to the cyan hatch beside the landed ship",
+            Self::MustBeSupported => "Stand and settle at the access marker to board",
+            Self::VehicleUnavailable => "Vehicle unavailable; restart this experiment",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct SurfaceSortieAction {
+    pub horizontal: f32,
+    /// Thrust aboard; fresh-press jump on foot.
+    pub primary_held: bool,
+    pub interact_held: bool,
+    pub brake_held: bool,
+}
+
+impl SurfaceSortieAction {
+    pub fn encode(self) -> Action {
+        let mut payload = self.horizontal.to_le_bytes().to_vec();
+        payload.extend([
+            self.primary_held as u8,
+            self.interact_held as u8,
+            self.brake_held as u8,
+        ]);
+        Action::scenario(CONTROL_V1, payload)
+    }
+
+    pub fn decode(action: &Action) -> Option<Self> {
+        let Action::Scenario {
+            kind: CONTROL_V1,
+            payload,
+        } = action
+        else {
+            return None;
+        };
+        if payload.len() != 7 || payload[4..].iter().any(|&value| value > 1) {
+            return None;
+        }
+        let horizontal = f32::from_le_bytes(payload[..4].try_into().ok()?);
+        horizontal.is_finite().then_some(Self {
+            horizontal: horizontal.clamp(-1.0, 1.0),
+            primary_held: payload[4] != 0,
+            interact_held: payload[5] != 0,
+            brake_held: payload[6] != 0,
+        })
+    }
+}
+
+pub struct SurfaceSortieState {
+    world: SpacewarsState,
+    pilot: SurfacePilot,
+    input: SurfaceSortieAction,
+    interact_was_held: bool,
+    controls_armed: bool,
+    transfers: u64,
+    last_transfer: TransferResult,
+    landing: LandingTelemetry,
+}
+
+pub(super) struct SurfacePilot {
+    id: SpacelingId,
+    owner: PlayerId,
+    vehicle: VehicleId,
+    body: Option<SpacelingAssembly>,
+    control: SpacelingControl,
+    gravity: Vec2,
+    facing: f32,
+    gait_phase: f32,
+    pub(super) ship_gravity_delta: Vec2,
+}
+
+impl SurfacePilot {
+    pub(super) fn snapshot(
+        &self,
+        physics: &physics::SpacewarsPhysics,
+    ) -> Option<SpacelingSnapshot> {
+        self.body.as_ref()?.snapshot(&physics.world)
+    }
+
+    pub(super) fn apply_gravity_and_control(
+        &mut self,
+        physics: &mut physics::SpacewarsPhysics,
+        velocity_delta: Vec2,
+        dt: f32,
+    ) {
+        if let Some(body) = self.body.as_mut() {
+            self.gravity = velocity_delta / dt;
+            body.apply_control(&mut physics.world, self.control, self.gravity, dt);
+            physics
+                .world
+                .apply_velocity_delta(body.body(), velocity_delta, true);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SurfaceSortieObservation {
+    pub version: u32,
+    pub tick: u64,
+    pub spaceling: SpacelingId,
+    pub owner: PlayerId,
+    pub vehicle: VehicleId,
+    pub location: PilotLocation,
+    pub position: Vec2,
+    pub velocity: Vec2,
+    pub angle: f32,
+    pub grounded: bool,
+    pub balance: &'static str,
+    pub jumps: u64,
+    pub ship_position: Vec2,
+    pub ship_health: f32,
+    pub ship_available: bool,
+    pub access_position: Vec2,
+    pub transfers: u64,
+    pub last_transfer: TransferResult,
+    pub controls_armed: bool,
+    pub physical_bodies: usize,
+    pub landing: LandingTelemetry,
+}
+
+impl SurfaceSortieState {
+    pub fn spaceling_snapshot(&self) -> Option<SpacelingSnapshot> {
+        self.pilot.snapshot(&self.world.physics)
+    }
+
+    pub fn location(&self) -> PilotLocation {
+        if self.pilot.body.is_some() {
+            PilotLocation::OnFoot
+        } else {
+            PilotLocation::Aboard(self.pilot.vehicle)
+        }
+    }
+
+    pub fn observation(&self) -> SurfaceSortieObservation {
+        let ship = &self.world.ships[self.pilot.vehicle.0];
+        let snapshot = self.spaceling_snapshot();
+        SurfaceSortieObservation {
+            version: 2,
+            tick: self.world.tick,
+            spaceling: self.pilot.id,
+            owner: self.pilot.owner,
+            vehicle: self.pilot.vehicle,
+            location: self.location(),
+            position: snapshot.map_or(ship.position, |s| s.motion.position),
+            velocity: snapshot.map_or(ship.velocity, |s| s.motion.linear_velocity),
+            angle: snapshot.map_or(ship.rotation_radians, |s| s.motion.angle),
+            grounded: snapshot.is_some_and(SpacelingSnapshot::grounded),
+            balance: snapshot.map_or("ABOARD", |s| match s.balance {
+                SpacelingBalance::Balanced => "BALANCED",
+                SpacelingBalance::KnockedDown => "KNOCKED DOWN",
+                SpacelingBalance::Recovering => "RECOVERING",
+            }),
+            jumps: snapshot.map_or(0, |s| s.jumps),
+            ship_position: ship.position,
+            ship_health: ship.life,
+            ship_available: self.vehicle_available(),
+            access_position: self.access_position(),
+            transfers: self.transfers,
+            last_transfer: self.last_transfer,
+            controls_armed: self.controls_armed,
+            physical_bodies: self.world.physics.world.body_count(),
+            landing: self.landing,
+        }
+    }
+
+    fn access_up(&self) -> Vec2 {
+        let ship = &self.world.ships[self.pilot.vehicle.0];
+        // A surface access point beside the *actual* ship. No elevated berth
+        // or fixed planet marker; the physical landing gate is checked first.
+        let hatch =
+            ship.position + SHIP_PIVOT + Vec2::new(8.0, -5.0).rotate_radians(ship.rotation_radians);
+        (hatch - self.world.planets[0].position).normalized()
+    }
+
+    fn access_position(&self) -> Vec2 {
+        let planet = &self.world.planets[0];
+        planet.position + self.access_up() * (planet.radius * BODY_BOUNDS_RADIUS_SCALE)
+    }
+
+    fn spec() -> SpacelingSpec {
+        SpacelingSpec {
+            collision_groups: physics::spaceling_collision_groups(),
+            ..SpacelingSpec::default()
+        }
+    }
+
+    fn vehicle_available(&self) -> bool {
+        let ship = &self.world.ships[self.pilot.vehicle.0];
+        !ship.dead && ship.form == ShipForm::Ship && ship.owner_id == self.pilot.owner.index()
+    }
+
+    fn vehicle_settled(&self) -> bool {
+        self.landing.phase == LandingPhase::Landed
+    }
+
+    fn try_transfer(&mut self) -> TransferResult {
+        if !self.vehicle_available() {
+            return TransferResult::VehicleUnavailable;
+        }
+        if !self.vehicle_settled() {
+            return TransferResult::ShipNotSettled;
+        }
+        if let Some(snapshot) = self.spaceling_snapshot() {
+            if snapshot.motion.position.distance_to(self.access_position()) > BOARDING_RANGE {
+                return TransferResult::TooFar;
+            }
+            let relative = snapshot.motion.linear_velocity
+                - planet_surface_velocity(&self.world.planets[0], snapshot.motion.position);
+            if !snapshot.grounded()
+                || snapshot.balance != SpacelingBalance::Balanced
+                || relative.length() > SETTLED_SPEED
+            {
+                return TransferResult::MustBeSupported;
+            }
+            // The creature remains alive/owned; only its external physical
+            // representation disappears while it occupies the existing ship.
+            self.world.physics.world.remove_entity(PILOT_PHYSICS_ID);
+            self.pilot.body = None;
+            TransferResult::Boarded
+        } else {
+            let spec = Self::spec();
+            let up = self.access_up();
+            let position = self.access_position() + up * (spec.half_height() + 0.12);
+            let angle = rotation_for_direction(up);
+            if !self.world.physics.world.capsule_is_clear(
+                position,
+                angle,
+                spec.half_segment,
+                spec.radius + 0.04,
+                spec.collision_groups,
+            ) {
+                return TransferResult::ExitBlocked;
+            }
+            let Some(body) = SpacelingAssembly::insert(
+                &mut self.world.physics.world,
+                PILOT_PHYSICS_ID,
+                position,
+                angle,
+                spec,
+            ) else {
+                return TransferResult::ExitBlocked;
+            };
+            self.world.physics.world.set_velocity(
+                body.body(),
+                planet_surface_velocity(&self.world.planets[0], position),
+                self.world.planets[0].wrapper_omega,
+                true,
+            );
+            self.pilot.body = Some(body);
+            TransferResult::Exited
+        }
+    }
+}
+
+impl Scenario for SurfaceSortieScenario {
+    type State = SurfaceSortieState;
+    type Config = ();
+
+    fn init(_config: (), seed: u64) -> SurfaceSortieState {
+        let mut world = SpacewarsScenario::init(
+            SpacewarsConfig {
+                universe_radius: 500,
+                use_planets: false,
+                use_starfield: false,
+                asteroid_probability_per_sec: 0.0,
+                ..SpacewarsConfig::default()
+            },
+            seed,
+        );
+        let planet = PlanetState {
+            position: Vec2::splat(500.0),
+            radius: SURFACE_RADIUS,
+            // Match 18 units/s² at the feet using the existing fixed-tick
+            // Spacewars gravity scale, without changing the normal game.
+            mass: 18.0 / 60.0 / GRAVITY * (SURFACE_RADIUS * BODY_BOUNDS_RADIUS_SCALE + 0.9).powi(2),
+            color: Color::scale_255(30.0, 55.0, 65.0),
+            owner_id: None,
+            capturing_player_id: None,
+            previous_docked_ship: None,
+            dock_contest_time: 0.0,
+            taking_ownership_time: 0.0,
+            building_new_ship_time: 0.0,
+            orbit_radius: 0.0,
+            orbit_angle: 0.0,
+            orbit_omega: 0.0,
+            wrapper_angle: std::f32::consts::FRAC_PI_2,
+            wrapper_omega: 0.015,
+        };
+        // Begin just above the ground on the rear feet; Rapier settles the
+        // vehicle during the first few ticks, just as after a flown landing.
+        let center = planet.position + Vec2::Y * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + 5.5);
+        world.ships[0].position = center - SHIP_PIVOT;
+        world.ships[0].rotation_radians = 0.0;
+        world.ships[0].direction = Vec2::Y;
+        world.ships[0].velocity = planet_surface_velocity(&planet, center);
+        // Keep the second vehicle far from the single-player fixture. Its
+        // existence does not imply that this pilot may occupy another owner's ship.
+        world.ships[1].position = Vec2::new(850.0, 850.0);
+        world.ships[1].velocity = Vec2::new(-6.0, 6.0);
+        world.planets = vec![planet];
+        world.rover_builds = vec![RoverBuildState::default()];
+        world.physics = physics::SpacewarsPhysics::new(500.0, &world.ships, None, &world.planets);
+        world.physics.enable_surface_landing(0, &world.ships[0]);
+        world.spaceport_contacts.clear();
+        SurfaceSortieState {
+            world,
+            pilot: SurfacePilot {
+                id: SpacelingId(1),
+                owner: PlayerId::PLAYER_1,
+                vehicle: VehicleId(0),
+                body: None,
+                control: SpacelingControl::default(),
+                gravity: Vec2::ZERO,
+                facing: 1.0,
+                gait_phase: 0.0,
+                ship_gravity_delta: Vec2::ZERO,
+            },
+            input: SurfaceSortieAction::default(),
+            interact_was_held: false,
+            controls_armed: false,
+            transfers: 0,
+            last_transfer: TransferResult::Ready,
+            landing: LandingTelemetry::default(),
+        }
+    }
+
+    fn step(state: &mut SurfaceSortieState, actions: &[Action], dt: Duration) -> StepResult {
+        // This fixture uses the same 60 Hz fixed-step contract as Spacewars.
+        if dt.is_zero() {
+            return StepResult::default();
+        }
+        if let Some(input) = actions
+            .iter()
+            .filter_map(SurfaceSortieAction::decode)
+            .next_back()
+        {
+            state.input = input;
+        }
+        let input = state.input;
+        let mut effective = SurfaceSortieAction::default();
+        if !state.controls_armed {
+            state.controls_armed = input == SurfaceSortieAction::default();
+        } else {
+            effective = input;
+            if input.interact_held && !state.interact_was_held {
+                state.last_transfer = state.try_transfer();
+                if matches!(
+                    state.last_transfer,
+                    TransferResult::Exited | TransferResult::Boarded
+                ) {
+                    state.transfers += 1;
+                    state.controls_armed = false;
+                    effective = SurfaceSortieAction::default();
+                }
+            }
+        }
+        state.interact_was_held = input.interact_held;
+        let on_foot = state.pilot.body.is_some();
+        state.pilot.control = if on_foot {
+            SpacelingControl {
+                walk: effective.horizontal,
+                jump_held: effective.primary_held,
+            }
+        } else {
+            SpacelingControl::default()
+        };
+        if effective.horizontal.abs() > 0.01 {
+            state.pilot.facing = effective.horizontal.signum();
+        }
+        let ship = &mut state.world.ships[state.pilot.vehicle.0];
+        ship.set_thrust(if !on_foot && effective.primary_held {
+            1.0
+        } else {
+            0.0
+        });
+        ship.set_turn(if on_foot { 0.0 } else { effective.horizontal });
+        ship.set_brake(if !on_foot && effective.brake_held {
+            1.0
+        } else {
+            0.0
+        });
+        ship.set_laser(false);
+        ship.set_cannon(false);
+        // Rotation is kinematic terrain motion. No spaceling pose/velocity
+        // transport is performed here or in the controller.
+        let dt = dt.as_secs_f32();
+        state.world.planets[0].wrapper_angle = (state.world.planets[0].wrapper_angle
+            + state.world.planets[0].wrapper_omega * dt)
+            .rem_euclid(std::f32::consts::TAU);
+        let result = SpacewarsScenario::step_with_surface_pilot(
+            &mut state.world,
+            &[],
+            Duration::from_secs_f32(dt),
+            Some(&mut state.pilot),
+        );
+        state.landing.update(
+            &state.world.physics,
+            state.pilot.vehicle.0,
+            &state.world.planets[0],
+            &state.world.ships[state.pilot.vehicle.0],
+            dt,
+        );
+        if let Some(snapshot) = state.spaceling_snapshot() {
+            state.pilot.gait_phase = (state.pilot.gait_phase
+                + snapshot.relative_speed.abs() * dt * 5.0)
+                .rem_euclid(std::f32::consts::TAU);
+        }
+        result
+    }
+
+    fn observe(state: &SurfaceSortieState) -> Observation {
+        Observation {
+            payload: serde_json::to_vec(&state.observation()).expect("finite sortie observation"),
+        }
+    }
+
+    fn render_frame(state: &SurfaceSortieState) -> RenderFrame {
+        render::frame(state)
+    }
+
+    fn tick_model() -> TickModel {
+        TickModel::FixedTimestep { hz: 60 }
+    }
+}
+
+impl SurfaceSortieScenario {
+    /// Fixed-scale north-up world context; the client overlays this second frame.
+    pub fn minimap_frame(state: &SurfaceSortieState, viewport_aspect: f32) -> RenderFrame {
+        render::minimap(state, viewport_aspect)
+    }
+}

--- a/scenarios/spacewars/src/surface_sortie/landing.rs
+++ b/scenarios/spacewars/src/surface_sortie/landing.rs
@@ -1,0 +1,207 @@
+//! Local flight assist and contact-based landing, opt-in to this fixture only.
+//! No pose snaps, docking constraints, or extra gravity solve.
+
+use super::*;
+
+const ASSIST_HEIGHT: f32 = 25.0;
+const FULL_ASSIST_HEIGHT: f32 = 8.0;
+const ASSIST_ANGLE: f32 = 50.0;
+const FULL_ASSIST_ANGLE: f32 = 15.0;
+const LANDED_ANGLE: f32 = 20.0;
+const SETTLE_SECONDS: f32 = 0.25;
+const DESCENT_SPEED: f32 = 2.0;
+const MAX_DESCENT_ACCELERATION: f32 = 30.0;
+const MAX_LATERAL_ACCELERATION: f32 = 12.0;
+const THRUST_ACCELERATION: f32 = 45.0;
+const BRAKE_ACCELERATION: f32 = 40.0;
+const TURN_SPEED: f32 = 1.8;
+const TURN_ACCELERATION: f32 = 6.0;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LandingPhase {
+    #[default]
+    Flying,
+    Assisted,
+    Settling,
+    Landed,
+}
+
+impl LandingPhase {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Flying => "FLYING",
+            Self::Assisted => "LANDING ASSIST",
+            Self::Settling => "SETTLING",
+            Self::Landed => "LANDED",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
+pub struct LandingTelemetry {
+    pub phase: LandingPhase,
+    pub altitude: f32,
+    pub angle_degrees: f32,
+    /// Positive is moving toward the ground; measured in the surface frame.
+    pub descent_speed: f32,
+    pub lateral_speed: f32,
+    pub relative_spin: f32,
+    pub supported_feet: usize,
+    pub assist_strength: f32,
+    pub settled_seconds: f32,
+}
+
+impl LandingTelemetry {
+    pub(super) fn measure(
+        physics: &physics::SpacewarsPhysics,
+        index: usize,
+        planet: &PlanetState,
+    ) -> Self {
+        let Some(motion) = physics.world.motion(physics.ship_body(index)) else {
+            return Self::default();
+        };
+        let up = (motion.position - planet.position).normalized();
+        let right = Vec2::new(up.y, -up.x);
+        let relative = motion.linear_velocity - planet_surface_velocity(planet, motion.position);
+        let angle_degrees = Vec2::Y
+            .rotate_radians(motion.angle)
+            .dot(up)
+            .clamp(-1.0, 1.0)
+            .acos()
+            .to_degrees();
+        let altitude = physics::LANDING_FEET
+            .into_iter()
+            .map(|foot| {
+                (motion.position + foot.rotate_radians(motion.angle)).distance_to(planet.position)
+                    - planet.radius * BODY_BOUNDS_RADIUS_SCALE
+                    - physics::LANDING_FOOT_RADIUS
+            })
+            .fold(f32::INFINITY, f32::min);
+        let near =
+            ((ASSIST_HEIGHT - altitude) / (ASSIST_HEIGHT - FULL_ASSIST_HEIGHT)).clamp(0.0, 1.0);
+        let aligned =
+            ((ASSIST_ANGLE - angle_degrees) / (ASSIST_ANGLE - FULL_ASSIST_ANGLE)).clamp(0.0, 1.0);
+        // Smooth both transitions so crossing the cone/height boundary is not a switch.
+        let smooth = |x: f32| x * x * (3.0 - 2.0 * x);
+        Self {
+            altitude,
+            angle_degrees,
+            descent_speed: -relative.dot(up),
+            lateral_speed: relative.dot(right),
+            relative_spin: motion.angular_velocity - planet.wrapper_omega,
+            supported_feet: physics.landing_feet_supported(index, 0, up),
+            assist_strength: smooth(near) * smooth(aligned),
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn update(
+        &mut self,
+        physics: &physics::SpacewarsPhysics,
+        index: usize,
+        planet: &PlanetState,
+        ship: &ShipState,
+        dt: f32,
+    ) {
+        let mut next = Self::measure(physics, index, planet);
+        let settled = ship.form == ShipForm::Ship
+            && !ship.dead
+            && ship.thrust == 0.0
+            && next.supported_feet == 2
+            && next.angle_degrees < LANDED_ANGLE
+            && next.descent_speed.abs() < SETTLED_SPEED
+            && next.lateral_speed.abs() < SETTLED_SPEED
+            && next.relative_spin.abs() < 0.2;
+        next.settled_seconds = if settled {
+            (self.settled_seconds + dt).min(SETTLE_SECONDS)
+        } else {
+            0.0
+        };
+        next.phase = if next.settled_seconds >= SETTLE_SECONDS {
+            LandingPhase::Landed
+        } else if next.supported_feet > 0 && next.angle_degrees < LANDED_ANGLE {
+            LandingPhase::Settling
+        } else if next.assist_strength > 0.0 && ship.thrust == 0.0 {
+            LandingPhase::Assisted
+        } else {
+            LandingPhase::Flying
+        };
+        *self = next;
+    }
+}
+
+impl SurfacePilot {
+    pub(crate) fn vehicle_index(&self) -> usize {
+        self.vehicle.0
+    }
+
+    pub(crate) fn control_vehicle(
+        &self,
+        physics: &mut physics::SpacewarsPhysics,
+        ship: &ShipState,
+        planet: &PlanetState,
+        dt: f32,
+    ) {
+        if ship.form != ShipForm::Ship || ship.dead {
+            return;
+        }
+        let body = physics.ship_body(self.vehicle.0);
+        let Some(motion) = physics.world.motion(body) else {
+            return;
+        };
+        let landing = LandingTelemetry::measure(physics, self.vehicle.0, planet);
+        let up = (motion.position - planet.position).normalized();
+        let right = Vec2::new(up.y, -up.x);
+        let mut acceleration =
+            Vec2::Y.rotate_radians(motion.angle) * (ship.thrust * THRUST_ACCELERATION);
+        if ship.brake > 0.0 {
+            let relative =
+                motion.linear_velocity - planet_surface_velocity(planet, motion.position);
+            let braking = relative * -4.0;
+            acceleration += braking.normalized() * braking.length().min(BRAKE_ACCELERATION);
+        } else if ship.thrust == 0.0 {
+            acceleration += right
+                * (-landing.lateral_speed * 3.0)
+                    .clamp(-MAX_LATERAL_ACCELERATION, MAX_LATERAL_ACCELERATION)
+                * landing.assist_strength;
+            if landing.supported_feet == 0 {
+                // A gentle nonzero sink rate, not hover. Gravity comes from the
+                // shared solver. Bounded thrust cannot rescue a very fast fall.
+                let gravity = self.ship_gravity_delta / dt;
+                let correction = (landing.descent_speed - DESCENT_SPEED) * 6.0 - gravity.dot(up);
+                acceleration +=
+                    up * correction.clamp(0.0, MAX_DESCENT_ACCELERATION) * landing.assist_strength;
+            }
+        }
+        physics
+            .world
+            .apply_velocity_delta(body, acceleration * dt, true);
+
+        // Rate control, never automatic orientation. The pilot must point the
+        // nose outward. Stronger damping near touchdown removes unwanted spin.
+        let desired_spin = -ship.turn * TURN_SPEED
+            + if landing.assist_strength > 0.0 {
+                planet.wrapper_omega
+            } else {
+                0.0
+            };
+        let strength = if ship.turn != 0.0 || ship.brake > 0.0 {
+            1.0
+        } else {
+            0.25 + 0.75 * landing.assist_strength
+        };
+        let spin_delta = (desired_spin - motion.angular_velocity).clamp(
+            -TURN_ACCELERATION * strength * dt,
+            TURN_ACCELERATION * strength * dt,
+        );
+        let velocity = physics
+            .world
+            .motion(body)
+            .expect("existing ship")
+            .linear_velocity;
+        physics
+            .world
+            .set_velocity(body, velocity, motion.angular_velocity + spin_delta, true);
+    }
+}

--- a/scenarios/spacewars/src/surface_sortie/render.rs
+++ b/scenarios/spacewars/src/surface_sortie/render.rs
@@ -1,0 +1,393 @@
+use super::*;
+use engine_common::RenderLine;
+
+const LIGHT: RenderColor = RenderColor::rgb(0.86, 0.93, 0.97);
+const CYAN: RenderColor = RenderColor::rgb(0.25, 0.93, 0.8);
+const ORANGE: RenderColor = RenderColor::rgb(1.0, 0.58, 0.23);
+
+fn camera(state: &SurfaceSortieState) -> Camera2 {
+    let snapshot = state.spaceling_snapshot();
+    let ship = &state.world.ships[state.pilot.vehicle.0];
+    let parked = state.vehicle_settled();
+    let center = snapshot.map_or_else(
+        || {
+            if parked {
+                (ship.position + state.access_position()) * 0.5 + Vec2::new(0.0, 2.0)
+            } else {
+                ship.position
+            }
+        },
+        |s| s.motion.position + Vec2::new(0.0, 7.0),
+    );
+    let height = if snapshot.is_some() || parked {
+        44.0
+    } else {
+        100.0
+    };
+    Camera2::new(render_point(center), height)
+}
+
+pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
+    let observation = state.observation();
+    let snapshot = state.spaceling_snapshot();
+    let ship = &state.world.ships[state.pilot.vehicle.0];
+    let parked = state.vehicle_settled();
+    let camera = camera(state);
+    let center = Vec2::new(camera.center.x, camera.center.y);
+    let height = camera.height;
+    let mut frame = RenderFrame::new(camera);
+    let planet = &state.world.planets[0];
+    let radius = planet.radius * BODY_BOUNDS_RADIUS_SCALE;
+    circle(
+        &mut frame,
+        -20,
+        planet.position,
+        radius,
+        RenderColor::rgb(0.09, 0.16, 0.23),
+    );
+    for index in 0..72 {
+        let up =
+            Vec2::from_radians(planet.wrapper_angle + index as f32 * std::f32::consts::TAU / 72.0);
+        line(
+            &mut frame,
+            -18,
+            planet.position + up * (radius - 1.0),
+            planet.position + up * (radius - 0.08),
+            RenderColor::rgb(0.28, 0.51, 0.6),
+            1.0,
+        );
+    }
+    let access = observation.access_position;
+    if parked {
+        circle(
+            &mut frame,
+            -1,
+            access + state.access_up() * 0.12,
+            0.38,
+            CYAN,
+        );
+    }
+    render_ship(&mut frame, ship);
+    if ship.form == ShipForm::Ship {
+        for foot in physics::LANDING_FEET {
+            let position = ship.position + SHIP_PIVOT + foot.rotate_radians(ship.rotation_radians);
+            line(
+                &mut frame,
+                1,
+                position,
+                position + Vec2::Y.rotate_radians(ship.rotation_radians) * 1.3,
+                LIGHT,
+                2.0,
+            );
+            circle(
+                &mut frame,
+                1,
+                position,
+                physics::LANDING_FOOT_RADIUS,
+                if parked { CYAN } else { LIGHT },
+            );
+        }
+    }
+    render_exhaust(&mut frame, ship);
+    if let Some(snapshot) = snapshot {
+        draw_spaceling(
+            &mut frame,
+            snapshot,
+            state.pilot.facing,
+            state.pilot.gait_phase,
+        );
+        if let Some(support) = snapshot.support {
+            line(
+                &mut frame,
+                6,
+                support.position,
+                support.position + support.normal,
+                CYAN,
+                2.0,
+            );
+        }
+    }
+    // Keep diagnostics legible when the parked ship crosses the HUD as the
+    // planet rotates. The scene remains visible through the shallow strips.
+    for (bottom, top) in [(0.27, 0.48), (-0.48, -0.28)] {
+        frame.push_primitive(
+            15,
+            RenderPrimitive::Polygon(RenderPolygon {
+                points: [(-4.0, bottom), (4.0, bottom), (4.0, top), (-4.0, top)]
+                    .map(|(x, y)| render_point(center + Vec2::new(x, y) * height))
+                    .to_vec(),
+                fill: Some(Fill::new(RenderColor::rgba(0.025, 0.03, 0.055, 0.85))),
+                stroke: None,
+            }),
+        );
+    }
+    let title_y = center.y + height * 0.43;
+    text(
+        &mut frame,
+        Vec2::new(center.x, title_y),
+        "SURFACE SORTIE  /  shared-world pilot experiment",
+        LIGHT,
+        18.0,
+    );
+    text(
+        &mut frame,
+        center + Vec2::new(0.0, height * 0.37),
+        if snapshot.is_some() {
+            "ON FOOT  |  Left/right: walk   A / Space: jump   B / X: board"
+        } else {
+            "ABOARD  |  Left/right: turn   A / Space: thrust   Down / S: brake   B / X: exit"
+        },
+        LIGHT,
+        14.0,
+    );
+    text(
+        &mut frame,
+        center + Vec2::new(0.0, height * 0.31),
+        "Start / Esc: pause   R: restart   No weapons or capture in this fixture",
+        LIGHT,
+        13.0,
+    );
+    let message = if !state.vehicle_available() {
+        TransferResult::VehicleUnavailable.label()
+    } else if !state.controls_armed {
+        "Release all controls to activate the new control context"
+    } else {
+        state.last_transfer.label()
+    };
+    text(
+        &mut frame,
+        center - Vec2::new(0.0, height * 0.32),
+        message,
+        CYAN,
+        16.0,
+    );
+    text(
+        &mut frame,
+        center - Vec2::new(0.0, height * 0.38),
+        format!(
+            "{}  |  angle {:.0}°  |  descent {:+.1}  |  sideways {:+.1}  |  feet {}/2",
+            observation.landing.phase.label(),
+            observation.landing.angle_degrees,
+            observation.landing.descent_speed,
+            observation.landing.lateral_speed,
+            observation.landing.supported_feet
+        ),
+        if parked {
+            CYAN
+        } else if observation.landing.assist_strength > 0.0 {
+            ORANGE
+        } else {
+            LIGHT
+        },
+        15.0,
+    );
+    text(
+        &mut frame,
+        center - Vec2::new(0.0, height * 0.44),
+        format!(
+            "{}  |  ship {:.0}%  |  transfers {}  |  bodies {}  |  access {:.1}u",
+            observation.balance,
+            ship.life / ship.life_max.max(1.0) * 100.0,
+            observation.transfers,
+            observation.physical_bodies,
+            observation.position.distance_to(access),
+        ),
+        ORANGE,
+        15.0,
+    );
+    frame
+}
+
+pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> RenderFrame {
+    let radius = state.world.config.universe_radius as f32;
+    let mut map = RenderFrame::new(Camera2::new(
+        render_point(Vec2::splat(radius)),
+        radius * 2.08,
+    ));
+    map.push_primitive(
+        -20,
+        RenderPrimitive::Circle(RenderCircle {
+            center: render_point(Vec2::splat(radius)),
+            radius,
+            fill: None,
+            stroke: Some(Stroke::new(RenderColor::rgb(0.36, 0.43, 0.52), 1.0)),
+        }),
+    );
+    for planet in &state.world.planets {
+        circle(
+            &mut map,
+            -10,
+            planet.position,
+            planet.radius * BODY_BOUNDS_RADIUS_SCALE,
+            CYAN,
+        );
+    }
+    // The footprint follows the actual full-window camera, including resizes.
+    let camera = camera(state);
+    let aspect = if viewport_aspect.is_finite() && viewport_aspect > 0.0 {
+        viewport_aspect
+    } else {
+        1.0
+    };
+    let half = Vec2::new(camera.height * aspect, camera.height) * 0.5;
+    let center = Vec2::new(camera.center.x, camera.center.y);
+    map.push_primitive(
+        0,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: [
+                Vec2::new(-half.x, -half.y),
+                Vec2::new(half.x, -half.y),
+                half,
+                Vec2::new(-half.x, half.y),
+            ]
+            .map(|offset| render_point(center + offset))
+            .to_vec(),
+            fill: None,
+            stroke: Some(Stroke::new(LIGHT, 1.0)),
+        }),
+    );
+    let ship = &state.world.ships[state.pilot.vehicle.0];
+    map.push_primitive(
+        2,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: [
+                Vec2::new(0.0, 20.0),
+                Vec2::new(-12.0, -12.0),
+                Vec2::new(0.0, -5.0),
+                Vec2::new(12.0, -12.0),
+            ]
+            .map(|offset| {
+                render_point(
+                    ship.position + SHIP_PIVOT + offset.rotate_radians(ship.rotation_radians),
+                )
+            })
+            .to_vec(),
+            fill: Some(Fill::new(RenderColor::rgb(1.0, 0.22, 0.22))),
+            stroke: Some(Stroke::new(LIGHT, 1.0)),
+        }),
+    );
+    if let Some(snapshot) = state.spaceling_snapshot() {
+        map.push_primitive(
+            3,
+            RenderPrimitive::Polygon(RenderPolygon {
+                points: [
+                    Vec2::new(0.0, 12.0),
+                    Vec2::new(-10.0, 0.0),
+                    Vec2::new(0.0, -12.0),
+                    Vec2::new(10.0, 0.0),
+                ]
+                .map(|offset| render_point(snapshot.motion.position + offset))
+                .to_vec(),
+                fill: Some(Fill::new(ORANGE)),
+                stroke: Some(Stroke::new(LIGHT, 1.0)),
+            }),
+        );
+    }
+    map
+}
+
+fn draw_spaceling(frame: &mut RenderFrame, snapshot: SpacelingSnapshot, facing: f32, phase: f32) {
+    let center = snapshot.motion.position;
+    let local = |x, y| center + Vec2::new(x, y).rotate_radians(snapshot.motion.angle);
+    let suit = match snapshot.balance {
+        SpacelingBalance::Balanced => ORANGE,
+        SpacelingBalance::KnockedDown => RenderColor::rgb(1.0, 0.25, 0.25),
+        SpacelingBalance::Recovering => RenderColor::rgb(1.0, 0.85, 0.3),
+    };
+    let stride = if snapshot.grounded() && snapshot.balance == SpacelingBalance::Balanced {
+        phase.sin()
+            * (snapshot.relative_speed.abs() / SurfaceSortieState::spec().walk_speed).min(1.0)
+    } else {
+        0.2
+    };
+    for side in [-1.0, 1.0] {
+        let swing = stride * side;
+        limb(
+            frame,
+            local(side * 0.1, -0.15),
+            local(side * 0.12 + swing * 0.25, -0.8),
+            LIGHT,
+            0.13,
+        );
+        limb(
+            frame,
+            local(side * 0.2, 0.3),
+            local(side * 0.36 - swing * 0.12, -0.12),
+            suit,
+            0.12,
+        );
+    }
+    frame.push_primitive(
+        3,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: [(-0.23, -0.2), (0.23, -0.2), (0.26, 0.4), (-0.26, 0.4)]
+                .map(|(x, y)| render_point(local(x, y)))
+                .to_vec(),
+            fill: Some(Fill::new(suit)),
+            stroke: Some(Stroke::new(LIGHT, 1.0)),
+        }),
+    );
+    circle(frame, 4, local(0.0, 0.63), 0.25, LIGHT);
+    circle(
+        frame,
+        5,
+        local(facing * 0.1, 0.65),
+        0.14,
+        RenderColor::rgb(0.09, 0.16, 0.23),
+    );
+}
+
+fn limb(frame: &mut RenderFrame, a: Vec2, b: Vec2, color: RenderColor, width: f32) {
+    let side = (b - a)
+        .normalized()
+        .rotate_radians(std::f32::consts::FRAC_PI_2)
+        * width
+        * 0.5;
+    frame.push_primitive(
+        2,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: [a - side, a + side, b + side, b - side]
+                .map(render_point)
+                .to_vec(),
+            fill: Some(Fill::new(color)),
+            stroke: None,
+        }),
+    );
+}
+
+fn circle(frame: &mut RenderFrame, layer: i32, center: Vec2, radius: f32, color: RenderColor) {
+    frame.push_primitive(
+        layer,
+        RenderPrimitive::Circle(RenderCircle {
+            center: render_point(center),
+            radius,
+            fill: Some(Fill::new(color)),
+            stroke: None,
+        }),
+    );
+}
+
+fn line(frame: &mut RenderFrame, layer: i32, a: Vec2, b: Vec2, color: RenderColor, width: f32) {
+    frame.push_primitive(
+        layer,
+        RenderPrimitive::Line(RenderLine::new(
+            render_point(a),
+            render_point(b),
+            Stroke::new(color, width),
+        )),
+    );
+}
+
+fn text(
+    frame: &mut RenderFrame,
+    position: Vec2,
+    label: impl Into<String>,
+    color: RenderColor,
+    size: f32,
+) {
+    let mut text = RenderText::new(render_point(position), label);
+    text.anchor = TextAnchor::Center;
+    text.color = color;
+    text.size = size;
+    frame.push_primitive(20, RenderPrimitive::Text(text));
+}

--- a/scenarios/spacewars/src/surface_sortie/tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests.rs
@@ -1,0 +1,502 @@
+use super::*;
+use engine_rapier::world::{
+    BodyId as PhysicsBodyId, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec,
+};
+
+fn tick(state: &mut SurfaceSortieState, input: SurfaceSortieAction) {
+    SurfaceSortieScenario::step(
+        state,
+        &[input.encode()],
+        Duration::from_secs_f64(1.0 / 60.0),
+    );
+}
+
+fn idle(state: &mut SurfaceSortieState, ticks: usize) {
+    for _ in 0..ticks {
+        tick(state, SurfaceSortieAction::default());
+    }
+}
+
+fn parked() -> SurfaceSortieState {
+    let mut state = SurfaceSortieScenario::init((), 7);
+    idle(&mut state, 120);
+    assert!(state.vehicle_settled(), "{:?}", state.observation());
+    state
+}
+
+fn approach(
+    up_angle: f32,
+    height: f32,
+    tilt: f32,
+    descent: f32,
+    sideways: f32,
+) -> SurfaceSortieState {
+    let mut state = SurfaceSortieScenario::init((), 7);
+    state.controls_armed = true;
+    let planet = state.world.planets[0];
+    let up = Vec2::from_radians(up_angle);
+    let center = planet.position + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + 5.5 + height);
+    let ship = &mut state.world.ships[0];
+    ship.position = center - SHIP_PIVOT;
+    ship.rotation_radians = rotation_for_direction(up) + tilt;
+    ship.direction = Vec2::Y.rotate_radians(ship.rotation_radians);
+    ship.velocity =
+        planet_surface_velocity(&planet, center) - up * descent + Vec2::new(up.y, -up.x) * sideways;
+    ship.omega = planet.wrapper_omega / (1.0 - ship.turn_power / ship.delta_time);
+    state
+}
+
+#[test]
+fn minimap_retains_world_context_and_uses_the_actual_camera_aspect() {
+    let mut state = parked();
+    let initial_map = SurfaceSortieScenario::minimap_frame(&state, 16.0 / 9.0);
+    // Move far enough that the planet is outside the main camera.
+    state.world.ships[0].position += Vec2::new(200.0, 170.0);
+    idle(&mut state, 1);
+    let camera = SurfaceSortieScenario::render_frame(&state).camera;
+    assert!(
+        Vec2::new(camera.center.x, camera.center.y).distance_to(state.world.planets[0].position)
+            > camera.height
+    );
+    for aspect in [16.0 / 9.0, 9.0 / 16.0] {
+        let map = SurfaceSortieScenario::minimap_frame(&state, aspect);
+        assert_eq!(map.camera, initial_map.camera);
+        let layer = map
+            .ordered_layers()
+            .into_iter()
+            .find(|layer| layer.z == 0)
+            .unwrap();
+        let RenderPrimitive::Polygon(rect) = &layer.primitives[0] else {
+            panic!("camera footprint")
+        };
+        let width = rect.points[1].x - rect.points[0].x;
+        let height = rect.points[2].y - rect.points[1].y;
+        assert!((width / height - aspect).abs() < 1.0e-5);
+        assert!((height - camera.height).abs() < 1.0e-4);
+    }
+}
+
+#[test]
+fn gentle_flown_landings_work_around_the_planet_and_access_follows_the_ship() {
+    for index in 0..8 {
+        let mut state = approach(
+            index as f32 * std::f32::consts::TAU / 8.0,
+            18.0,
+            5.0_f32.to_radians(),
+            5.0,
+            3.0,
+        );
+        let original_health = state.world.ships[0].life;
+        let mut landed_at = None;
+        for tick_index in 0..900 {
+            idle(&mut state, 1);
+            assert!(!state.world.physics.ship_is_constrained(0));
+            assert!(state.world.spaceport_contacts.is_empty());
+            if state.vehicle_settled() {
+                landed_at = Some(tick_index);
+                break;
+            }
+        }
+        assert!(
+            landed_at.is_some(),
+            "bearing {index}: {:?}",
+            state.observation()
+        );
+        assert_eq!(state.world.ships[0].life, original_health);
+        assert_eq!(state.landing.supported_feet, 2);
+        assert!(
+            state
+                .access_position()
+                .distance_to(state.world.ships[0].position + SHIP_PIVOT)
+                < 12.0
+        );
+        disembark(&mut state);
+        interact(&mut state);
+        assert_eq!(
+            state.last_transfer,
+            TransferResult::Boarded,
+            "bearing {index}: {:?}",
+            state.observation()
+        );
+    }
+}
+
+#[test]
+fn thrust_lifts_off_physically_and_released_thrust_returns_to_a_landed_ship() {
+    let mut state = parked();
+    let start = state.world.ships[0].position;
+    let bodies = state.world.physics.world.body_count();
+    for index in 0..35 {
+        let before = state.world.ships[0].position;
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                primary_held: true,
+                ..SurfaceSortieAction::default()
+            },
+        );
+        assert!(!state.vehicle_settled());
+        assert!(!state.world.physics.ship_is_constrained(0));
+        if index == 0 {
+            assert!(state.world.ships[0].position.distance_to(before) < 0.05);
+        }
+    }
+    assert!(state.world.ships[0].position.distance_to(start) > 3.0);
+    assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+    idle(&mut state, 900);
+    assert!(state.vehicle_settled(), "{:?}", state.observation());
+    assert_eq!(state.world.physics.world.body_count(), bodies);
+}
+
+#[test]
+fn hovering_or_nose_contact_does_not_allow_transfer_and_settling_takes_time() {
+    let mut state = approach(std::f32::consts::FRAC_PI_2, 1.0, 0.0, 0.0, 0.0);
+    idle(&mut state, 1);
+    assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+    let mut saw_settling = false;
+    for _ in 0..300 {
+        idle(&mut state, 1);
+        if state.landing.phase == LandingPhase::Settling {
+            saw_settling = true;
+            assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+        }
+        if state.vehicle_settled() {
+            break;
+        }
+    }
+    assert!(saw_settling && state.vehicle_settled());
+
+    let mut nose_first = approach(
+        std::f32::consts::FRAC_PI_2,
+        0.0,
+        std::f32::consts::PI,
+        2.0,
+        0.0,
+    );
+    let mut touched_hull = false;
+    for _ in 0..60 {
+        idle(&mut nose_first, 1);
+        assert!(!nose_first.vehicle_settled());
+        assert_eq!(nose_first.landing.assist_strength, 0.0);
+        touched_hull |= nose_first.world.physics.contacts().iter().any(|contact| {
+            matches!(
+                (contact.a, contact.b),
+                (
+                    physics::MechanicalEntity::Body(BodyId::Planet(0)),
+                    physics::MechanicalEntity::Ship(0)
+                )
+            )
+        });
+    }
+    assert!(touched_hull, "test must exercise a physical hull collision");
+    assert_eq!(nose_first.try_transfer(), TransferResult::ShipNotSettled);
+}
+
+#[test]
+fn assist_reduces_sideways_drift_but_is_bounded_and_does_not_auto_point_the_ship() {
+    let mut aligned = approach(std::f32::consts::FRAC_PI_2, 8.0, 0.0, 4.0, 8.0);
+    idle(&mut aligned, 30);
+    assert!(
+        aligned.landing.lateral_speed.abs() < 5.0,
+        "{:?}",
+        aligned.landing
+    );
+    assert!(
+        aligned.landing.descent_speed > 0.5,
+        "assist must descend, not hover"
+    );
+    let mut sideways = approach(
+        std::f32::consts::FRAC_PI_2,
+        12.0,
+        std::f32::consts::FRAC_PI_2,
+        0.0,
+        0.0,
+    );
+    let original_angle = sideways.world.ships[0].rotation_radians;
+    idle(&mut sideways, 20);
+    assert_eq!(sideways.landing.assist_strength, 0.0);
+    assert!((sideways.world.ships[0].rotation_radians - original_angle).abs() < 0.03);
+
+    let mut fast = approach(std::f32::consts::FRAC_PI_2, 8.0, 0.0, 65.0, 0.0);
+    let health = fast.world.ships[0].life;
+    idle(&mut fast, 60);
+    assert!(
+        fast.world.ships[0].life < health || fast.world.ships[0].form != ShipForm::Ship,
+        "a hard impact must not be silently converted to a safe landing: {:?}",
+        fast.observation()
+    );
+}
+
+fn interact(state: &mut SurfaceSortieState) {
+    tick(
+        state,
+        SurfaceSortieAction {
+            interact_held: true,
+            ..SurfaceSortieAction::default()
+        },
+    );
+}
+
+fn disembark(state: &mut SurfaceSortieState) {
+    interact(state);
+    assert_eq!(state.last_transfer, TransferResult::Exited);
+    idle(state, 120);
+    assert!(
+        state.spaceling_snapshot().unwrap().grounded(),
+        "{:?}",
+        state.observation()
+    );
+}
+
+#[test]
+fn parked_exit_walk_jump_return_and_reboard_preserves_identity_and_vehicle() {
+    let mut state = parked();
+    let original = state.observation();
+    state.world.ships[0].life = 70.0;
+    disembark(&mut state);
+    assert_eq!(
+        state.observation().physical_bodies,
+        original.physical_bodies + 1
+    );
+    let start_position = state.observation().position;
+    for _ in 0..40 {
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                horizontal: 1.0,
+                ..SurfaceSortieAction::default()
+            },
+        );
+    }
+    assert!(state.observation().position.distance_to(start_position) > 1.0);
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..SurfaceSortieAction::default()
+        },
+    );
+    assert_eq!(state.spaceling_snapshot().unwrap().jumps, 1);
+    idle(&mut state, 120);
+    // Walk back toward the real access point; no test pose teleport is used.
+    for _ in 0..600 {
+        let position = state.observation().position;
+        let offset = state.access_position() - position;
+        if offset.length() < 1.3 {
+            break;
+        }
+        let up = (position - state.world.planets[0].position).normalized();
+        let right = Vec2::new(up.y, -up.x);
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                horizontal: offset.dot(right).signum(),
+                ..SurfaceSortieAction::default()
+            },
+        );
+    }
+    idle(&mut state, 60);
+    assert!(state.vehicle_settled());
+    interact(&mut state);
+    assert_eq!(
+        state.last_transfer,
+        TransferResult::Boarded,
+        "{:?}",
+        state.observation()
+    );
+    let after = state.observation();
+    assert_eq!(after.spaceling, original.spaceling);
+    assert_eq!(after.owner, original.owner);
+    assert_eq!(after.vehicle, original.vehicle);
+    assert_eq!(after.ship_health, 70.0);
+    assert_eq!(after.physical_bodies, original.physical_bodies);
+    assert_eq!(after.transfers, 2);
+    assert_eq!(state.world.planets[0].owner_id, None);
+    assert!(state.world.rovers.is_empty());
+}
+
+#[test]
+fn spawn_inherits_rotating_surface_velocity_without_transporting_airborne_body() {
+    let mut state = parked();
+    let planet = state.world.planets[0];
+    assert_eq!(state.try_transfer(), TransferResult::Exited);
+    let snapshot = state.spaceling_snapshot().unwrap();
+    assert_eq!(
+        snapshot.motion.linear_velocity,
+        planet_surface_velocity(&planet, snapshot.motion.position)
+    );
+    assert_eq!(snapshot.motion.angular_velocity, planet.wrapper_omega);
+    assert_eq!(snapshot.contacts, 0);
+    // In flight, changing the terrain angle must not teleport the actor.
+    let body = state.pilot.body.as_ref().unwrap().body();
+    let position = planet.position + Vec2::Y * 100.0;
+    state
+        .world
+        .physics
+        .world
+        .set_pose(body, position, 0.0, true);
+    state
+        .world
+        .physics
+        .world
+        .set_velocity(body, Vec2::new(2.0, 0.0), 0.0, true);
+    state.world.planets[0].wrapper_angle += 0.7;
+    idle(&mut state, 1);
+    assert!(state.observation().position.distance_to(position) < 0.1);
+    let expected_velocity = Vec2::new(2.0, -GRAVITY * planet.mass / 100.0_f32.powi(2));
+    assert!((state.observation().velocity - expected_velocity).length() < 1.0e-4);
+}
+
+#[test]
+fn repeated_sorties_stay_supported_around_the_rotating_planet_without_body_leaks() {
+    let mut state = parked();
+    let bodies = state.observation().physical_bodies;
+    for _ in 0..12 {
+        disembark(&mut state);
+        idle(&mut state, 1200);
+        let snapshot = state.spaceling_snapshot().unwrap();
+        assert!(snapshot.grounded());
+        assert_eq!(snapshot.knockdowns, 0);
+        assert!(
+            snapshot
+                .motion
+                .position
+                .distance_to(state.access_position())
+                < 1.5
+        );
+        assert_eq!(state.observation().physical_bodies, bodies + 1);
+        interact(&mut state);
+        assert_eq!(state.last_transfer, TransferResult::Boarded);
+        assert_eq!(state.observation().physical_bodies, bodies);
+        idle(&mut state, 60);
+    }
+    assert_eq!(state.transfers, 24);
+    assert_eq!(state.world.planets[0].owner_id, None);
+}
+
+#[test]
+fn held_inputs_cannot_leak_across_either_transfer() {
+    let mut state = parked();
+    let held = SurfaceSortieAction {
+        horizontal: 1.0,
+        primary_held: true,
+        interact_held: true,
+        brake_held: false,
+    };
+    for _ in 0..180 {
+        tick(&mut state, held);
+    }
+    assert_eq!(state.transfers, 1);
+    assert!(!state.controls_armed);
+    assert_eq!(state.spaceling_snapshot().unwrap().jumps, 0);
+    assert_eq!(state.world.ships[0].thrust, 0.0);
+    idle(&mut state, 120);
+    for _ in 0..120 {
+        tick(&mut state, held);
+    }
+    assert_eq!(state.transfers, 2, "{:?}", state.observation());
+    assert!(matches!(state.location(), PilotLocation::Aboard(_)));
+    assert_eq!(state.world.ships[0].thrust, 0.0);
+    assert_eq!(state.world.ships[0].turn, 0.0);
+    assert!(!state.world.ships[0].laser_firing);
+    idle(&mut state, 1);
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..SurfaceSortieAction::default()
+        },
+    );
+    assert_eq!(state.world.ships[0].thrust, 1.0);
+}
+
+#[test]
+fn unsafe_exit_blocked_capsule_remote_or_airborne_boarding_and_lost_vehicle_are_rejected() {
+    let mut state = parked();
+    state.world.ships[0].velocity += Vec2::Y * 20.0;
+    idle(&mut state, 1);
+    assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+    let mut state = parked();
+    let obstacle = PhysicsId::new(45_000);
+    let center = state.access_position() + state.access_up() * 1.0;
+    let collider = ColliderSpec::ball(ColliderId::new(obstacle, ColliderRole::PRIMARY, 0), 1.3);
+    assert!(state.world.physics.world.insert_body(
+        PhysicsBodyId::new(obstacle, BodyRole::PRIMARY),
+        BodySpec {
+            kind: engine_rapier::world::BodyKind::Fixed,
+            position: center,
+            ..BodySpec::default()
+        },
+        &[collider]
+    ));
+    idle(&mut state, 1); // Publish the obstacle in the broad-phase index.
+    assert_eq!(state.try_transfer(), TransferResult::ExitBlocked);
+    assert!(state.pilot.body.is_none());
+    state.world.physics.world.remove_entity(obstacle);
+    idle(&mut state, 1);
+    disembark(&mut state);
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..SurfaceSortieAction::default()
+        },
+    );
+    assert_eq!(state.try_transfer(), TransferResult::MustBeSupported);
+    idle(&mut state, 120);
+    for _ in 0..120 {
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                horizontal: 1.0,
+                ..SurfaceSortieAction::default()
+            },
+        );
+    }
+    idle(&mut state, 60);
+    assert_eq!(state.try_transfer(), TransferResult::TooFar);
+    state.world.ships[0].change_to_escape_pod();
+    assert_eq!(state.try_transfer(), TransferResult::VehicleUnavailable);
+    assert!(state.pilot.body.is_some());
+}
+
+#[test]
+fn restart_actions_and_observations_are_reproducible_and_malformed_actions_are_rejected() {
+    let mut a = SurfaceSortieScenario::init((), 3);
+    let mut b = SurfaceSortieScenario::init((), 3);
+    for frame in 0..800 {
+        let input = SurfaceSortieAction {
+            interact_held: frame == 120 || frame == 600,
+            horizontal: if (300..350).contains(&frame) {
+                1.0
+            } else {
+                0.0
+            },
+            primary_held: frame == 400,
+            ..SurfaceSortieAction::default()
+        };
+        tick(&mut a, input);
+        tick(&mut b, input);
+        assert_eq!(
+            SurfaceSortieScenario::observe(&a).payload,
+            SurfaceSortieScenario::observe(&b).payload
+        );
+    }
+    for payload in [vec![], vec![0; 6], vec![0, 0, 0, 0, 2, 0, 0]] {
+        assert!(SurfaceSortieAction::decode(&Action::scenario(CONTROL_V1, payload)).is_none());
+    }
+    assert!(
+        SurfaceSortieAction::decode(
+            &SurfaceSortieAction {
+                horizontal: f32::NAN,
+                ..SurfaceSortieAction::default()
+            }
+            .encode()
+        )
+        .is_none()
+    );
+    assert_eq!(
+        SurfaceSortieScenario::observe(&SurfaceSortieScenario::init((), 3)).payload,
+        SurfaceSortieScenario::observe(&SurfaceSortieScenario::init((), 3)).payload
+    );
+}


### PR DESCRIPTION
## Summary

Add an opt-in Surface Sortie scenario that shares the Spacewars physics world and gravity solve while keeping ordinary capture gameplay unchanged.

- Keep spaceling identity and ship occupancy separate; insert one physical capsule only while on foot.
- Add safe exit/boarding beside the actual landed ship, collider-checked clearance, surface velocity inheritance, and neutral-input handoffs.
- Replace the temporary berth in this fixture with rear landing feet, bounded nose-outward landing assistance, contact-based settling, and physical thrust takeoff.
- Add a translucent north-up minimap and landing diagnostics, with grouped compositing in both renderers and correct camera footprints on resize.
- Register keyboard/NES-style gamepad controls and document the fixture, architecture, and remaining gameplay boundaries.

No capture/services, weapons, asteroid spawning, bot policy, or pilot-loss rules are introduced by this PR. Those remain separate follow-ups. Related to #41.

## Validation

- Manual sortie and refined landing playtesting passed.
- Workspace all-target tests passed.
- Surface Sortie real-window launcher/pause/restart workflow passed in both renderer modes; raster screenshots checked.
- Rust 1.89 client all-target check passed.
- Pinned navigation-v1 and strategy-v1 AI baselines matched.
- Regressions cover eight-bearing flown landings, takeoff/return, unsafe and blocked transfers, repeated body lifecycle, moving-surface support, deterministic replay, renderer layout, and minimap compositing.
- Strict Clippy still reports pre-existing unrelated warnings.

## Try it

`cargo run -p engine-client -- --scenario surface-sortie`

A/Space thrusts, left/right turns or walks, Down/S brakes, and B/X exits or boards after the ship is physically landed. Point the nose away from the planet when returning; watch for LANDED and cyan feet.