### PR TITLE
Add Surface Sortie outpost capture and repair loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ The local launcher currently hosts seven playable scenarios:
   planet, with gravity-relative upright control and visible contact diagnostics.
   See [Spaceling Lab](docs/spaceling-lab.md).
 - **Surface Sortie** — an opt-in Spacewars pilot/vehicle experiment: land
-  rear-first with flight assistance, walk/jump on the planet, and reboard the
-  same physical ship. Includes a translucent minimap and landing diagnostics.
+  rear-first with flight assistance, walk to capture an outpost, repair your
+  nearby landed ship, and reboard to depart. Includes a translucent minimap,
+  ownership flag, and landing/capture diagnostics.
   See [Surface Sortie](docs/surface-sortie.md) for controls and scope.
 - **Falling** — the pinned MIT-licensed NES homebrew running on this repository's
   Rust-native mapper-0 emulator, with pixel-perfect native video, exact-rational

--- a/crates/engine-client/src/client_scenarios/surface_sortie.rs
+++ b/crates/engine-client/src/client_scenarios/surface_sortie.rs
@@ -26,7 +26,7 @@ pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
         captures_gamepad_start: false,
         captures_gamepad_select: false,
     },
-    controls_help: "Surface Sortie (experimental): left/right or A/D turns aboard, walks on foot. A / Space thrusts aboard and jumps on foot. Down / S brakes. Point the nose away from the planet for landing assist; settle on both rear feet. B / X exits a landed ship or boards at its cyan hatch. Release controls after transferring. Start / Esc pauses; R restarts. North-up minimap: red ship, orange spaceling, cyan planet. No weapons or capture.",
+    controls_help: "Surface Sortie: left/right or A/D turns aboard, walks on foot. A / Space thrusts aboard and jumps on foot. Down / S brakes. Face away from the planet for landing assist; settle on both rear feet. B / X exits or boards at the cyan hatch. Release controls after transferring. Stand beside the amber terminal for 3 seconds to capture; leaving, jumping, or knockdown resets progress. A friendly outpost repairs a nearby landed ship at 5%/s. The ship starts at 75% health. Minimap: red ship, orange spaceling, cyan planet, square outpost (owner color). Start / Esc pauses; R restarts. No weapons or rebuilding.",
     create,
 };
 
@@ -129,6 +129,103 @@ mod tests {
             scenario.map_input(&mut input, false),
             vec![SurfaceSortieAction::default().encode()]
         );
+    }
+
+    #[test]
+    fn outpost_capture_progress_and_owner_flag_render_in_both_backends() {
+        let mut scenario = SurfaceSortieClientScenario {
+            state: SurfaceSortieScenario::init((), 0),
+        };
+        let dt = Duration::from_secs_f64(1.0 / 60.0);
+        for frame in 0..120 {
+            scenario.step(
+                &[SurfaceSortieAction {
+                    interact_held: frame == 60,
+                    ..SurfaceSortieAction::default()
+                }
+                .encode()],
+                dt,
+            );
+        }
+        for _ in 0..600 {
+            let observation = scenario.state.observation();
+            if observation
+                .position
+                .distance_to(observation.outpost.position)
+                < 2.35
+            {
+                break;
+            }
+            scenario.step(
+                &[SurfaceSortieAction {
+                    horizontal: 1.0,
+                    ..SurfaceSortieAction::default()
+                }
+                .encode()],
+                dt,
+            );
+        }
+        for _ in 0..60 {
+            scenario.step(&[SurfaceSortieAction::default().encode()], dt);
+        }
+        let partial = scenario.state.observation().outpost;
+        assert!(partial.capture_progress > 0.0 && partial.capture_progress < 1.0);
+        let viewport = Viewport::new(1280.0, 720.0);
+        check_render(&scenario, viewport, "on-foot-capturing");
+        for _ in 0..180 {
+            scenario.step(&[SurfaceSortieAction::default().encode()], dt);
+        }
+        let observation = scenario.state.observation();
+        assert_eq!(observation.outpost.owner, Some(observation.owner));
+        assert!(observation.outpost.repaired_health > 0.0);
+        for viewport in [viewport, Viewport::new(1280.0, 1400.0)] {
+            let frames = scenario.render_frames(RenderBackend::Vector, viewport);
+            assert_eq!(
+                frames,
+                scenario.render_frames(RenderBackend::Raster, viewport)
+            );
+            let overlay =
+                crate::render::raster_text_overlay(&frames, viewport, scenario.frame_layout());
+            assert!(
+                overlay
+                    .iter()
+                    .any(|primitive| primitive.text.starts_with("OUTPOST P1"))
+            );
+            assert!(
+                overlay
+                    .iter()
+                    .any(|primitive| primitive.text == "P1 OUTPOST")
+            );
+            let name = if viewport.height > viewport.width {
+                "on-foot-secured-portrait"
+            } else {
+                "on-foot-secured"
+            };
+            check_render(&scenario, viewport, name);
+            // Check the actual owner-colored flag, not just a text/model entry.
+            let up = observation.outpost.surface_normal;
+            let flag = observation.outpost.position
+                + up * 3.15
+                + engine_core::Vec2::new(up.y, -up.x) * 1.3;
+            let projected = frames[0].camera.world_to_viewport(
+                engine_common::RenderPoint::new(flag.x, flag.y),
+                viewport.aspect_ratio(),
+            );
+            let image = crate::raster::RasterRenderer::new().image_from_frames_with_layout(
+                &frames,
+                viewport,
+                scenario.frame_layout(),
+                crate::raster::RasterOptions::default(),
+            );
+            let pixels = image.to_rgb8().unwrap();
+            let x = (projected.x * pixels.width() as f32) as usize;
+            let y = (projected.y * pixels.height() as f32) as usize;
+            let pixel = pixels.as_slice()[y * pixels.width() as usize + x];
+            assert!(
+                pixel.r > 200 && pixel.g < 80 && pixel.b < 80,
+                "missing owner flag: {pixel:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
+++ b/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
@@ -111,6 +111,8 @@ fn assert_raster_sortie_visible(path: &Path) {
     let mut ship_pixels = 0;
     let mut diagnostics_pixels = 0;
     let mut minimap_planet_pixels = 0;
+    let mut outpost_pixels = 0;
+    let mut outpost_hud_pixels = 0;
     for (index, pixel) in buffer[..frame.buffer_size()]
         .chunks_exact(channels)
         .enumerate()
@@ -121,8 +123,18 @@ fn assert_raster_sortie_visible(path: &Path) {
         {
             ship_pixels += 1;
         }
-        if y > height * 4 / 5 && pixel[0] < 150 && pixel[1] > 175 && pixel[2] > 140 {
+        // The cyan transfer row is in the bottom quarter. Landing diagnostics
+        // below it change from orange to cyan as the initial ship settles.
+        if y > height * 3 / 4 && pixel[0] < 150 && pixel[1] > 175 && pixel[2] > 140 {
             diagnostics_pixels += 1;
+        }
+        if pixel[0] > 200 && pixel[1] > 160 && pixel[1] < 230 && pixel[2] < 100 {
+            if y > height / 3 && y < height * 3 / 4 {
+                outpost_pixels += 1;
+            }
+            if y > height * 4 / 5 {
+                outpost_hud_pixels += 1;
+            }
         }
         // The overview sits below the top HUD at the right. Its planet stays
         // cyan even though the main scene uses a dark-blue surface.
@@ -136,7 +148,15 @@ fn assert_raster_sortie_visible(path: &Path) {
             minimap_planet_pixels += 1;
         }
     }
-    assert!(ship_pixels > 100, "missing parked ship: {ship_pixels}");
+    assert!(ship_pixels > 100, "missing initial ship: {ship_pixels}");
+    assert!(
+        outpost_pixels > 40,
+        "missing amber outpost: {outpost_pixels}"
+    );
+    assert!(
+        outpost_hud_pixels > 40,
+        "missing outpost capture HUD: {outpost_hud_pixels}"
+    );
     assert!(
         minimap_planet_pixels > 40,
         "missing minimap planet: {minimap_planet_pixels}"

--- a/docs/design/reboot-rust-slint.md
+++ b/docs/design/reboot-rust-slint.md
@@ -592,5 +592,15 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - M27b: ✅ Add collider-checked exit, surface-relative velocity inheritance, nearby supported boarding, control-context neutral gating, and visible feedback. The initial elevated-berth round trip passed manual playtesting.
 - M27c: ✅ Replace that temporary berth in the fixture with physical rear landing feet, nose-outward bounded flight assistance, contact-based settling, and physical takeoff. Add a translucent north-up minimap and landing diagnostics. Refined landing feel passed manual playtesting.
 - M27d: ✅ Add deterministic round-trip, eight-bearing flown landing, takeoff/return, blocked/unsafe transition, repeated body lifecycle, gravity, renderer/compositing, keyboard/gamepad mapping, and launcher workflow regressions.
-- Follow-ups: an intact surface-outpost capture/reward loop; explicit damage/rescue/pod rules; accelerating orbital supports; ordinary Spacewars integration and bot intent. Normal capture gameplay is unchanged by this fixture.
+- Follow-ups: M28 adds an intact surface-outpost capture/reward loop. Explicit damage/rescue/pod rules, accelerating orbital supports, ordinary Spacewars integration, and bot intent remain later work. Normal capture gameplay is unchanged by this fixture.
 - Guide: [Surface Sortie](../surface-sortie.md).
+
+### M28: Intact outpost capture and repair
+
+- M28a: ✅ Add one solid terminal on Surface Sortie's existing rotating planet body, with scenario-owned capture state separate from terrain ownership and physical landing. Start the ship at 75% health; require three continuous supported, balanced, settled seconds near the terminal.
+- M28b: ✅ Add gradual friendly-ship repair requiring a live, physically landed ship within service range. Do not heal on boarding, repair airborne ships, or rebuild pods.
+- M28c: ✅ Show capture progress and service eligibility, raise an owner-colored flag, and add a square ownership marker to the minimap. Extend typed/versioned observations with outpost and repair statistics.
+- M28d: ✅ Cover the control-driven round trip, capture interruptions/support identity, rotating solid geometry, repair eligibility/rate/clamping, deterministic replay/restart, and owner rendering in landscape/portrait through both paths.
+- Manual playtesting: the user reported the deployed outpost gameplay loop worked well with a controller on the Raspberry Pi (2026-09-06).
+- Design direction: neutral-outpost capture is one experimental path, not the only future way to claim or develop a planet. Keep planet claims, infrastructure ownership, and operational services distinct; do not require a pre-existing neutral outpost on every claimable planet.
+- Boundaries: no contested-capture policy, destructible infrastructure, resource economy, rebuilding, pilot/vehicle loss policy, or ordinary Spacewars/bot rule changes.

--- a/docs/design/spacelings.md
+++ b/docs/design/spacelings.md
@@ -119,13 +119,13 @@ gravity and Rapier contacts move it. Do not copy the rover's scripted-orbit
 transport into this controller. Accelerating orbital supports need their own
 regressions before enabling this in ordinary generated Spacewars worlds.
 
-This slice disables capture/services, weapons, and asteroid spawning in the
-fixture. It leaves the ordinary Spacewars game and bot observations unchanged.
+The initial slice disabled capture/services, weapons, and asteroid spawning in
+the fixture. It leaves the ordinary Spacewars game and bot observations unchanged.
 Pilot damage, ship destruction while unoccupied, rescue/pods/elimination, NPC
 policy, and the contested outpost reward loop require explicit later policy;
 the fixture reports a lost vehicle and offers restart rather than inventing
-those rules. The next gameplay slice can make walking useful through an intact
-outpost capture and repair/rebuild service.
+those rules. The next slice below makes walking useful through an intact
+outpost capture and repair service, without adding rebuilding.
 
 Acceptance: rear-first landing at multiple bearings, physical takeoff/return,
 bounded assist, rejected hover/nose contact, parked exit/walk/jump/reboard,
@@ -133,6 +133,51 @@ moving-surface velocity inheritance,
 actual collider clearance, fresh-input gating, preserved ship state, rejected
 unsafe transitions, deterministic restart/observations, both renderers and the
 standard launcher/pause flow, plus unchanged ordinary-game regressions.
+
+## Fourth slice: surface-outpost capture and repair
+
+Implemented on `surface-outpost-loop`; the deployed loop passed user-reported
+controller playtesting on the Raspberry Pi on 2026-09-06. Extend
+Surface Sortie with one intact terminal attached to the rotating planet body
+as a solid collider. The ship starts at 75% health so the reward is visible.
+Disembark, walk to the terminal, remain supported/balanced/settled for three
+seconds, capture, repair the nearby landed ship, return, and depart.
+
+Keep three separate contracts: physics establishes support and landing;
+scenario policy establishes outpost ownership; service policy checks ownership,
+ship availability, landed state, and range before gradually restoring health.
+The outpost owns no terrain, creates no landing hold, and grants no remote or
+airborne repair. Reboarding still preserves the same ship without itself
+changing health. The reusable spaceling controller needs no capture code.
+
+Neutral-outpost capture is only one path toward establishing a presence, not
+the sole future way to claim a planet or get it running. Keep planet claims,
+infrastructure ownership, and operational services distinct. For example,
+building a new base or restoring abandoned infrastructure could provide other
+paths; their specific rules are not decided or implemented by this slice.
+Do not require every claimable planet to spawn with a neutral outpost, or
+equate ownership of one installation with control of all terrain. The current
+capture-enables-repair rule is fixture policy, not an engine invariant.
+
+Capture requires support from this planet or its terminal, not merely any
+grounded contact nearby. Leaving, jumping, losing balance, or excessive
+support-relative speed resets partial progress. Ownership remains secured on
+departure. The owner-colored physical flag and square minimap marker expose
+that state; the HUD shows capture progress and service eligibility. Structured
+observations include owner/claimant, progress, captures, and health restored.
+
+This is deliberately one operator and one outpost, not a general contested-base
+system. The terminal is intact and non-destructible; terrain removal and service
+invalidation need explicit later policy. There are no new weapons, resources,
+pod rebuilding, pilot death rules, or changes to ordinary Spacewars/bots.
+Moving/accelerating-planet evidence and independent pilot/vehicle loss rules
+still precede ordinary-game integration.
+
+Acceptance: an action-driven capture/repair/departure round trip; interrupted
+capture and wrong-support rejection; solid rotating terminal/body-count bounds;
+friendly, live, in-range, landed repair with rate/clamp checks; deterministic
+replay and restart; capture/ownership rendering in both paths and window
+orientations; unchanged landing, normal-game, and pinned bot regressions.
 
 ## Planet and ship direction
 

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -65,9 +65,11 @@ in `engine-rapier` and `scenario-spaceling-lab`; physical controller hardware is
 manual check.
 
 Surface Sortie uses the same launcher/pause/restart workflow with both renderers;
-its raster check requires the landed ship, diagnostics, and minimap planet. The client unit
-tests also render the disembarked spaceling, while `scenario-spacewars` exercises
-the complete physical exit/walk/jump/return/board loop and input gating. See
+its raster check requires the ship, amber outpost, capture/landing HUD,
+and minimap planet. The client unit tests also render the disembarked spaceling,
+capture progress, and owner-colored flag in landscape/portrait, while
+`scenario-spacewars` exercises the physical exit/walk/capture/repair/return/board/
+departure loop and input gating. See
 [Surface Sortie](surface-sortie.md) for the manual controls and retained images.
 
 The harness uses Slint's software backend, which does not draw vector paths.

--- a/docs/surface-sortie.md
+++ b/docs/surface-sortie.md
@@ -7,10 +7,13 @@ in the launcher, or run:
 cargo run -p engine-client -- --scenario surface-sortie
 ```
 
-The fixture starts with your ship settling rear-first onto a slowly rotating planet. Press
-**B** on a gamepad or **X** on the keyboard to disembark. Release the controls,
-walk around, and return to the cyan access marker. Once standing and settled,
-press B/X again to reboard the same ship. Boarding does not heal or replace it.
+The fixture starts with your ship at **75% health**, settling rear-first onto a
+slowly rotating planet. Press **B** on a gamepad or **X** on the keyboard to
+disembark. Release the controls, walk right to the amber terminal, and stand
+beside it for three seconds to capture the outpost. It repairs your nearby
+landed ship. Return to the cyan access marker and, once standing and settled,
+press B/X again to reboard and depart. Boarding itself does not heal or replace
+the ship.
 
 | Control | Aboard | On foot |
 | --- | --- | --- |
@@ -25,6 +28,37 @@ After each successful transfer, all controls must return to neutral before the
 new context accepts them. Holding A while exiting cannot become an unintended
 jump, and holding it while boarding cannot immediately launch the ship. An
 unsuccessful interaction does not repeat until B/X is released and pressed again.
+
+## Capturing and repairing
+
+Capture is automatic while standing within **3 world units** of the terminal's
+base, balanced and supported by that planet's surface or terminal. Your
+support-point-relative speed must be at most **1 unit/s**. Jumping, getting
+knocked down, walking out of range, or moving too quickly resets partial
+progress. Landing the ship cannot capture; neither can hovering nearby or
+standing on an unrelated vehicle/platform. No additional interaction button is
+needed.
+
+After **3 continuous seconds**, the outpost raises your owner-colored flag and
+its square minimap marker changes from amber to your color. The HUD shows
+progress and why capture is waiting. Ownership persists when you leave; it
+belongs to the outpost, **not the entire planet**.
+
+Capturing a neutral outpost is one testbed interaction, not the universal rule
+for claiming or developing a planet. Future scenarios must allow other paths
+without requiring a pre-existing neutral terminal. Planet claims, infrastructure
+ownership, and operational services remain separate concepts; this fixture
+implements only outpost ownership and its simple repair service.
+
+A friendly outpost restores **5% of maximum ship health per second**, capped at
+full health, while the same live ship is physically landed and its center is
+within **24 world units** of the terminal's base. The faint service-range circle
+is a visual guide, not a landing constraint. Repairs work while you are outside
+the ship too; the starting landing spot is already in range. Taking off or
+leaving service range stops repair immediately. An enemy ship, destroyed ship,
+or pod cannot use this repair service; this is not a rebuild or resurrection
+mechanic. After landing elsewhere, you can still capture on foot, but must move
+the ship into range to repair it.
 
 ## Flying and landing
 
@@ -51,7 +85,9 @@ to the existing hull body, not extra bodies, joints, or mass.
 
 The camera follows the active ship or spaceling. A translucent, fixed-scale,
 north-up minimap stays visible at the right below the top HUD: cyan planet, red
-ship with heading, orange spaceling, and a white camera footprint. Its footprint
+ship with heading, orange spaceling, square outpost marker, and a white camera
+footprint. A short leader connects the outpost marker to its surface location.
+Its footprint
 uses the actual window aspect ratio, including portrait layouts. The main view
 keeps the whole window; both vector and raster backends composite the circular
 backing and map as one faded layer.
@@ -59,7 +95,8 @@ backing and map as one faded layer.
 Orange is balanced, red is
 knocked down, yellow is recovering; cyan identifies physical support and surface
 access. The HUD shows landing phase, angle, descent and sideways speed, foot
-contacts, transfer feedback, ship health, body count, and access distance.
+contacts, transfer feedback, ship health, body count, access distance, outpost
+capture progress, and repair eligibility.
 Use raster rendering on software-only backends (including the kiosk).
 
 ## Model and boundaries
@@ -78,6 +115,13 @@ hitting the coincident ship-only surface. Spawn clearance is an infrequent
 capsule query against the world's spatial index; ordinary support queries stay
 local to the character's contacts.
 
+The intact terminal adds one solid collider to the existing rotating planet
+body, not another simulated body. Capture and repair are small scenario-owned
+policies consuming completed support/landing state; they do not manipulate
+physics, transfer ownership of terrain, or reuse the ordinary game's port
+capture/heal rules. This single-operator fixture does not define contested
+capture, destructible infrastructure, or multiple-outpost service arbitration.
+
 The former elevated berth/access connection is removed in this fixture. Its
 ship opts out of the port sensor, compact dock collider, and kinematic hold,
 and collides only with the planet's rough surface, not both coincident surfaces.
@@ -92,12 +136,12 @@ Afterward Rapier and gravity own its motion; no radial snapping or per-tick
 orbital transport is added. The center is stationary on purpose. Accelerating
 scripted orbits need separate regression evidence before ordinary-world use.
 
-This is a noncombat fixture: no weapons, asteroids, capture, healing, rover
-construction, or win condition. Ordinary Spacewars and its bots are unchanged.
+This is a noncombat fixture: no weapons, asteroids, pod rebuilding, rover
+construction, resources, or win condition. Ordinary Spacewars and its bots are unchanged.
 If you lose the ship while experimenting with flight, restart; damage, rescue,
 pod, and elimination policy for an independent pilot are not settled here.
-The next gameplay slice can add an intact surface outpost to capture and a
-repair/rebuild reward. This is not yet that outpost game mode.
+The intact outpost gives walking a useful capture-and-repair loop without
+settling those larger game-mode policies.
 
 ## Verification
 
@@ -111,25 +155,37 @@ Headless regressions cover exit/walk/jump/return/reboard without pose shortcuts,
 ship health and creature identity preservation, one-body lifecycle, velocity
 inheritance, no airborne transport, blocked exits, unsafe/remote boarding,
 held-input gating in both directions, and reproducible actions/restarts. Typed
-`SurfaceSortieState::observation()` and version-2 JSON scenario observations
+`SurfaceSortieState::observation()` and version-3 JSON scenario observations
 include landing phase, clearance, angle, relative speeds/spin, foot count,
-assist strength, and settling duration for future runners; this does not add
-a live IPC telemetry API.
+assist strength, and settling duration for future runners. Outpost observations
+add identity, position/normal, owner, active claimant, capture eligibility and
+progress, capture count, repair eligibility/range, and cumulative health
+restored. This does not add a live IPC telemetry API.
 
 Landing regressions fly gentle approaches at eight bearings, verify physical
 takeoff/return, contact-only boarding, the settling interval, sideways damping,
 no automatic pointing, and damage on fast approaches. Ordinary Spacewars' port
 regressions and pinned AI suites remain the compatibility guard.
 
-The client test checks both render paths and on-foot geometry. To retain images:
+Outpost regressions complete exit/walk/capture/repair/return/reboard/takeoff
+using only player controls. They also cover interrupted capture, wrong support
+identity, solid rotating terminal geometry without another body, ownership
+separate from the planet, repair eligibility/rate/clamping, fresh capture time
+for a changed claimant, deterministic replay, restart, and no progress without
+simulation steps.
+
+Client tests check both render paths, on-foot geometry, capture feedback, and
+the actual owner-colored flag in landscape and portrait layouts. To retain images:
 
 ```sh
 SPACEWARS_SORTIE_ARTIFACTS=target/surface-sortie-poses cargo test -p engine-client \
   registered_fixture_renders_and_restarts_in_both_backends
+SPACEWARS_SORTIE_ARTIFACTS=target/surface-sortie-poses cargo test -p engine-client \
+  outpost_capture_progress_and_owner_flag_render_in_both_backends
 ```
 
 The real-window functional test covers launcher selection, both renderers,
-pause, restart, return, and relaunch, with raster ship/HUD/minimap visibility checks:
+pause, restart, return, and relaunch, with raster ship/outpost/HUD/minimap visibility checks:
 
 ```sh
 SPACEWARS_KEEP_FUNCTIONAL_ARTIFACTS=1 cargo test -p engine-client \
@@ -139,3 +195,6 @@ SPACEWARS_KEEP_FUNCTIONAL_ARTIFACTS=1 cargo test -p engine-client \
 Use an existing display or the [Xvfb workflow](functional-tests.md). Physical
 gamepad feel and the complete round trip remain manual acceptance checks; the
 initial sortie and refined assisted landing have both passed manual playtesting.
+The outpost loop also passed user-reported controller playtesting on the
+Raspberry Pi on 2026-09-06: gameplay worked well and the direction was accepted.
+This validates the experimental loop, not a final planet-claiming mechanic.

--- a/scenarios/spacewars/src/physics.rs
+++ b/scenarios/spacewars/src/physics.rs
@@ -35,9 +35,16 @@ const SHIP_HULL_ROLE: ColliderRole = ColliderRole::new(5);
 const DEBRIS_ROLE: ColliderRole = ColliderRole::new(6);
 const ROVER_SURFACE_ROLE: ColliderRole = ColliderRole::new(7);
 const LANDING_FOOT_ROLE: ColliderRole = ColliderRole::new(8);
+const OUTPOST_TERMINAL_ROLE: ColliderRole = ColliderRole::new(9);
 
 pub(super) const LANDING_FOOT_RADIUS: f32 = 0.45;
 pub(super) const LANDING_FEET: [Vec2; 2] = [Vec2::new(-3.0, -5.0), Vec2::new(3.0, -5.0)];
+pub(super) const OUTPOST_TERMINAL_HALF_SIZE: Vec2 = Vec2::new(0.7, 1.1);
+
+pub(super) fn is_planet_surface_support(collider: ColliderId, planet: usize) -> bool {
+    collider.entity == planet_entity(planet)
+        && (collider.role == ROVER_SURFACE_ROLE || collider.role == OUTPOST_TERMINAL_ROLE)
+}
 
 const GROUP_SHIP_0: u32 = 1 << 0;
 const GROUP_SHIP_1: u32 = 1 << 1;
@@ -401,6 +408,33 @@ impl SpacewarsPhysics {
         self.docked_planets[index] = None;
         self.world.remove_entity(ship_entity(index));
         assert!(self.insert_ship(index, ship, false, false, false));
+    }
+
+    /// An intact terminal attached to existing terrain: one collider, no new body.
+    /// This fixture has fixed planet geometry; regeneration/destruction is a later policy.
+    pub(super) fn insert_surface_terminal(
+        &mut self,
+        planet: usize,
+        radius: f32,
+        local_angle: f32,
+    ) -> bool {
+        let entity = planet_entity(planet);
+        let mut terminal = ColliderSpec::cuboid(
+            collider_id(entity, OUTPOST_TERMINAL_ROLE, 0),
+            OUTPOST_TERMINAL_HALF_SIZE.x,
+            OUTPOST_TERMINAL_HALF_SIZE.y,
+        );
+        terminal.local_position = Vec2::from_radians(local_angle)
+            * (radius * BODY_BOUNDS_RADIUS_SCALE + OUTPOST_TERMINAL_HALF_SIZE.y - 0.02);
+        terminal.local_angle = local_angle - core::f32::consts::FRAC_PI_2;
+        terminal.density = 0.0;
+        terminal.friction = 0.8;
+        terminal.collision_groups = CollisionGroups::new(
+            GROUP_BODY | GROUP_ROVER_SURFACE,
+            GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_ROVER | GROUP_SPACELING,
+        );
+        terminal.solver_groups = terminal.collision_groups;
+        self.world.insert_collider(primary_body(entity), &terminal)
     }
 
     pub(super) fn ship_body(&self, index: usize) -> PhysicsBodyId {

--- a/scenarios/spacewars/src/surface_sortie.rs
+++ b/scenarios/spacewars/src/surface_sortie.rs
@@ -9,8 +9,10 @@ use engine_rapier::{
 };
 
 mod landing;
+mod outpost;
 mod render;
 pub use landing::{LandingPhase, LandingTelemetry};
+pub use outpost::{CaptureStatus, OutpostId, OutpostObservation, RepairStatus};
 #[cfg(test)]
 mod tests;
 
@@ -115,6 +117,7 @@ pub struct SurfaceSortieState {
     transfers: u64,
     last_transfer: TransferResult,
     landing: LandingTelemetry,
+    outpost: outpost::SurfaceOutpost,
 }
 
 pub(super) struct SurfacePilot {
@@ -176,6 +179,7 @@ pub struct SurfaceSortieObservation {
     pub controls_armed: bool,
     pub physical_bodies: usize,
     pub landing: LandingTelemetry,
+    pub outpost: OutpostObservation,
 }
 
 impl SurfaceSortieState {
@@ -195,7 +199,7 @@ impl SurfaceSortieState {
         let ship = &self.world.ships[self.pilot.vehicle.0];
         let snapshot = self.spaceling_snapshot();
         SurfaceSortieObservation {
-            version: 2,
+            version: 3,
             tick: self.world.tick,
             spaceling: self.pilot.id,
             owner: self.pilot.owner,
@@ -220,6 +224,9 @@ impl SurfaceSortieState {
             controls_armed: self.controls_armed,
             physical_bodies: self.world.physics.world.body_count(),
             landing: self.landing,
+            outpost: self
+                .outpost
+                .observation(&self.world.planets[self.outpost.planet]),
         }
     }
 
@@ -353,6 +360,7 @@ impl Scenario for SurfaceSortieScenario {
         world.ships[0].rotation_radians = 0.0;
         world.ships[0].direction = Vec2::Y;
         world.ships[0].velocity = planet_surface_velocity(&planet, center);
+        world.ships[0].life = world.ships[0].life_max * 0.75;
         // Keep the second vehicle far from the single-player fixture. Its
         // existence does not imply that this pilot may occupy another owner's ship.
         world.ships[1].position = Vec2::new(850.0, 850.0);
@@ -362,6 +370,12 @@ impl Scenario for SurfaceSortieScenario {
         world.physics = physics::SpacewarsPhysics::new(500.0, &world.ships, None, &world.planets);
         world.physics.enable_surface_landing(0, &world.ships[0]);
         world.spaceport_contacts.clear();
+        let outpost = outpost::SurfaceOutpost::new(OutpostId(1), 0, -0.34);
+        assert!(world.physics.insert_surface_terminal(
+            outpost.planet,
+            planet.radius,
+            outpost.local_angle
+        ));
         SurfaceSortieState {
             world,
             pilot: SurfacePilot {
@@ -381,6 +395,7 @@ impl Scenario for SurfaceSortieScenario {
             transfers: 0,
             last_transfer: TransferResult::Ready,
             landing: LandingTelemetry::default(),
+            outpost,
         }
     }
 
@@ -465,6 +480,8 @@ impl Scenario for SurfaceSortieScenario {
                 + snapshot.relative_speed.abs() * dt * 5.0)
                 .rem_euclid(std::f32::consts::TAU);
         }
+        // Services consume completed physical support/landing, never create it.
+        state.update_outpost(Duration::from_secs_f32(dt));
         result
     }
 

--- a/scenarios/spacewars/src/surface_sortie/outpost.rs
+++ b/scenarios/spacewars/src/surface_sortie/outpost.rs
@@ -1,0 +1,251 @@
+//! Scenario-owned capture and repair policy, independent of landing mechanics.
+
+use super::*;
+
+pub(super) const CAPTURE_TIME: Duration = Duration::from_secs(3);
+pub(super) const CAPTURE_RANGE: f32 = 3.0;
+pub(super) const CAPTURE_MAX_SPEED: f32 = 1.0;
+pub(super) const REPAIR_RANGE: f32 = 24.0;
+pub(super) const REPAIR_FRACTION_PER_SECOND: f32 = 0.05;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct OutpostId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureStatus {
+    Aboard,
+    TooFar,
+    NeedSupport,
+    NeedBalance,
+    NeedSettle,
+    Capturing,
+    Secured,
+}
+
+impl CaptureStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Aboard => "disembark to capture",
+            Self::TooFar => "walk to the amber terminal",
+            Self::NeedSupport => "land beside the terminal",
+            Self::NeedBalance => "recover your balance",
+            Self::NeedSettle => "stand still to capture",
+            Self::Capturing => "capturing; stay beside the terminal",
+            Self::Secured => "secured",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepairStatus {
+    NeedsCapture,
+    NotFriendly,
+    VehicleUnavailable,
+    NeedLanding,
+    OutOfRange,
+    Repairing,
+    Ready,
+}
+
+impl RepairStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::NeedsCapture => "capture the outpost",
+            Self::NotFriendly => "outpost is not friendly",
+            Self::VehicleUnavailable => "vehicle unavailable",
+            Self::NeedLanding => "land to repair",
+            Self::OutOfRange => "land closer to the outpost",
+            Self::Repairing => "repairing +5%/s",
+            Self::Ready => "ship ready for departure",
+        }
+    }
+}
+
+pub(super) struct SurfaceOutpost {
+    pub id: OutpostId,
+    pub planet: usize,
+    pub local_angle: f32,
+    pub owner: Option<PlayerId>,
+    capture_elapsed: Duration,
+    capturing_player: Option<PlayerId>,
+    capture_status: CaptureStatus,
+    captures: u64,
+    repair_status: RepairStatus,
+    repaired_health: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct OutpostObservation {
+    pub id: OutpostId,
+    pub planet: usize,
+    pub position: Vec2,
+    pub surface_normal: Vec2,
+    pub owner: Option<PlayerId>,
+    pub capturing_player: Option<PlayerId>,
+    pub capture_status: CaptureStatus,
+    pub capture_progress: f32,
+    pub capture_required_seconds: f32,
+    pub capture_range: f32,
+    pub captures: u64,
+    pub repair_status: RepairStatus,
+    pub repair_range: f32,
+    pub repaired_health: f32,
+}
+
+impl SurfaceOutpost {
+    pub(super) fn new(id: OutpostId, planet: usize, local_angle: f32) -> Self {
+        Self {
+            id,
+            planet,
+            local_angle,
+            owner: None,
+            capture_elapsed: Duration::ZERO,
+            capturing_player: None,
+            capture_status: CaptureStatus::Aboard,
+            captures: 0,
+            repair_status: RepairStatus::NeedsCapture,
+            repaired_health: 0.0,
+        }
+    }
+
+    pub(super) fn up(&self, planet: &PlanetState) -> Vec2 {
+        Vec2::from_radians(planet.wrapper_angle + self.local_angle)
+    }
+
+    pub(super) fn position(&self, planet: &PlanetState) -> Vec2 {
+        planet.position + self.up(planet) * (planet.radius * BODY_BOUNDS_RADIUS_SCALE)
+    }
+
+    pub(super) fn observation(&self, planet: &PlanetState) -> OutpostObservation {
+        OutpostObservation {
+            id: self.id,
+            planet: self.planet,
+            position: self.position(planet),
+            surface_normal: self.up(planet),
+            owner: self.owner,
+            capturing_player: self.capturing_player,
+            capture_status: self.capture_status,
+            capture_progress: self.capture_elapsed.as_secs_f32() / CAPTURE_TIME.as_secs_f32(),
+            capture_required_seconds: CAPTURE_TIME.as_secs_f32(),
+            capture_range: CAPTURE_RANGE,
+            captures: self.captures,
+            repair_status: self.repair_status,
+            repair_range: REPAIR_RANGE,
+            repaired_health: self.repaired_health,
+        }
+    }
+
+    pub(super) fn update_capture(
+        &mut self,
+        claimant: PlayerId,
+        status: CaptureStatus,
+        dt: Duration,
+    ) {
+        if self.owner == Some(claimant) {
+            self.capture_status = CaptureStatus::Secured;
+            self.capturing_player = None;
+            self.capture_elapsed = CAPTURE_TIME;
+            return;
+        }
+        self.capture_status = status;
+        if status != CaptureStatus::Capturing {
+            self.capture_elapsed = Duration::ZERO;
+            self.capturing_player = None;
+            return;
+        }
+        if self.capturing_player != Some(claimant) {
+            self.capture_elapsed = Duration::ZERO;
+            self.capturing_player = Some(claimant);
+        }
+        self.capture_elapsed = self.capture_elapsed.saturating_add(dt).min(CAPTURE_TIME);
+        if self.capture_elapsed == CAPTURE_TIME {
+            self.owner = Some(claimant);
+            self.capturing_player = None;
+            self.capture_status = CaptureStatus::Secured;
+            self.captures += 1;
+        }
+    }
+
+    pub(super) fn repair_ship(
+        &mut self,
+        ship: &mut ShipState,
+        landed: bool,
+        distance: f32,
+        dt: Duration,
+    ) {
+        self.repair_status = if self.owner.is_none() {
+            RepairStatus::NeedsCapture
+        } else if ship.dead || ship.life <= 0.0 || ship.form != ShipForm::Ship {
+            RepairStatus::VehicleUnavailable
+        } else if self.owner.map(PlayerId::index) != Some(ship.owner_id) {
+            RepairStatus::NotFriendly
+        } else if !landed {
+            RepairStatus::NeedLanding
+        } else if distance > REPAIR_RANGE {
+            RepairStatus::OutOfRange
+        } else if ship.life >= ship.life_max {
+            RepairStatus::Ready
+        } else {
+            let before = ship.life;
+            ship.life = (ship.life + ship.life_max * REPAIR_FRACTION_PER_SECOND * dt.as_secs_f32())
+                .min(ship.life_max);
+            self.repaired_health += ship.life - before;
+            if ship.life >= ship.life_max {
+                RepairStatus::Ready
+            } else {
+                RepairStatus::Repairing
+            }
+        };
+    }
+}
+
+impl SurfaceSortieState {
+    fn capture_status(&self) -> CaptureStatus {
+        let Some(snapshot) = self.spaceling_snapshot() else {
+            return CaptureStatus::Aboard;
+        };
+        let planet = &self.world.planets[self.outpost.planet];
+        if snapshot
+            .motion
+            .position
+            .distance_to(self.outpost.position(planet))
+            > CAPTURE_RANGE
+        {
+            return CaptureStatus::TooFar;
+        }
+        let Some(support) = snapshot.support.filter(|support| {
+            physics::is_planet_surface_support(support.collider, self.outpost.planet)
+        }) else {
+            return CaptureStatus::NeedSupport;
+        };
+        if snapshot.balance != SpacelingBalance::Balanced {
+            return CaptureStatus::NeedBalance;
+        }
+        let offset = support.position - snapshot.motion.position;
+        let relative = snapshot.motion.linear_velocity
+            + Vec2::new(-offset.y, offset.x) * snapshot.motion.angular_velocity
+            - support.velocity;
+        if relative.length() > CAPTURE_MAX_SPEED {
+            return CaptureStatus::NeedSettle;
+        }
+        CaptureStatus::Capturing
+    }
+
+    pub(super) fn update_outpost(&mut self, dt: Duration) {
+        let status = self.capture_status();
+        self.outpost.update_capture(self.pilot.owner, status, dt);
+        let position = self
+            .outpost
+            .position(&self.world.planets[self.outpost.planet]);
+        let landed = self.vehicle_settled();
+        let ship = &mut self.world.ships[self.pilot.vehicle.0];
+        self.outpost.repair_ship(
+            ship,
+            landed,
+            (ship.position + SHIP_PIVOT).distance_to(position),
+            dt,
+        );
+    }
+}

--- a/scenarios/spacewars/src/surface_sortie/render.rs
+++ b/scenarios/spacewars/src/surface_sortie/render.rs
@@ -4,6 +4,7 @@ use engine_common::RenderLine;
 const LIGHT: RenderColor = RenderColor::rgb(0.86, 0.93, 0.97);
 const CYAN: RenderColor = RenderColor::rgb(0.25, 0.93, 0.8);
 const ORANGE: RenderColor = RenderColor::rgb(1.0, 0.58, 0.23);
+const AMBER: RenderColor = RenderColor::rgb(1.0, 0.82, 0.25);
 
 fn camera(state: &SurfaceSortieState) -> Camera2 {
     let snapshot = state.spaceling_snapshot();
@@ -57,6 +58,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
             1.0,
         );
     }
+    draw_outpost(&mut frame, state, &observation.outpost);
     let access = observation.access_position;
     if parked {
         circle(
@@ -109,7 +111,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     }
     // Keep diagnostics legible when the parked ship crosses the HUD as the
     // planet rotates. The scene remains visible through the shallow strips.
-    for (bottom, top) in [(0.27, 0.48), (-0.48, -0.28)] {
+    for (bottom, top) in [(0.27, 0.48), (-0.49, -0.255)] {
         frame.push_primitive(
             15,
             RenderPrimitive::Polygon(RenderPolygon {
@@ -125,7 +127,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     text(
         &mut frame,
         Vec2::new(center.x, title_y),
-        "SURFACE SORTIE  /  shared-world pilot experiment",
+        "SURFACE SORTIE  /  capture an outpost, repair, depart",
         LIGHT,
         18.0,
     );
@@ -143,7 +145,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     text(
         &mut frame,
         center + Vec2::new(0.0, height * 0.31),
-        "Start / Esc: pause   R: restart   No weapons or capture in this fixture",
+        "Stand beside the amber terminal for 3s to capture.  Start / Esc: pause   R: restart",
         LIGHT,
         13.0,
     );
@@ -156,14 +158,35 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     };
     text(
         &mut frame,
-        center - Vec2::new(0.0, height * 0.32),
+        center - Vec2::new(0.0, height * 0.29),
         message,
         CYAN,
         16.0,
     );
+    let post = &observation.outpost;
+    let ownership = post.owner.map_or_else(
+        || "NEUTRAL".to_owned(),
+        |owner| format!("P{}", owner.index() + 1),
+    );
     text(
         &mut frame,
-        center - Vec2::new(0.0, height * 0.38),
+        center - Vec2::new(0.0, height * 0.348),
+        format!(
+            "OUTPOST {ownership}  |  {:.0}%  |  {}  |  {:.1}u",
+            post.capture_progress * 100.0,
+            post.capture_status.label(),
+            observation.position.distance_to(post.position)
+        ),
+        if post.owner == Some(observation.owner) {
+            CYAN
+        } else {
+            AMBER
+        },
+        14.0,
+    );
+    text(
+        &mut frame,
+        center - Vec2::new(0.0, height * 0.405),
         format!(
             "{}  |  angle {:.0}°  |  descent {:+.1}  |  sideways {:+.1}  |  feet {}/2",
             observation.landing.phase.label(),
@@ -183,14 +206,13 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     );
     text(
         &mut frame,
-        center - Vec2::new(0.0, height * 0.44),
+        center - Vec2::new(0.0, height * 0.463),
         format!(
-            "{}  |  ship {:.0}%  |  transfers {}  |  bodies {}  |  access {:.1}u",
-            observation.balance,
+            "Ship {:.0}%  |  {}  |  hatch {:.1}u  |  bodies {}",
             ship.life / ship.life_max.max(1.0) * 100.0,
-            observation.transfers,
-            observation.physical_bodies,
+            post.repair_status.label(),
             observation.position.distance_to(access),
+            observation.physical_bodies,
         ),
         ORANGE,
         15.0,
@@ -222,6 +244,29 @@ pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> Rende
             CYAN,
         );
     }
+    let outpost = &state.outpost;
+    let planet = &state.world.planets[outpost.planet];
+    let site = outpost.position(planet);
+    // Lift the symbol off the planet rim, with a leader to its exact location;
+    // the tiny ship/creature icons must remain distinguishable nearby.
+    let marker = site + outpost.up(planet) * 35.0;
+    let owner_color = outpost_color(state);
+    line(&mut map, 1, site, marker, owner_color, 1.0);
+    map.push_primitive(
+        1,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: [
+                Vec2::new(-12.0, -12.0),
+                Vec2::new(12.0, -12.0),
+                Vec2::new(12.0, 12.0),
+                Vec2::new(-12.0, 12.0),
+            ]
+            .map(|point| render_point(marker + point))
+            .to_vec(),
+            fill: Some(Fill::new(owner_color)),
+            stroke: Some(Stroke::new(LIGHT, 1.0)),
+        }),
+    );
     // The footprint follows the actual full-window camera, including resizes.
     let camera = camera(state);
     let aspect = if viewport_aspect.is_finite() && viewport_aspect > 0.0 {
@@ -284,6 +329,123 @@ pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> Rende
         );
     }
     map
+}
+
+fn outpost_color(state: &SurfaceSortieState) -> RenderColor {
+    state.outpost.owner.map_or(AMBER, |owner| {
+        render_color(state.world.players[owner.index()].color)
+    })
+}
+
+fn draw_outpost(
+    frame: &mut RenderFrame,
+    state: &SurfaceSortieState,
+    observation: &OutpostObservation,
+) {
+    let planet = &state.world.planets[state.outpost.planet];
+    let up = state.outpost.up(planet);
+    let right = Vec2::new(up.y, -up.x);
+    let base = observation.position;
+    let local = |x, y| base + right * x + up * y;
+    let owner_color = outpost_color(state);
+    // Service radius is an eligibility hint, not a docking region or force.
+    // Its underground half is occluded by the planet fill.
+    let range_color = if observation.owner.is_some() {
+        RenderColor::rgba(0.3, 0.9, 0.7, 0.35)
+    } else {
+        RenderColor::rgba(1.0, 0.82, 0.25, 0.2)
+    };
+    for segment in (0..64).step_by(2) {
+        let a = segment as f32 * std::f32::consts::TAU / 64.0;
+        let b = (segment + 1) as f32 * std::f32::consts::TAU / 64.0;
+        line(
+            frame,
+            -21,
+            base + Vec2::from_radians(a) * observation.repair_range,
+            base + Vec2::from_radians(b) * observation.repair_range,
+            range_color,
+            1.0,
+        );
+    }
+    for segment in 0..12 {
+        let a = (segment as f32 / 12.0 * 2.0 - 1.0) * observation.capture_range
+            / (planet.radius * BODY_BOUNDS_RADIUS_SCALE);
+        let b = ((segment + 1) as f32 / 12.0 * 2.0 - 1.0) * observation.capture_range
+            / (planet.radius * BODY_BOUNDS_RADIUS_SCALE);
+        let radius = planet.radius * BODY_BOUNDS_RADIUS_SCALE + 0.08;
+        line(
+            frame,
+            -5,
+            planet.position + up.rotate_radians(a) * radius,
+            planet.position + up.rotate_radians(b) * radius,
+            owner_color,
+            2.0,
+        );
+    }
+    let quad = |left, bottom, right, top, fill| {
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: [(left, bottom), (right, bottom), (right, top), (left, top)]
+                .map(|(x, y)| render_point(local(x, y)))
+                .to_vec(),
+            fill: Some(Fill::new(fill)),
+            stroke: Some(Stroke::new(LIGHT, 1.0)),
+        })
+    };
+    let half = physics::OUTPOST_TERMINAL_HALF_SIZE;
+    frame.push_primitive(
+        -4,
+        quad(
+            -half.x,
+            -0.02,
+            half.x,
+            half.y * 2.0 - 0.02,
+            RenderColor::rgb(0.2, 0.27, 0.35),
+        ),
+    );
+    frame.push_primitive(
+        -3,
+        quad(
+            -0.48,
+            0.9,
+            0.48,
+            1.8,
+            if observation.owner.is_some() {
+                CYAN
+            } else {
+                AMBER
+            },
+        ),
+    );
+    line(frame, -3, local(0.6, 1.8), local(0.6, 3.6), LIGHT, 1.5);
+    if observation.owner.is_some() {
+        frame.push_primitive(-2, quad(0.6, 2.75, 2.1, 3.6, owner_color));
+    }
+    frame.push_primitive(
+        -2,
+        quad(-1.2, 2.6, 0.25, 2.8, RenderColor::rgb(0.08, 0.1, 0.16)),
+    );
+    if observation.capture_progress > 0.0 {
+        frame.push_primitive(
+            -1,
+            quad(
+                -1.2,
+                2.6,
+                -1.2 + 1.45 * observation.capture_progress,
+                2.8,
+                owner_color,
+            ),
+        );
+    }
+    text(
+        frame,
+        local(0.0, 4.4),
+        observation.owner.map_or_else(
+            || "NEUTRAL OUTPOST".to_owned(),
+            |owner| format!("P{} OUTPOST", owner.index() + 1),
+        ),
+        owner_color,
+        12.0,
+    );
 }
 
 fn draw_spaceling(frame: &mut RenderFrame, snapshot: SpacelingSnapshot, facing: f32, phase: f32) {

--- a/scenarios/spacewars/src/surface_sortie/tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests.rs
@@ -3,6 +3,8 @@ use engine_rapier::world::{
     BodyId as PhysicsBodyId, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec,
 };
 
+mod outpost_tests;
+
 fn tick(state: &mut SurfaceSortieState, input: SurfaceSortieAction) {
     SurfaceSortieScenario::step(
         state,

--- a/scenarios/spacewars/src/surface_sortie/tests/outpost_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/outpost_tests.rs
@@ -1,0 +1,417 @@
+use super::*;
+
+fn walk_to(state: &mut SurfaceSortieState, target: impl Fn(&SurfaceSortieState) -> Vec2) {
+    for _ in 0..600 {
+        let snapshot = state.spaceling_snapshot().unwrap();
+        let delta = target(state) - snapshot.motion.position;
+        if delta.length() < 0.3 {
+            idle(state, 12);
+            return;
+        }
+        let up = (snapshot.motion.position - state.world.planets[0].position).normalized();
+        tick(
+            state,
+            SurfaceSortieAction {
+                horizontal: delta.dot(Vec2::new(up.y, -up.x)).signum(),
+                ..SurfaceSortieAction::default()
+            },
+        );
+    }
+    panic!("could not walk to target: {:?}", state.observation());
+}
+
+fn terminal_approach(state: &SurfaceSortieState) -> Vec2 {
+    let planet = &state.world.planets[state.outpost.planet];
+    let up = state
+        .outpost
+        .up(planet)
+        .rotate_radians(2.0 / (planet.radius * BODY_BOUNDS_RADIUS_SCALE));
+    planet.position
+        + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + SurfaceSortieState::spec().half_height())
+}
+
+fn at_terminal() -> SurfaceSortieState {
+    let mut state = parked();
+    disembark(&mut state);
+    walk_to(&mut state, terminal_approach);
+    assert_eq!(
+        state.observation().outpost.capture_status,
+        CaptureStatus::Capturing,
+        "{:?}",
+        state.observation()
+    );
+    state
+}
+
+fn capture(state: &mut SurfaceSortieState) {
+    for _ in 0..200 {
+        idle(state, 1);
+        if state.outpost.owner == Some(state.pilot.owner) {
+            return;
+        }
+    }
+    panic!("capture did not complete: {:?}", state.observation());
+}
+
+#[test]
+fn outpost_capture_and_repair_replay_identically_and_do_not_advance_without_steps() {
+    let mut a = SurfaceSortieScenario::init((), 7);
+    let mut b = SurfaceSortieScenario::init((), 7);
+    for frame in 0..650 {
+        let observation = a.observation();
+        let input = SurfaceSortieAction {
+            interact_held: frame == 60,
+            horizontal: if frame > 120
+                && observation
+                    .position
+                    .distance_to(observation.outpost.position)
+                    > 2.35
+            {
+                1.0
+            } else {
+                0.0
+            },
+            ..SurfaceSortieAction::default()
+        };
+        tick(&mut a, input);
+        tick(&mut b, input);
+        assert_eq!(a.observation(), b.observation(), "tick {frame}");
+    }
+    assert_eq!(a.outpost.owner, Some(a.pilot.owner));
+    assert!(a.observation().outpost.repaired_health > 0.0);
+    let before = a.observation();
+    for _ in 0..10 {
+        let _ = SurfaceSortieScenario::render_frame(&a);
+        let _ = SurfaceSortieScenario::minimap_frame(&a, 16.0 / 9.0);
+        let _ = SurfaceSortieScenario::observe(&a);
+        SurfaceSortieScenario::step(&mut a, &[], Duration::ZERO);
+    }
+    assert_eq!(a.observation(), before);
+    let fresh = SurfaceSortieScenario::init((), 7).observation();
+    assert_eq!(fresh.outpost.owner, None);
+    assert_eq!(fresh.outpost.capture_progress, 0.0);
+    assert_eq!(fresh.outpost.repaired_health, 0.0);
+    assert_eq!(fresh.ship_health, 75.0);
+}
+
+#[test]
+fn outpost_round_trip_captures_repairs_and_departs_using_only_player_controls() {
+    let mut state = parked();
+    let initial = state.observation();
+    assert_eq!(initial.ship_health, state.world.ships[0].life_max * 0.75);
+    idle(&mut state, 360);
+    assert_eq!(state.outpost.owner, None, "landing alone cannot capture");
+    assert_eq!(state.world.ships[0].life, initial.ship_health);
+    disembark(&mut state);
+    assert_eq!(state.outpost.owner, None, "must walk away from the hatch");
+    walk_to(&mut state, terminal_approach);
+    idle(&mut state, 60);
+    let partial = state.observation().outpost;
+    assert!(partial.capture_progress > 0.2 && partial.capture_progress < 1.0);
+    assert_eq!(partial.owner, None);
+    assert_eq!(partial.repair_status, RepairStatus::NeedsCapture);
+    capture(&mut state);
+    assert!(state.vehicle_settled());
+    assert_eq!(state.observation().outpost.captures, 1);
+    assert_eq!(
+        state.world.planets[0].owner_id, None,
+        "outpost ownership is not planet ownership"
+    );
+    assert!(state.world.spaceport_contacts.is_empty());
+    assert_eq!(
+        state.observation().physical_bodies,
+        initial.physical_bodies + 1
+    );
+    for _ in 0..360 {
+        let before = state.world.ships[0].life;
+        idle(&mut state, 1);
+        let after = state.world.ships[0].life;
+        assert!(
+            after >= before && after - before <= state.world.ships[0].life_max * 0.05 / 60.0 + 1e-5
+        );
+    }
+    assert_eq!(state.world.ships[0].life, state.world.ships[0].life_max);
+    let initial_damage = state.world.ships[0].life_max - initial.ship_health;
+    assert!((state.observation().outpost.repaired_health - initial_damage).abs() < 1e-3);
+    assert_eq!(
+        state.observation().outpost.repair_status,
+        RepairStatus::Ready
+    );
+    walk_to(&mut state, |s| {
+        s.access_position() + s.access_up() * SurfaceSortieState::spec().half_height()
+    });
+    interact(&mut state);
+    assert_eq!(
+        state.last_transfer,
+        TransferResult::Boarded,
+        "{:?}",
+        state.observation()
+    );
+    assert_eq!(state.observation().physical_bodies, initial.physical_bodies);
+    assert_eq!(state.observation().spaceling, initial.spaceling);
+    assert_eq!(state.observation().vehicle, initial.vehicle);
+    idle(&mut state, 1); // Neutral transfer handoff.
+    state.world.ships[0].life = 60.0;
+    for _ in 0..30 {
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                primary_held: true,
+                ..SurfaceSortieAction::default()
+            },
+        );
+        assert_eq!(state.world.ships[0].life, 60.0, "no repair once taking off");
+        assert_eq!(
+            state.observation().outpost.repair_status,
+            RepairStatus::NeedLanding
+        );
+    }
+    assert!(state.landing.altitude > 1.0);
+    assert_eq!(state.observation().outpost.owner, Some(initial.owner));
+}
+
+#[test]
+fn interrupted_outpost_capture_resets_when_walking_away_jumping_or_knocked_down() {
+    for interruption in 0..3 {
+        let mut state = at_terminal();
+        idle(&mut state, 60);
+        assert!(state.observation().outpost.capture_progress > 0.2);
+        match interruption {
+            0 => {
+                for _ in 0..40 {
+                    tick(
+                        &mut state,
+                        SurfaceSortieAction {
+                            horizontal: -1.0,
+                            ..SurfaceSortieAction::default()
+                        },
+                    );
+                }
+                assert_eq!(
+                    state.observation().outpost.capture_status,
+                    CaptureStatus::TooFar
+                );
+            }
+            1 => {
+                tick(
+                    &mut state,
+                    SurfaceSortieAction {
+                        primary_held: true,
+                        ..SurfaceSortieAction::default()
+                    },
+                );
+                assert!(!state.spaceling_snapshot().unwrap().grounded());
+            }
+            _ => {
+                let snapshot = state.spaceling_snapshot().unwrap();
+                let body = state.pilot.body.as_ref().unwrap().body();
+                state.world.physics.world.set_velocity(
+                    body,
+                    snapshot.motion.linear_velocity,
+                    10.0,
+                    true,
+                );
+                idle(&mut state, 1);
+                assert_eq!(
+                    state.spaceling_snapshot().unwrap().balance,
+                    SpacelingBalance::KnockedDown
+                );
+            }
+        }
+        let outpost = state.observation().outpost;
+        assert_eq!(outpost.capture_progress, 0.0);
+        assert_eq!(outpost.capturing_player, None);
+        assert_eq!(outpost.owner, None);
+        assert_eq!(outpost.repaired_health, 0.0);
+    }
+}
+
+#[test]
+fn unrelated_physical_support_near_the_terminal_does_not_capture() {
+    let mut state = parked();
+    state.world.planets[0].wrapper_omega = 0.0;
+    let planet = state.world.planets[0];
+    let position = terminal_approach(&state);
+    let up = (position - planet.position).normalized();
+    let platform = PhysicsId::new(45_123);
+    let body_id = PhysicsBodyId::new(platform, BodyRole::PRIMARY);
+    let shape = ColliderSpec::cuboid(
+        ColliderId::new(platform, ColliderRole::PRIMARY, 0),
+        0.7,
+        0.2,
+    );
+    assert!(state.world.physics.world.insert_body(
+        body_id,
+        BodySpec {
+            kind: engine_rapier::world::BodyKind::Fixed,
+            position: position - up * 0.4,
+            angle: rotation_for_direction(up),
+            ..BodySpec::default()
+        },
+        &[shape]
+    ));
+    // Construct a supported actor on an unrelated platform inside the capture
+    // radius. This isolates the surface-identity gate from the walk-up test.
+    let spec = SurfaceSortieState::spec();
+    state.pilot.body = SpacelingAssembly::insert(
+        &mut state.world.physics.world,
+        PILOT_PHYSICS_ID,
+        position + up * 0.75,
+        rotation_for_direction(up),
+        spec,
+    );
+    assert!(state.pilot.body.is_some());
+    idle(&mut state, 240);
+    assert!(state.spaceling_snapshot().unwrap().grounded());
+    assert_eq!(
+        state.observation().outpost.capture_status,
+        CaptureStatus::NeedSupport,
+        "{:?}",
+        state.observation()
+    );
+    assert_eq!(state.outpost.owner, None);
+    state.world.physics.world.remove_entity(platform);
+    idle(&mut state, 300);
+    assert_eq!(
+        state.outpost.owner,
+        Some(state.pilot.owner),
+        "actual planet support permits capture"
+    );
+}
+
+#[test]
+fn outpost_terminal_is_solid_and_rotates_with_its_planet_without_an_extra_body() {
+    let mut state = parked();
+    let bodies = state.world.physics.world.body_count();
+    let colliders = state.world.physics.world.collider_count();
+    let terminal_center = |s: &SurfaceSortieState| {
+        let planet = &s.world.planets[0];
+        s.outpost.position(planet) + s.outpost.up(planet) * physics::OUTPOST_TERMINAL_HALF_SIZE.y
+    };
+    let original = terminal_center(&state);
+    let groups = SurfaceSortieState::spec().collision_groups;
+    assert!(
+        !state
+            .world
+            .physics
+            .world
+            .capsule_is_clear(original, 0.0, 0.1, 0.1, groups)
+    );
+    idle(&mut state, 600);
+    assert!(terminal_center(&state).distance_to(original) > 5.0);
+    assert!(!state.world.physics.world.capsule_is_clear(
+        terminal_center(&state),
+        0.0,
+        0.1,
+        0.1,
+        groups
+    ));
+    assert!(
+        state
+            .world
+            .physics
+            .world
+            .capsule_is_clear(original, 0.0, 0.1, 0.1, groups)
+    );
+    assert_eq!(state.world.physics.world.body_count(), bodies);
+    assert_eq!(state.world.physics.world.collider_count(), colliders);
+}
+
+#[test]
+fn outpost_repair_policy_requires_friendly_landed_in_range_and_live_ship() {
+    let mut state = parked();
+    let initial = state.world.ships[0].clone();
+    let post = &mut state.outpost;
+    let mut ship = initial.clone();
+    post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
+    assert_eq!(
+        post.observation(&state.world.planets[0]).repair_status,
+        RepairStatus::NeedsCapture
+    );
+    assert_eq!(ship.life, initial.life);
+    post.owner = Some(PlayerId::PLAYER_2);
+    post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
+    assert_eq!(
+        post.observation(&state.world.planets[0]).repair_status,
+        RepairStatus::NotFriendly
+    );
+    post.owner = Some(PlayerId::PLAYER_1);
+    for (landed, distance, expected) in [
+        (false, 0.0, RepairStatus::NeedLanding),
+        (true, 25.0, RepairStatus::OutOfRange),
+    ] {
+        post.repair_ship(&mut ship, landed, distance, Duration::from_secs(1));
+        assert_eq!(
+            post.observation(&state.world.planets[0]).repair_status,
+            expected
+        );
+        assert_eq!(ship.life, initial.life);
+    }
+    for unavailable in 0..3 {
+        let mut ship = initial.clone();
+        match unavailable {
+            0 => ship.dead = true,
+            1 => ship.form = ShipForm::EscapePod,
+            _ => ship.life = 0.0,
+        }
+        let before = ship.life;
+        post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
+        assert_eq!(
+            post.observation(&state.world.planets[0]).repair_status,
+            RepairStatus::VehicleUnavailable
+        );
+        assert_eq!(ship.life, before);
+    }
+    post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
+    assert_eq!(ship.life, initial.life + initial.life_max * 0.05);
+    ship.life = ship.life_max - 0.02;
+    post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
+    assert_eq!(ship.life, ship.life_max);
+    let repaired = post.observation(&state.world.planets[0]).repaired_health;
+    post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(10));
+    assert_eq!(
+        post.observation(&state.world.planets[0]).repaired_health,
+        repaired
+    );
+    assert_eq!(
+        post.observation(&state.world.planets[0]).repair_status,
+        RepairStatus::Ready
+    );
+}
+
+#[test]
+fn outpost_capture_uses_elapsed_time_and_never_shares_partial_progress_between_players() {
+    let mut state = parked();
+    let post = &mut state.outpost;
+    post.update_capture(
+        PlayerId::PLAYER_1,
+        CaptureStatus::Capturing,
+        Duration::from_secs(2),
+    );
+    assert_eq!(post.owner, None);
+    post.update_capture(
+        PlayerId::PLAYER_2,
+        CaptureStatus::Capturing,
+        Duration::from_secs(2),
+    );
+    assert_eq!(post.owner, None);
+    post.update_capture(
+        PlayerId::PLAYER_2,
+        CaptureStatus::Capturing,
+        Duration::from_secs(1),
+    );
+    assert_eq!(post.owner, Some(PlayerId::PLAYER_2));
+    post.update_capture(
+        PlayerId::PLAYER_2,
+        CaptureStatus::Capturing,
+        Duration::from_secs(10),
+    );
+    assert_eq!(post.observation(&state.world.planets[0]).captures, 1);
+    post.update_capture(
+        PlayerId::PLAYER_1,
+        CaptureStatus::Capturing,
+        Duration::from_secs(3),
+    );
+    assert_eq!(post.owner, Some(PlayerId::PLAYER_1));
+    assert_eq!(post.observation(&state.world.planets[0]).captures, 2);
+}


### PR DESCRIPTION
## Summary

Follow-up to #44: give the opt-in Surface Sortie fixture a complete on-foot objective and a reason to return to the ship.

- Start the ship at 75% health. Disembark, walk to the amber terminal, capture it, repair the nearby landed ship, then reboard and take off.
- Capture requires three uninterrupted seconds of balanced, slow movement with actual support from the terminal's planet or the terminal itself. Leaving, jumping, knockdown, or excessive movement resets partial progress; landing, hovering, and unrelated platforms cannot capture it.
- Show capture eligibility/progress in the HUD, an owner-colored physical flag, an ownership marker on the minimap, and a visual repair-service range.
- Repair a friendly, live, full ship at 5% of maximum health per second while physically landed within 24 world units. Preserve the existing ship and pilot identities; boarding does not heal, and this service cannot rebuild pods or resurrect destroyed ships.
- Add version-3 scenario observations for outpost identity, ownership, capture state, repair eligibility, and cumulative healing.

## Design and scope

The terminal adds one solid collider to the existing rotating planet body, with no additional physics body. Capture and repair remain scenario-owned policies consuming the completed shared physics/support/landing state.

Outpost ownership is deliberately separate from planet ownership. Capturing a pre-existing neutral outpost is one testbed interaction, **not** the required future path for claiming or developing planets. Documentation keeps planet claims, infrastructure ownership, and operational services distinct.

Normal Spacewars gameplay, bots, and the landing implementation merged in #44 are unchanged. Moving/orbiting planets, resources, contested capture, destructible infrastructure, and pilot rescue/death policy remain separate work.

Related to #41; this does not close the broader integration work.

## Validation

- Passed on Rust 1.89 after rebasing onto merged main:
  - `cargo fmt --all -- --check`
  - `cargo test --locked --workspace --all-targets --quiet`
- Added seven headless outpost regressions covering the full controls-driven round trip, interrupted capture, support identity, collider lifecycle/rotation, repair gates/rate/clamping, claimant changes, deterministic replay, restart, and no progress without simulation steps.
- Added client rendering coverage for capture feedback and the actual owner-colored flag in landscape and portrait layouts; updated the real-window fixture's HUD/outpost checks.
- The same source tree previously passed the Surface Sortie real-window launcher/pause/restart/both-renderer workflow and the pinned `navigation-v1` (6 episodes) and `strategy-v1` (12 episodes) baseline checks.
- Deployed to the Raspberry Pi and manually playtested with a physical gamepad; user accepted the gameplay on 2026-09-06. The clean rebase changed commit ancestry only, not the tested source tree.

The separate NES process-wide allocation-test flake discussed on #44 is not modified or worked around here; the full local workspace run passed.
