### PR TITLE
Add orbital Surface Sortie motion fixtures and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The local launcher currently hosts seven playable scenarios:
 - **Surface Sortie** — an opt-in Spacewars pilot/vehicle experiment: land
   rear-first with flight assistance, walk to capture an outpost, repair your
   nearby landed ship, and reboard to depart. Includes a translucent minimap,
-  ownership flag, and landing/capture diagnostics.
+  ownership flag, and landing/capture diagnostics. Choose **surface-sortie-orbit**
+  for the same loop on a moving, spinning planet, with drift/support-loss telemetry.
   See [Surface Sortie](docs/surface-sortie.md) for controls and scope.
 - **Falling** — the pinned MIT-licensed NES homebrew running on this repository's
   Rust-native mapper-0 emulator, with pixel-perfect native video, exact-rational
@@ -92,6 +93,7 @@ cargo run -p engine-client -- --scenario clock
 cargo run -p engine-client -- --scenario rover-lab
 cargo run -p engine-client -- --scenario spaceling-lab
 cargo run -p engine-client -- --scenario surface-sortie
+cargo run -p engine-client -- --scenario surface-sortie-orbit
 cargo run -p engine-client -- --scenario spacewars
 cargo run -p engine-client -- --scenario falling
 ```

--- a/crates/engine-client/src/client_scenarios/mod.rs
+++ b/crates/engine-client/src/client_scenarios/mod.rs
@@ -374,6 +374,7 @@ static SCENARIOS: &[ScenarioRegistration] = &[
     spaceling_lab::REGISTRATION,
     spacewars::REGISTRATION,
     surface_sortie::REGISTRATION,
+    surface_sortie::ORBIT_REGISTRATION,
 ];
 
 pub fn registrations() -> &'static [ScenarioRegistration] {
@@ -440,7 +441,8 @@ mod tests {
                 "rover-lab",
                 "spaceling-lab",
                 "spacewars",
-                "surface-sortie"
+                "surface-sortie",
+                "surface-sortie-orbit"
             ]
         );
     }

--- a/crates/engine-client/src/client_scenarios/surface_sortie.rs
+++ b/crates/engine-client/src/client_scenarios/surface_sortie.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
 use scenario_spacewars::surface_sortie::{
-    SurfaceSortieAction, SurfaceSortieScenario, SurfaceSortieState,
+    SurfaceMotionPreset, SurfaceSortieAction, SurfaceSortieScenario, SurfaceSortieState,
 };
 
 use super::{
@@ -30,6 +30,15 @@ pub(super) const REGISTRATION: ScenarioRegistration = ScenarioRegistration {
     create,
 };
 
+/// Another selectable preset of the same scenario, input mapping and renderer.
+/// Keeping a distinct registry ID makes the choice persist and remain reachable
+/// through ordinary keyboard/gamepad launcher navigation without new buttons.
+pub(super) const ORBIT_REGISTRATION: ScenarioRegistration = ScenarioRegistration {
+    id: "surface-sortie-orbit",
+    create: create_orbit,
+    ..REGISTRATION
+};
+
 struct SurfaceSortieClientScenario {
     state: SurfaceSortieState,
 }
@@ -42,13 +51,28 @@ fn create(
     _asset: &ScenarioAsset,
 ) -> Result<Box<dyn ClientScenario>, ScenarioCreateError> {
     Ok(Box::new(SurfaceSortieClientScenario {
-        state: SurfaceSortieScenario::init((), seed),
+        state: SurfaceSortieScenario::init(SurfaceMotionPreset::default(), seed),
+    }))
+}
+
+fn create_orbit(
+    seed: u64,
+    _settings: &Settings,
+    _viewport: Viewport,
+    _mode: ScenarioStartMode,
+    _asset: &ScenarioAsset,
+) -> Result<Box<dyn ClientScenario>, ScenarioCreateError> {
+    Ok(Box::new(SurfaceSortieClientScenario {
+        state: SurfaceSortieScenario::init(SurfaceMotionPreset::Orbit, seed),
     }))
 }
 
 impl ClientScenario for SurfaceSortieClientScenario {
     fn registration(&self) -> &'static ScenarioRegistration {
-        &REGISTRATION
+        match self.state.motion_preset() {
+            SurfaceMotionPreset::Orbit => &ORBIT_REGISTRATION,
+            _ => &REGISTRATION,
+        }
     }
     fn tick_model(&self) -> TickModel {
         SurfaceSortieScenario::tick_model()
@@ -96,7 +120,7 @@ mod tests {
     #[test]
     fn keyboard_and_nes_pad_produce_the_same_context_neutral_intent() {
         let scenario = SurfaceSortieClientScenario {
-            state: SurfaceSortieScenario::init((), 0),
+            state: SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 0),
         };
         let mut keyboard = ClientInput::default();
         for key in [
@@ -133,150 +157,154 @@ mod tests {
 
     #[test]
     fn outpost_capture_progress_and_owner_flag_render_in_both_backends() {
-        let mut scenario = SurfaceSortieClientScenario {
-            state: SurfaceSortieScenario::init((), 0),
-        };
-        let dt = Duration::from_secs_f64(1.0 / 60.0);
-        for frame in 0..120 {
-            scenario.step(
-                &[SurfaceSortieAction {
-                    interact_held: frame == 60,
-                    ..SurfaceSortieAction::default()
-                }
-                .encode()],
-                dt,
-            );
-        }
-        for _ in 0..600 {
-            let observation = scenario.state.observation();
-            if observation
-                .position
-                .distance_to(observation.outpost.position)
-                < 2.35
-            {
-                break;
-            }
-            scenario.step(
-                &[SurfaceSortieAction {
-                    horizontal: 1.0,
-                    ..SurfaceSortieAction::default()
-                }
-                .encode()],
-                dt,
-            );
-        }
-        for _ in 0..60 {
-            scenario.step(&[SurfaceSortieAction::default().encode()], dt);
-        }
-        let partial = scenario.state.observation().outpost;
-        assert!(partial.capture_progress > 0.0 && partial.capture_progress < 1.0);
-        let viewport = Viewport::new(1280.0, 720.0);
-        check_render(&scenario, viewport, "on-foot-capturing");
-        for _ in 0..180 {
-            scenario.step(&[SurfaceSortieAction::default().encode()], dt);
-        }
-        let observation = scenario.state.observation();
-        assert_eq!(observation.outpost.owner, Some(observation.owner));
-        assert!(observation.outpost.repaired_health > 0.0);
-        for viewport in [viewport, Viewport::new(1280.0, 1400.0)] {
-            let frames = scenario.render_frames(RenderBackend::Vector, viewport);
-            assert_eq!(
-                frames,
-                scenario.render_frames(RenderBackend::Raster, viewport)
-            );
-            let overlay =
-                crate::render::raster_text_overlay(&frames, viewport, scenario.frame_layout());
-            assert!(
-                overlay
-                    .iter()
-                    .any(|primitive| primitive.text.starts_with("OUTPOST P1"))
-            );
-            assert!(
-                overlay
-                    .iter()
-                    .any(|primitive| primitive.text == "P1 OUTPOST")
-            );
-            let name = if viewport.height > viewport.width {
-                "on-foot-secured-portrait"
-            } else {
-                "on-foot-secured"
+        for preset in [SurfaceMotionPreset::Stationary, SurfaceMotionPreset::Orbit] {
+            let mut scenario = SurfaceSortieClientScenario {
+                state: SurfaceSortieScenario::init(preset, 0),
             };
-            check_render(&scenario, viewport, name);
-            // Check the actual owner-colored flag, not just a text/model entry.
-            let up = observation.outpost.surface_normal;
-            let flag = observation.outpost.position
-                + up * 3.15
-                + engine_core::Vec2::new(up.y, -up.x) * 1.3;
-            let projected = frames[0].camera.world_to_viewport(
-                engine_common::RenderPoint::new(flag.x, flag.y),
-                viewport.aspect_ratio(),
-            );
-            let image = crate::raster::RasterRenderer::new().image_from_frames_with_layout(
-                &frames,
-                viewport,
-                scenario.frame_layout(),
-                crate::raster::RasterOptions::default(),
-            );
-            let pixels = image.to_rgb8().unwrap();
-            let x = (projected.x * pixels.width() as f32) as usize;
-            let y = (projected.y * pixels.height() as f32) as usize;
-            let pixel = pixels.as_slice()[y * pixels.width() as usize + x];
-            assert!(
-                pixel.r > 200 && pixel.g < 80 && pixel.b < 80,
-                "missing owner flag: {pixel:?}"
-            );
+            let dt = Duration::from_secs_f64(1.0 / 60.0);
+            for frame in 0..120 {
+                scenario.step(
+                    &[SurfaceSortieAction {
+                        interact_held: frame == 60,
+                        ..SurfaceSortieAction::default()
+                    }
+                    .encode()],
+                    dt,
+                );
+            }
+            for _ in 0..600 {
+                let observation = scenario.state.observation();
+                if observation
+                    .position
+                    .distance_to(observation.outpost.position)
+                    < 2.35
+                {
+                    break;
+                }
+                scenario.step(
+                    &[SurfaceSortieAction {
+                        horizontal: 1.0,
+                        ..SurfaceSortieAction::default()
+                    }
+                    .encode()],
+                    dt,
+                );
+            }
+            for _ in 0..60 {
+                scenario.step(&[SurfaceSortieAction::default().encode()], dt);
+            }
+            let partial = scenario.state.observation().outpost;
+            assert!(partial.capture_progress > 0.0 && partial.capture_progress < 1.0);
+            let viewport = Viewport::new(1280.0, 720.0);
+            check_render(&scenario, viewport, "on-foot-capturing");
+            for _ in 0..180 {
+                scenario.step(&[SurfaceSortieAction::default().encode()], dt);
+            }
+            let observation = scenario.state.observation();
+            assert_eq!(observation.outpost.owner, Some(observation.owner));
+            assert!(observation.outpost.repaired_health > 0.0);
+            for viewport in [viewport, Viewport::new(1280.0, 1400.0)] {
+                let frames = scenario.render_frames(RenderBackend::Vector, viewport);
+                assert_eq!(
+                    frames,
+                    scenario.render_frames(RenderBackend::Raster, viewport)
+                );
+                let overlay =
+                    crate::render::raster_text_overlay(&frames, viewport, scenario.frame_layout());
+                assert!(
+                    overlay
+                        .iter()
+                        .any(|primitive| primitive.text.starts_with("OUTPOST P1"))
+                );
+                assert!(
+                    overlay
+                        .iter()
+                        .any(|primitive| primitive.text == "P1 OUTPOST")
+                );
+                let name = if viewport.height > viewport.width {
+                    "on-foot-secured-portrait"
+                } else {
+                    "on-foot-secured"
+                };
+                check_render(&scenario, viewport, name);
+                // Check the actual owner-colored flag, not just a text/model entry.
+                let up = observation.outpost.surface_normal;
+                let flag = observation.outpost.position
+                    + up * 3.15
+                    + engine_core::Vec2::new(up.y, -up.x) * 1.3;
+                let projected = frames[0].camera.world_to_viewport(
+                    engine_common::RenderPoint::new(flag.x, flag.y),
+                    viewport.aspect_ratio(),
+                );
+                let image = crate::raster::RasterRenderer::new().image_from_frames_with_layout(
+                    &frames,
+                    viewport,
+                    scenario.frame_layout(),
+                    crate::raster::RasterOptions::default(),
+                );
+                let pixels = image.to_rgb8().unwrap();
+                let x = (projected.x * pixels.width() as f32) as usize;
+                let y = (projected.y * pixels.height() as f32) as usize;
+                let pixel = pixels.as_slice()[y * pixels.width() as usize + x];
+                assert!(
+                    pixel.r > 200 && pixel.g < 80 && pixel.b < 80,
+                    "missing owner flag: {pixel:?}"
+                );
+            }
         }
     }
 
     #[test]
     fn registered_fixture_renders_and_restarts_in_both_backends() {
-        let viewport = Viewport::new(1280.0, 720.0);
-        let mut scenario = REGISTRATION
-            .create(0, &Settings::default(), viewport, ScenarioStartMode::Normal)
-            .unwrap();
-        let initial = scenario.render_frames(RenderBackend::Vector, viewport);
-        for tick in 0..90 {
-            scenario.step(
-                &[SurfaceSortieAction {
-                    interact_held: tick == 60,
-                    ..SurfaceSortieAction::default()
+        for registration in [&REGISTRATION, &ORBIT_REGISTRATION] {
+            let viewport = Viewport::new(1280.0, 720.0);
+            let mut scenario = registration
+                .create(0, &Settings::default(), viewport, ScenarioStartMode::Normal)
+                .unwrap();
+            let initial = scenario.render_frames(RenderBackend::Vector, viewport);
+            for tick in 0..90 {
+                scenario.step(
+                    &[SurfaceSortieAction {
+                        interact_held: tick == 60,
+                        ..SurfaceSortieAction::default()
+                    }
+                    .encode()],
+                    Duration::from_secs_f64(1.0 / 60.0),
+                );
+                if tick == 59 {
+                    check_render(&*scenario, viewport, "aboard");
+                    check_render(&*scenario, Viewport::new(1280.0, 1400.0), "aboard-portrait");
                 }
-                .encode()],
-                Duration::from_secs_f64(1.0 / 60.0),
-            );
-            if tick == 59 {
-                check_render(&*scenario, viewport, "aboard");
-                check_render(&*scenario, Viewport::new(1280.0, 1400.0), "aboard-portrait");
             }
+            let frames = scenario.render_frames(RenderBackend::Vector, viewport);
+            assert_eq!(
+                frames,
+                scenario.render_frames(RenderBackend::Raster, viewport)
+            );
+            assert_ne!(frames, initial);
+            check_render(&*scenario, viewport, "on-foot");
+            check_render(
+                &*scenario,
+                Viewport::new(1280.0, 1400.0),
+                "on-foot-portrait",
+            );
+            assert!(matches!(
+                scenario
+                    .as_any()
+                    .downcast_ref::<SurfaceSortieClientScenario>()
+                    .unwrap()
+                    .state
+                    .location(),
+                scenario_spacewars::surface_sortie::PilotLocation::OnFoot
+            ));
+            let fresh = registration
+                .create(0, &Settings::default(), viewport, ScenarioStartMode::Normal)
+                .unwrap();
+            assert_eq!(
+                initial,
+                fresh.render_frames(RenderBackend::Vector, viewport)
+            );
         }
-        let frames = scenario.render_frames(RenderBackend::Vector, viewport);
-        assert_eq!(
-            frames,
-            scenario.render_frames(RenderBackend::Raster, viewport)
-        );
-        assert_ne!(frames, initial);
-        check_render(&*scenario, viewport, "on-foot");
-        check_render(
-            &*scenario,
-            Viewport::new(1280.0, 1400.0),
-            "on-foot-portrait",
-        );
-        assert!(matches!(
-            scenario
-                .as_any()
-                .downcast_ref::<SurfaceSortieClientScenario>()
-                .unwrap()
-                .state
-                .location(),
-            scenario_spacewars::surface_sortie::PilotLocation::OnFoot
-        ));
-        let fresh = REGISTRATION
-            .create(0, &Settings::default(), viewport, ScenarioStartMode::Normal)
-            .unwrap();
-        assert_eq!(
-            initial,
-            fresh.render_frames(RenderBackend::Vector, viewport)
-        );
     }
 
     fn check_render(scenario: &dyn ClientScenario, viewport: Viewport, name: &str) {
@@ -352,7 +380,10 @@ mod tests {
                     .join(directory)
             };
             std::fs::create_dir_all(&directory).unwrap();
-            let file = std::fs::File::create(directory.join(format!("{name}.png"))).unwrap();
+            let file = std::fs::File::create(
+                directory.join(format!("{name}-{}.png", scenario.registration().id)),
+            )
+            .unwrap();
             let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
             encoder.set_color(png::ColorType::Rgb);
             encoder.set_depth(png::BitDepth::Eight);

--- a/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
+++ b/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
@@ -20,6 +20,16 @@ fn surface_sortie_launch_pause_restart_and_both_renderers() {
     );
 }
 
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn surface_sortie_orbit_launch_pause_restart_and_both_renderers() {
+    lab_lifecycle(
+        "surface-sortie-orbit",
+        "surface-sortie-orbit-lifecycle",
+        assert_raster_sortie_visible,
+    );
+}
+
 fn lab_lifecycle(scenario: &str, test_name: &'static str, assert_visible: fn(&Path)) {
     run_functional_test(test_name, |harness| {
         let ready = harness.wait_until_ready();

--- a/crates/engine-rapier/src/world.rs
+++ b/crates/engine-rapier/src/world.rs
@@ -358,8 +358,10 @@ impl Default for PhysicsWorldConfig {
 /// Authoritative motion read directly from one Rapier rigid body.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BodyMotion {
+    /// Body-frame origin in world coordinates; not necessarily the center of mass.
     pub position: Vec2,
     pub angle: f32,
+    /// Center-of-mass velocity. Use `PhysicsWorld::velocity_at_point` elsewhere.
     pub linear_velocity: Vec2,
     pub angular_velocity: f32,
 }
@@ -775,6 +777,17 @@ impl PhysicsWorld {
     pub fn motion(&self, id: BodyId) -> Option<BodyMotion> {
         let handle = self.body_handle(id)?;
         self.raw.bodies.get(handle).map(body_motion)
+    }
+
+    /// Velocity at a world-space point, accounting for an off-center mass.
+    /// `BodyMotion::position` is the body origin, whereas its linear velocity
+    /// is Rapier's center-of-mass velocity. They need not coincide.
+    pub fn velocity_at_point(&self, id: BodyId, point: Vec2) -> Option<Vec2> {
+        if !finite_vec2(point) {
+            return None;
+        }
+        let body = self.raw.bodies.get(self.body_handle(id)?)?;
+        Some(from_rapier(body.velocity_at_point(to_rapier(point))))
     }
 
     pub fn motions(&self) -> impl ExactSizeIterator<Item = BodyMotionRecord> + '_ {
@@ -1692,6 +1705,46 @@ mod tests {
             before.position,
             true,
         ));
+    }
+
+    #[test]
+    fn point_velocity_accounts_for_offset_mass_and_rejects_invalid_queries() {
+        let mut world = PhysicsWorld::new(PhysicsWorldConfig::default());
+        let (entity, body, collider_id) = ball_ids(1);
+        let mut collider = ColliderSpec::ball(collider_id, 1.0);
+        collider.local_position = Vec2::new(2.0, 0.0);
+        let origin = Vec2::new(10.0, 20.0);
+        assert!(world.insert_body(
+            body,
+            BodySpec {
+                position: origin,
+                ..BodySpec::default()
+            },
+            &[collider]
+        ));
+        // Populate mass properties through the normal lifecycle, with no motion.
+        world.step(1.0 / 60.0);
+        assert!(world.set_velocity(body, Vec2::new(3.0, 4.0), 2.0, true));
+        let before = world.motion(body).unwrap();
+        assert_eq!(
+            world.velocity_at_point(body, origin),
+            Some(Vec2::new(3.0, 0.0))
+        );
+        assert_eq!(
+            world.velocity_at_point(body, origin + Vec2::X * 2.0),
+            Some(Vec2::new(3.0, 4.0))
+        );
+        assert_eq!(
+            world.velocity_at_point(body, Vec2::new(f32::NAN, 0.0)),
+            None
+        );
+        assert_eq!(
+            world.motion(body),
+            Some(before),
+            "queries never change state"
+        );
+        world.remove_entity(entity);
+        assert_eq!(world.velocity_at_point(body, origin), None);
     }
 
     #[test]

--- a/docs/design/physics-architecture.md
+++ b/docs/design/physics-architecture.md
@@ -171,6 +171,21 @@ world's Rapier mass/inertia binding. Recovery does not introduce another body,
 pose snapping, free-space damping, or a terrain scan. See the
 [lab's balance model](../spaceling-lab.md#balance-and-recovery).
 
+Surface Sortie's stationary and orbital presets use that same controller and
+canonical world alongside a dynamic ship with physical landing feet. Terrain
+targets are scheduled once; pre-step gravity/controllers read the completed
+physics frame, and post-step landing/services consume completed contacts.
+`BodyMotion.position` is the body origin but `linear_velocity` is the center-of-mass
+velocity. Use the allocation-free `PhysicsWorld::velocity_at_point` when comparing
+motion at a hatch, foot, or frame origin; an asymmetric collider set can offset
+the center of mass. Never substitute the next kinematic target or an analytic
+endpoint derivative for the contacts' completed motion.
+
+The orbital sortie matches its sun's gravity to the prescribed planet path at
+the center; it adds no actor transport or compensating field. This controlled
+fixture does not establish support on every ordinary scripted orbit, whose
+rate and mass may be inconsistent. See the [motion boundary](../surface-sortie.md#moving-planet-evidence).
+
 Spacewars' implemented mapping is:
 
 - planets and orbiting spaceports: fixed or kinematic bodies;

--- a/docs/design/reboot-rust-slint.md
+++ b/docs/design/reboot-rust-slint.md
@@ -592,7 +592,7 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - M27b: ✅ Add collider-checked exit, surface-relative velocity inheritance, nearby supported boarding, control-context neutral gating, and visible feedback. The initial elevated-berth round trip passed manual playtesting.
 - M27c: ✅ Replace that temporary berth in the fixture with physical rear landing feet, nose-outward bounded flight assistance, contact-based settling, and physical takeoff. Add a translucent north-up minimap and landing diagnostics. Refined landing feel passed manual playtesting.
 - M27d: ✅ Add deterministic round-trip, eight-bearing flown landing, takeoff/return, blocked/unsafe transition, repeated body lifecycle, gravity, renderer/compositing, keyboard/gamepad mapping, and launcher workflow regressions.
-- Follow-ups: M28 adds an intact surface-outpost capture/reward loop. Explicit damage/rescue/pod rules, accelerating orbital supports, ordinary Spacewars integration, and bot intent remain later work. Normal capture gameplay is unchanged by this fixture.
+- Follow-ups: M28 adds an intact surface-outpost capture/reward loop; M29 exercises controlled accelerating supports. Explicit damage/rescue/pod rules, general orbital compatibility, ordinary Spacewars integration, and bot intent remain later work. Normal capture gameplay is unchanged by this fixture.
 - Guide: [Surface Sortie](../surface-sortie.md).
 
 ### M28: Intact outpost capture and repair
@@ -604,3 +604,12 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - Manual playtesting: the user reported the deployed outpost gameplay loop worked well with a controller on the Raspberry Pi (2026-09-06).
 - Design direction: neutral-outpost capture is one experimental path, not the only future way to claim or develop a planet. Keep planet claims, infrastructure ownership, and operational services distinct; do not require a pre-existing neutral outpost on every claimable planet.
 - Boundaries: no contested-capture policy, destructible infrastructure, resource economy, rebuilding, pilot/vehicle loss policy, or ordinary Spacewars/bot rule changes.
+
+### M29: Orbital Surface Sortie evidence
+
+- M29a: ✅ Keep the original preset and register `surface-sortie-orbit` with the same scenario/controllers. Add a headless translating diagnostic and a sun whose gravity matches the prescribed circular path at the planet center.
+- M29b: ✅ Sample completed terrain motion consistently for gravity, landing, and boarding; use center-of-mass-aware point velocity, schedule terrain once, and stop simulating the unused second ship. No actor transport or controller-force retuning.
+- M29c: ✅ Add deterministic motion/support/drift/damage counters, frame diagnostics, preset HUD, and sun/orbit minimap context.
+- M29d: ✅ Regress the full orbital round trip, extended support, opposite/faster rates, multi-bearing landings, independent jump/takeoff, excessive-acceleration separation, and bounded body lifecycle. Exercise both presets through renderer and launcher workflows.
+- Manual playtesting: deployed `surface-sortie-orbit` on the Pi, verified about 60 FPS / 60 UPS and a connected Switch Pro controller; the user reported that playtesting seemed good (2026-09-06).
+- Boundary: ordinary generated orbits need an explicit acceleration/gravity policy before integration; pilot/vehicle loss rules and bots remain separate work. See [Surface Sortie](../surface-sortie.md#moving-planet-evidence).

--- a/docs/design/spacelings.md
+++ b/docs/design/spacelings.md
@@ -113,11 +113,11 @@ There is no kinematic hold, radial snapping, or hidden takeoff impulse. The hatc
 follows the landed ship, not the old pad marker; clearance uses actual colliders.
 A translucent north-up minimap preserves world context when flying away.
 
-The fixture starts parked on a slowly rotating planet with a stationary center.
+The original fixture starts parked on a slowly rotating planet with a stationary center.
 The spaceling inherits the local surface velocity at spawn; after that only
 gravity and Rapier contacts move it. Do not copy the rover's scripted-orbit
-transport into this controller. Accelerating orbital supports need their own
-regressions before enabling this in ordinary generated Spacewars worlds.
+transport into this controller. The fifth slice below adds controlled orbital
+evidence; arbitrary generated Spacewars orbits still need an explicit policy.
 
 The initial slice disabled capture/services, weapons, and asteroid spawning in
 the fixture. It leaves the ordinary Spacewars game and bot observations unchanged.
@@ -170,14 +170,45 @@ This is deliberately one operator and one outpost, not a general contested-base
 system. The terminal is intact and non-destructible; terrain removal and service
 invalidation need explicit later policy. There are no new weapons, resources,
 pod rebuilding, pilot death rules, or changes to ordinary Spacewars/bots.
-Moving/accelerating-planet evidence and independent pilot/vehicle loss rules
-still precede ordinary-game integration.
+Orbital compatibility and independent pilot/vehicle loss rules still precede
+ordinary-game integration.
 
 Acceptance: an action-driven capture/repair/departure round trip; interrupted
 capture and wrong-support rejection; solid rotating terminal/body-count bounds;
 friendly, live, in-range, landed repair with rate/clamp checks; deterministic
 replay and restart; capture/ownership rendering in both paths and window
 orientations; unchanged landing, normal-game, and pinned bot regressions.
+
+## Fifth slice: orbital surface motion
+
+Implemented on `surface-sortie-motion`. Keep the stationary-center scenario and
+register `surface-sortie-orbit` as another preset of the same scenario, controls,
+landing, and outpost loop. A headless translating preset isolates linear motion.
+The orbital fixture adds one sun and a prescribed circular path whose center
+acceleration matches that sun's gravity. Nearby actors receive the unmodified
+shared gravity field once; no actor attachment, frame transport, or common-field
+subtraction is added. The unused second ship slot is not simulated.
+
+Landing, boarding, and gravity sample the completed terrain pose before the
+next kinematic step. Contact-point velocity accounts for Rapier's potentially
+offset center of mass. The fixture schedules orbit/spin only once per tick.
+Bounded landing and spaceling controllers retain their existing force limits.
+
+Versioned observations expose the completed frame, relative motion, scripted
+acceleration versus external gravity, support losses, knockdowns, damage, and
+planet-local idle drift. The HUD shows a compact subset. Deterministic tests
+cover the full orbital round trip, extended idle support, faster/reverse motion,
+multi-bearing landings, independent jumps/takeoff, and separation when motion
+exceeds the support budget. Desktop lifecycle/render tests cover both presets.
+The user reported successful playtesting of the deployed orbital preset on the
+Pi/controller on 2026-09-06.
+
+This is evidence for a controlled acceleration envelope, not a general solution
+for ordinary planets whose prescribed orbit and gravity masses are chosen
+independently. Decide that policy before enabling natural landing there. Pilot
+loss/rescue, contested infrastructure, terrain, and bot intent remain separate
+slices; this controlled preset's acceptance does not cover arbitrary generated
+orbits or combat.
 
 ## Planet and ship direction
 

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -64,12 +64,13 @@ enabled. Character mechanics and deterministic movement are tested headlessly
 in `engine-rapier` and `scenario-spaceling-lab`; physical controller hardware is a
 manual check.
 
-Surface Sortie uses the same launcher/pause/restart workflow with both renderers;
-its raster check requires the ship, amber outpost, capture/landing HUD,
+Both Surface Sortie presets (stationary center and orbital) use the same
+launcher/pause/restart workflow with both renderers;
+their raster checks require the ship, amber outpost, capture/landing HUD,
 and minimap planet. The client unit tests also render the disembarked spaceling,
 capture progress, and owner-colored flag in landscape/portrait, while
 `scenario-spacewars` exercises the physical exit/walk/capture/repair/return/board/
-departure loop and input gating. See
+departure loop and input gating on stationary and orbital terrain. See
 [Surface Sortie](surface-sortie.md) for the manual controls and retained images.
 
 The harness uses Slint's software backend, which does not draw vector paths.

--- a/docs/surface-sortie.md
+++ b/docs/surface-sortie.md
@@ -7,6 +7,17 @@ in the launcher, or run:
 cargo run -p engine-client -- --scenario surface-sortie
 ```
 
+For the same loop on a moving planet, choose **surface-sortie-orbit** in the
+launcher (including gamepad navigation), or run:
+
+```sh
+cargo run -p engine-client -- --scenario surface-sortie-orbit
+```
+
+These are presets of the same scenario, not separate gameplay implementations.
+Restart repeats the selected preset; returning to the launcher preserves its
+selection. Controls and the capture/repair rules are identical.
+
 The fixture starts with your ship at **75% health**, settling rear-first onto a
 slowly rotating planet. Press **B** on a gamepad or **X** on the keyboard to
 disembark. Release the controls, walk right to the amber terminal, and stand
@@ -131,13 +142,15 @@ Boarding requires that same available ship, proximity to its access point,
 physical support, balance, and low support-relative speed. This is a short hatch
 transition, not remote boarding or a physical door/ladder simulation.
 
-At exit the capsule inherits the rotating surface's point velocity and spin.
+At exit the capsule inherits the moving surface's point velocity and spin.
 Afterward Rapier and gravity own its motion; no radial snapping or per-tick
-orbital transport is added. The center is stationary on purpose. Accelerating
-scripted orbits need separate regression evidence before ordinary-world use.
+orbital transport is added. The original preset retains its stationary center;
+the orbital preset and its compatibility boundary are described below.
 
 This is a noncombat fixture: no weapons, asteroids, pod rebuilding, rover
 construction, resources, or win condition. Ordinary Spacewars and its bots are unchanged.
+Only the pilot's ship is simulated; the legacy world's unused second ship slot
+has no physics body, controls, or gravity target to interfere with the experiment.
 If you lose the ship while experimenting with flight, restart; damage, rescue,
 pod, and elimination policy for an independent pilot are not settled here.
 The intact outpost gives walking a useful capture-and-repair loop without
@@ -155,7 +168,7 @@ Headless regressions cover exit/walk/jump/return/reboard without pose shortcuts,
 ship health and creature identity preservation, one-body lifecycle, velocity
 inheritance, no airborne transport, blocked exits, unsafe/remote boarding,
 held-input gating in both directions, and reproducible actions/restarts. Typed
-`SurfaceSortieState::observation()` and version-3 JSON scenario observations
+`SurfaceSortieState::observation()` and version-4 JSON scenario observations
 include landing phase, clearance, angle, relative speeds/spin, foot count,
 assist strength, and settling duration for future runners. Outpost observations
 add identity, position/normal, owner, active claimant, capture eligibility and
@@ -184,7 +197,7 @@ SPACEWARS_SORTIE_ARTIFACTS=target/surface-sortie-poses cargo test -p engine-clie
   outpost_capture_progress_and_owner_flag_render_in_both_backends
 ```
 
-The real-window functional test covers launcher selection, both renderers,
+The real-window functional tests cover both presets' launcher selection, both renderers,
 pause, restart, return, and relaunch, with raster ship/outpost/HUD/minimap visibility checks:
 
 ```sh
@@ -198,3 +211,84 @@ initial sortie and refined assisted landing have both passed manual playtesting.
 The outpost loop also passed user-reported controller playtesting on the
 Raspberry Pi on 2026-09-06: gameplay worked well and the direction was accepted.
 This validates the experimental loop, not a final planet-claiming mechanic.
+
+## Moving-planet evidence
+
+The orbital preset uses a radius-60 planet on a radius-220 circular path at
+0.065 radians/s (14.3 units/s, about 97 seconds per orbit), with the same
+0.015 radians/s surface spin as the original fixture. The yellow central source
+and orbital guide appear on the minimap. A `Translating` Rust configuration
+provides a short, straight-line diagnostic at 3 units/s; it is not another
+launcher entry because an indefinite straight path eventually leaves the map.
+
+Terrain remains position-driven kinematic geometry in the canonical world.
+The fixture schedules its path once per step. Before physics, gravity and
+controls read the completed terrain pose, not its next target; after physics,
+landing and services consume the new completed contacts. Point velocities use
+Rapier's center-of-mass-aware query. A body's origin and center of mass need
+not coincide, so adding angular velocity around the origin to its raw linear
+velocity is not generally correct.
+
+For this controlled orbit, the sun's mass is selected so its gravity at the
+planet center matches the scripted centripetal acceleration. Ships and the
+spaceling receive the ordinary shared field, including its spatial variation,
+once per tick. There is **no** rover-style frame transport, common-gravity
+subtraction, invisible attachment, or extra gravity solve. Jumping and thrusting
+inherit surface momentum and then leave support normally.
+
+This does not establish compatibility with every generated Spacewars planet.
+The ordinary game's scripted orbital rates and gravity masses are selected
+independently; its planets need not follow the acceleration experienced by
+nearby actors. That mismatch and the supported spin/acceleration envelope need
+an explicit policy before replacing ordinary-game docking. This fixture does
+not retune those orbits, gravity, rovers, ships, or bots.
+
+### Motion diagnostics
+
+Version-4 typed/JSON observations add `motion` and `motion_metrics`:
+
+- completed planet position, origin velocity, angle/spin, active-body
+  surface-relative velocity, and actual support-point velocity/relative speed;
+- scripted orbital acceleration and external gravity at the planet center,
+  making their mismatch visible rather than silently compensating for it;
+- on-foot/supported/landed tick counts, unexpected pilot/ship support losses,
+  jumps, knockdowns, landings, deliberate departures, and cumulative ship damage;
+- current and maximum planet-local idle drift of the active actor. Movement,
+  flight, loss of balance, and controller-context changes reset the current
+  interval; the lifetime maximum remains.
+
+Counters advance only in simulation steps. Boarding and commanded jumps are
+not unexpected support losses; service healing does not erase recorded damage.
+The HUD shows the preset, speed/spin, relative speed, support losses, current
+idle drift, and damage. These are scenario observations and HUD diagnostics,
+not a new live IPC gameplay-state API.
+
+### Reproduce the motion tests
+
+```sh
+cargo test -p scenario-spacewars surface_sortie::tests::motion_tests -- --nocapture
+cargo test -p scenario-spacewars outpost_round_trip -- --nocapture
+
+# Isolated headless timing, including assertions/diagnostic reads, not rendered FPS:
+cargo test --release -p scenario-spacewars \
+  orbiting_and_translating_sorties_stay_supported -- --nocapture --test-threads=1
+```
+
+Coverage includes a 200-second orbital idle period, faster/opposite orbit and
+spin, both actors' independent flight, eight-bearing orbital approaches, the full capture/repair/reboard/
+departure loop, deliberately excessive support acceleration, stable body/collider
+counts, and deterministic actions/observations/restarts. Timing is printed for
+comparison but never used as a flaky pass/fail threshold.
+
+One local x86_64 Rust 1.89 release run on 2026-09-06 completed the 12,000-tick
+orbital idle window with pilot support and ship landing on every tick, zero
+support losses/knockdowns/damage, five bodies while on foot, and maximum recorded
+idle drift of 0.128 units. It ran at about 98,000 headless ticks/s including
+assertions and diagnostic reads. This is a tiny-fixture measurement, not rendered
+FPS, Pi performance, or evidence about crowded worlds.
+
+The orbital preset was deployed to `spacewars.local` on 2026-09-06. Runtime
+checks reported about 60 FPS / 60 UPS with the Switch Pro controller connected;
+the user subsequently reported that playtesting seemed good. This adds orbital
+Pi/controller acceptance alongside the previously accepted stationary outpost
+loop, without extending the claim to arbitrary generated planets or combat.

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -1318,12 +1318,12 @@ impl SpacewarsScenario {
         }
 
         let dt = dt.as_secs_f32();
-        if let Some(sun) = state.sun {
-            for planet in &mut state.planets {
-                planet.update_orbit(sun.position, dt);
-            }
-        }
         if !experimental {
+            if let Some(sun) = state.sun {
+                for planet in &mut state.planets {
+                    planet.update_orbit(sun.position, dt);
+                }
+            }
             update_spaceports(state, dt);
             reconcile_rover_deployments(state, dt);
         }
@@ -1331,6 +1331,12 @@ impl SpacewarsScenario {
 
         let universe_radius = state.config.universe_radius as f32;
         for (index, ship) in state.ships.iter_mut().enumerate() {
+            if surface_pilot
+                .as_ref()
+                .is_some_and(|pilot| pilot.vehicle_index() != index)
+            {
+                continue;
+            }
             if surface_pilot
                 .as_ref()
                 .is_some_and(|pilot| pilot.vehicle_index() == index)
@@ -2406,9 +2412,22 @@ fn apply_world_gravity_with_pilot(
         ));
     }
     gravity_participants.extend(planets.iter().enumerate().map(|(index, planet)| {
+        // The sortie has scheduled the next kinematic terrain pose, but its
+        // actors and contacts still describe the completed step. Sample the
+        // same current frame for gravity and controls. Legacy gameplay retains
+        // its established integration order and deterministic baselines.
+        let position = if pilot.is_some() {
+            physics
+                .world
+                .motion(physics.planet_body(index))
+                .unwrap()
+                .position
+        } else {
+            planet.position
+        };
         GravityParticipant::direct_source(
             tagged_gravity_id(GRAVITY_BODY_TAG, index as u64 + 1),
-            planet.position,
+            position,
             planet.mass,
         )
     }));
@@ -2423,7 +2442,12 @@ fn apply_world_gravity_with_pilot(
         ships
             .iter()
             .enumerate()
-            .filter(|(index, _)| !physics.ship_is_constrained(*index))
+            .filter(|(index, _)| {
+                !physics.ship_is_constrained(*index)
+                    && pilot
+                        .as_ref()
+                        .is_none_or(|pilot| pilot.vehicle_index() == *index)
+            })
             .map(|(index, ship)| {
                 GravityParticipant::target(
                     tagged_gravity_id(GRAVITY_SHIP_TAG, index as u64),

--- a/scenarios/spacewars/src/physics.rs
+++ b/scenarios/spacewars/src/physics.rs
@@ -294,6 +294,11 @@ impl SpacewarsPhysics {
         }
 
         for (index, ship) in ships.iter_mut().enumerate() {
+            if self.surface_ship.is_some_and(|active| index != active) {
+                // The single-pilot fixture retains the legacy two-slot data
+                // layout, but does not simulate an invisible second craft.
+                continue;
+            }
             if self.surface_ship == Some(index) {
                 self.docked_planets[index] = None;
                 let key = ShipColliderKey {
@@ -403,8 +408,16 @@ impl SpacewarsPhysics {
             .is_some_and(|key| key.constrained)
     }
 
-    pub(super) fn enable_surface_landing(&mut self, index: usize, ship: &ShipState) {
+    /// Configure the single-vehicle fixture, including physical landing feet.
+    pub(super) fn enable_surface_sortie(&mut self, index: usize, ship: &ShipState) {
         self.surface_ship = Some(index);
+        for other in 0..self.ship_keys.len() {
+            if other != index {
+                self.world.remove_entity(ship_entity(other));
+                self.ship_keys[other] = None;
+                self.docked_planets[other] = None;
+            }
+        }
         self.docked_planets[index] = None;
         self.world.remove_entity(ship_entity(index));
         assert!(self.insert_ship(index, ship, false, false, false));
@@ -441,12 +454,13 @@ impl SpacewarsPhysics {
         primary_body(ship_entity(index))
     }
 
+    pub(super) fn planet_body(&self, index: usize) -> PhysicsBodyId {
+        primary_body(planet_entity(index))
+    }
+
     /// Solver-backed rear-foot support within contact slop, not hull or port overlap.
     pub(super) fn landing_feet_supported(&self, index: usize, planet: usize, up: Vec2) -> usize {
         let body = self.ship_body(index);
-        let Some(motion) = self.world.motion(body) else {
-            return 0;
-        };
         (0..LANDING_FEET.len())
             .filter(|&part| {
                 self.world
@@ -456,9 +470,10 @@ impl SpacewarsPhysics {
                         part as u16,
                     ))
                     .any(|contact| {
-                        let offset = contact.position - motion.position;
-                        let velocity = motion.linear_velocity
-                            + Vec2::new(-offset.y, offset.x) * motion.angular_velocity;
+                        let velocity = self
+                            .world
+                            .velocity_at_point(body, contact.position)
+                            .unwrap();
                         contact.collider.entity == planet_entity(planet)
                             && contact.collider.role == ROVER_SURFACE_ROLE
                             && contact.separation <= 0.04

--- a/scenarios/spacewars/src/surface_sortie.rs
+++ b/scenarios/spacewars/src/surface_sortie.rs
@@ -9,9 +9,11 @@ use engine_rapier::{
 };
 
 mod landing;
+mod motion;
 mod outpost;
 mod render;
 pub use landing::{LandingPhase, LandingTelemetry};
+pub use motion::{SurfaceMotionMetrics, SurfaceMotionObservation, SurfaceMotionPreset};
 pub use outpost::{CaptureStatus, OutpostId, OutpostObservation, RepairStatus};
 #[cfg(test)]
 mod tests;
@@ -110,6 +112,9 @@ impl SurfaceSortieAction {
 
 pub struct SurfaceSortieState {
     world: SpacewarsState,
+    motion_preset: SurfaceMotionPreset,
+    motion_metrics: SurfaceMotionMetrics,
+    idle_anchor: Option<(bool, Vec2)>,
     pilot: SurfacePilot,
     input: SurfaceSortieAction,
     interact_was_held: bool,
@@ -180,6 +185,8 @@ pub struct SurfaceSortieObservation {
     pub physical_bodies: usize,
     pub landing: LandingTelemetry,
     pub outpost: OutpostObservation,
+    pub motion: SurfaceMotionObservation,
+    pub motion_metrics: SurfaceMotionMetrics,
 }
 
 impl SurfaceSortieState {
@@ -199,7 +206,7 @@ impl SurfaceSortieState {
         let ship = &self.world.ships[self.pilot.vehicle.0];
         let snapshot = self.spaceling_snapshot();
         SurfaceSortieObservation {
-            version: 3,
+            version: 4,
             tick: self.world.tick,
             spaceling: self.pilot.id,
             owner: self.pilot.owner,
@@ -227,6 +234,8 @@ impl SurfaceSortieState {
             outpost: self
                 .outpost
                 .observation(&self.world.planets[self.outpost.planet]),
+            motion: self.motion_observation(),
+            motion_metrics: self.motion_metrics,
         }
     }
 
@@ -272,7 +281,7 @@ impl SurfaceSortieState {
                 return TransferResult::TooFar;
             }
             let relative = snapshot.motion.linear_velocity
-                - planet_surface_velocity(&self.world.planets[0], snapshot.motion.position);
+                - motion::point_velocity(self.planet_motion(), snapshot.motion.position);
             if !snapshot.grounded()
                 || snapshot.balance != SpacelingBalance::Balanced
                 || relative.length() > SETTLED_SPEED
@@ -307,10 +316,11 @@ impl SurfaceSortieState {
             ) else {
                 return TransferResult::ExitBlocked;
             };
+            let surface = self.planet_motion();
             self.world.physics.world.set_velocity(
                 body.body(),
-                planet_surface_velocity(&self.world.planets[0], position),
-                self.world.planets[0].wrapper_omega,
+                motion::point_velocity(surface, position),
+                surface.angular_velocity,
                 true,
             );
             self.pilot.body = Some(body);
@@ -321,9 +331,9 @@ impl SurfaceSortieState {
 
 impl Scenario for SurfaceSortieScenario {
     type State = SurfaceSortieState;
-    type Config = ();
+    type Config = SurfaceMotionPreset;
 
-    fn init(_config: (), seed: u64) -> SurfaceSortieState {
+    fn init(motion_preset: SurfaceMotionPreset, seed: u64) -> SurfaceSortieState {
         let mut world = SpacewarsScenario::init(
             SpacewarsConfig {
                 universe_radius: 500,
@@ -334,7 +344,7 @@ impl Scenario for SurfaceSortieScenario {
             },
             seed,
         );
-        let planet = PlanetState {
+        let mut planet = PlanetState {
             position: Vec2::splat(500.0),
             radius: SURFACE_RADIUS,
             // Match 18 units/s² at the feet using the existing fixed-tick
@@ -353,22 +363,26 @@ impl Scenario for SurfaceSortieScenario {
             wrapper_angle: std::f32::consts::FRAC_PI_2,
             wrapper_omega: 0.015,
         };
+        world.sun = motion_preset.configure(&mut planet);
         // Begin just above the ground on the rear feet; Rapier settles the
         // vehicle during the first few ticks, just as after a flown landing.
         let center = planet.position + Vec2::Y * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + 5.5);
         world.ships[0].position = center - SHIP_PIVOT;
         world.ships[0].rotation_radians = 0.0;
         world.ships[0].direction = Vec2::Y;
-        world.ships[0].velocity = planet_surface_velocity(&planet, center);
+        world.ships[0].velocity = motion_preset.initial_velocity(&planet)
+            + Vec2::new(-(center - planet.position).y, (center - planet.position).x)
+                * planet.wrapper_omega;
         world.ships[0].life = world.ships[0].life_max * 0.75;
-        // Keep the second vehicle far from the single-player fixture. Its
-        // existence does not imply that this pilot may occupy another owner's ship.
-        world.ships[1].position = Vec2::new(850.0, 850.0);
-        world.ships[1].velocity = Vec2::new(-6.0, 6.0);
+        // The legacy world stores two ship slots. Surface physics disables the
+        // unused slot instead of letting an invisible craft orbit into the lab.
         world.planets = vec![planet];
         world.rover_builds = vec![RoverBuildState::default()];
-        world.physics = physics::SpacewarsPhysics::new(500.0, &world.ships, None, &world.planets);
-        world.physics.enable_surface_landing(0, &world.ships[0]);
+        world.physics =
+            physics::SpacewarsPhysics::new(500.0, &world.ships, world.sun, &world.planets);
+        // Position-based kinematic terrain derives its velocity on the first
+        // physics step. Do not try to set its COM velocity with set_velocity.
+        world.physics.enable_surface_sortie(0, &world.ships[0]);
         world.spaceport_contacts.clear();
         let outpost = outpost::SurfaceOutpost::new(OutpostId(1), 0, -0.34);
         assert!(world.physics.insert_surface_terminal(
@@ -378,6 +392,9 @@ impl Scenario for SurfaceSortieScenario {
         ));
         SurfaceSortieState {
             world,
+            motion_preset,
+            motion_metrics: SurfaceMotionMetrics::default(),
+            idle_anchor: None,
             pilot: SurfacePilot {
                 id: SpacelingId(1),
                 owner: PlayerId::PLAYER_1,
@@ -412,6 +429,7 @@ impl Scenario for SurfaceSortieScenario {
             state.input = input;
         }
         let input = state.input;
+        let before = motion::StepSample::read(state);
         let mut effective = SurfaceSortieAction::default();
         if !state.controls_armed {
             state.controls_armed = input == SurfaceSortieAction::default();
@@ -456,12 +474,12 @@ impl Scenario for SurfaceSortieScenario {
         });
         ship.set_laser(false);
         ship.set_cannon(false);
-        // Rotation is kinematic terrain motion. No spaceling pose/velocity
-        // transport is performed here or in the controller.
+        // Schedule terrain exactly once. Actors are never transported with it;
+        // controls, gravity, and Rapier contacts own their dynamic motion.
         let dt = dt.as_secs_f32();
-        state.world.planets[0].wrapper_angle = (state.world.planets[0].wrapper_angle
-            + state.world.planets[0].wrapper_omega * dt)
-            .rem_euclid(std::f32::consts::TAU);
+        state
+            .motion_preset
+            .advance(&mut state.world.planets[0], state.world.sun, dt);
         let result = SpacewarsScenario::step_with_surface_pilot(
             &mut state.world,
             &[],
@@ -480,6 +498,7 @@ impl Scenario for SurfaceSortieScenario {
                 + snapshot.relative_speed.abs() * dt * 5.0)
                 .rem_euclid(std::f32::consts::TAU);
         }
+        state.record_motion_step(before, effective);
         // Services consume completed physical support/landing, never create it.
         state.update_outpost(Duration::from_secs_f32(dt));
         result

--- a/scenarios/spacewars/src/surface_sortie/landing.rs
+++ b/scenarios/spacewars/src/surface_sortie/landing.rs
@@ -61,9 +61,14 @@ impl LandingTelemetry {
         let Some(motion) = physics.world.motion(physics.ship_body(index)) else {
             return Self::default();
         };
-        let up = (motion.position - planet.position).normalized();
+        let surface = motion::SurfaceFrame::read(physics);
+        let up = (motion.position - surface.position).normalized();
         let right = Vec2::new(up.y, -up.x);
-        let relative = motion.linear_velocity - planet_surface_velocity(planet, motion.position);
+        let relative = physics
+            .world
+            .velocity_at_point(physics.ship_body(index), motion.position)
+            .unwrap()
+            - motion::point_velocity(surface, motion.position);
         let angle_degrees = Vec2::Y
             .rotate_radians(motion.angle)
             .dot(up)
@@ -73,7 +78,7 @@ impl LandingTelemetry {
         let altitude = physics::LANDING_FEET
             .into_iter()
             .map(|foot| {
-                (motion.position + foot.rotate_radians(motion.angle)).distance_to(planet.position)
+                (motion.position + foot.rotate_radians(motion.angle)).distance_to(surface.position)
                     - planet.radius * BODY_BOUNDS_RADIUS_SCALE
                     - physics::LANDING_FOOT_RADIUS
             })
@@ -89,7 +94,7 @@ impl LandingTelemetry {
             angle_degrees,
             descent_speed: -relative.dot(up),
             lateral_speed: relative.dot(right),
-            relative_spin: motion.angular_velocity - planet.wrapper_omega,
+            relative_spin: motion.angular_velocity - surface.angular_velocity,
             supported_feet: physics.landing_feet_supported(index, 0, up),
             assist_strength: smooth(near) * smooth(aligned),
             ..Self::default()
@@ -150,14 +155,18 @@ impl SurfacePilot {
         let Some(motion) = physics.world.motion(body) else {
             return;
         };
+        let surface = motion::SurfaceFrame::read(physics);
         let landing = LandingTelemetry::measure(physics, self.vehicle.0, planet);
-        let up = (motion.position - planet.position).normalized();
+        let up = (motion.position - surface.position).normalized();
         let right = Vec2::new(up.y, -up.x);
         let mut acceleration =
             Vec2::Y.rotate_radians(motion.angle) * (ship.thrust * THRUST_ACCELERATION);
         if ship.brake > 0.0 {
-            let relative =
-                motion.linear_velocity - planet_surface_velocity(planet, motion.position);
+            let relative = physics
+                .world
+                .velocity_at_point(body, motion.position)
+                .unwrap()
+                - motion::point_velocity(surface, motion.position);
             let braking = relative * -4.0;
             acceleration += braking.normalized() * braking.length().min(BRAKE_ACCELERATION);
         } else if ship.thrust == 0.0 {
@@ -182,7 +191,7 @@ impl SurfacePilot {
         // nose outward. Stronger damping near touchdown removes unwanted spin.
         let desired_spin = -ship.turn * TURN_SPEED
             + if landing.assist_strength > 0.0 {
-                planet.wrapper_omega
+                surface.angular_velocity
             } else {
                 0.0
             };

--- a/scenarios/spacewars/src/surface_sortie/motion.rs
+++ b/scenarios/spacewars/src/surface_sortie/motion.rs
@@ -1,0 +1,295 @@
+//! Motion fixtures and completed-step surface frames. No actor transport.
+
+use super::*;
+
+/// Named, deterministic configurations of the same scenario and controllers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceMotionPreset {
+    #[default]
+    Stationary,
+    /// A short headless diagnostic; a straight path eventually leaves the map.
+    Translating,
+    Orbit,
+}
+
+impl SurfaceMotionPreset {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Stationary => "STATIONARY CENTER",
+            Self::Translating => "TRANSLATING",
+            Self::Orbit => "ORBIT + SPIN",
+        }
+    }
+
+    pub(super) fn configure(self, planet: &mut PlanetState) -> Option<SunState> {
+        if self != Self::Orbit {
+            return None;
+        }
+        let center = planet.position;
+        planet.orbit_radius = 220.0;
+        planet.orbit_omega = 0.065;
+        planet.position = center + Vec2::X * planet.orbit_radius;
+        // For this evidence fixture, the scripted circular path's acceleration
+        // agrees with the common sun gravity at the planet center. The planet
+        // is still kinematic, not an N-body integration. Nearby actors receive
+        // the unmodified field (including its spatial variation) exactly once.
+        let mass = planet.orbit_omega.powi(2) * planet.orbit_radius.powi(3) / (60.0 * GRAVITY);
+        Some(SunState {
+            position: center,
+            radius: 20.0,
+            mass,
+            color: Color::YELLOW,
+        })
+    }
+
+    pub(super) fn initial_velocity(self, planet: &PlanetState) -> Vec2 {
+        match self {
+            Self::Translating => Vec2::new(3.0, 0.0),
+            Self::Stationary | Self::Orbit => planet_surface_velocity(planet, planet.position),
+        }
+    }
+
+    pub(super) fn advance(self, planet: &mut PlanetState, sun: Option<SunState>, dt: f32) {
+        if self == Self::Orbit {
+            planet.update_orbit(
+                sun.expect("orbital fixture has its central source")
+                    .position,
+                dt,
+            );
+        } else {
+            planet.wrapper_angle += planet.wrapper_omega * dt;
+            if self == Self::Translating {
+                planet.position += self.initial_velocity(planet) * dt;
+            }
+        }
+        planet.wrapper_angle = planet.wrapper_angle.rem_euclid(std::f32::consts::TAU);
+    }
+}
+
+/// Use actual completed Rapier motion, not the analytic endpoint velocity or
+/// next target pose. Contacts, boarding, and landing must share one time sample.
+pub(super) fn point_velocity(surface: SurfaceFrame, point: Vec2) -> Vec2 {
+    let offset = point - surface.position;
+    surface.linear_velocity + Vec2::new(-offset.y, offset.x) * surface.angular_velocity
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct SurfaceFrame {
+    pub position: Vec2,
+    pub angle: f32,
+    /// Velocity of the frame origin, not of the rigid body's center of mass.
+    pub linear_velocity: Vec2,
+    pub angular_velocity: f32,
+}
+
+impl SurfaceFrame {
+    pub(super) fn read(physics: &physics::SpacewarsPhysics) -> Self {
+        let body = physics.planet_body(0);
+        let motion = physics
+            .world
+            .motion(body)
+            .expect("sortie planet is present");
+        Self {
+            position: motion.position,
+            angle: motion.angle,
+            linear_velocity: physics
+                .world
+                .velocity_at_point(body, motion.position)
+                .unwrap(),
+            angular_velocity: motion.angular_velocity,
+        }
+    }
+}
+
+impl SurfaceSortieState {
+    pub(super) fn planet_motion(&self) -> SurfaceFrame {
+        SurfaceFrame::read(&self.world.physics)
+    }
+
+    pub fn motion_preset(&self) -> SurfaceMotionPreset {
+        self.motion_preset
+    }
+}
+
+/// Completed-step values. Relative velocity is measured at the active body's
+/// origin, using the same surface frame as landing/boarding (not screen motion).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct SurfaceMotionObservation {
+    pub preset: SurfaceMotionPreset,
+    pub planet_position: Vec2,
+    pub planet_velocity: Vec2,
+    pub planet_angle: f32,
+    pub planet_spin: f32,
+    pub scripted_acceleration: Vec2,
+    pub external_gravity_at_center: Vec2,
+    pub surface_velocity: Vec2,
+    pub relative_velocity: Vec2,
+    pub support_velocity: Option<Vec2>,
+    pub support_relative_speed: Option<f32>,
+}
+
+/// Deterministic counters, updated only by simulation steps. No wall-clock
+/// assertions or per-frame trace storage. Jumps/boarding are not support losses.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
+pub struct SurfaceMotionMetrics {
+    pub on_foot_ticks: u64,
+    pub supported_ticks: u64,
+    pub ship_landed_ticks: u64,
+    pub pilot_support_losses: u64,
+    pub ship_support_losses: u64,
+    pub jumps: u64,
+    pub knockdowns: u64,
+    pub landings: u64,
+    pub departures: u64,
+    pub ship_damage: f32,
+    /// Largest displacement in planet-local coordinates during a continuous
+    /// balanced/supported idle interval. Movement, transfer, or flight resets
+    /// that interval, but not this lifetime maximum.
+    pub max_idle_drift: f32,
+    pub idle_drift: f32,
+}
+
+pub(super) struct StepSample {
+    snapshot: Option<SpacelingSnapshot>,
+    landing: LandingTelemetry,
+    ship_health: f32,
+    ship_available: bool,
+}
+
+impl StepSample {
+    pub(super) fn read(state: &SurfaceSortieState) -> Self {
+        Self {
+            snapshot: state.spaceling_snapshot(),
+            landing: state.landing,
+            ship_health: state.world.ships[state.pilot.vehicle.0].life,
+            ship_available: state.vehicle_available(),
+        }
+    }
+}
+
+impl SurfaceSortieState {
+    pub(super) fn motion_observation(&self) -> SurfaceMotionObservation {
+        let frame = self.planet_motion();
+        let snapshot = self.spaceling_snapshot();
+        let body = self.pilot.body.as_ref().map_or_else(
+            || self.world.physics.ship_body(self.pilot.vehicle.0),
+            |pilot| pilot.body(),
+        );
+        let actor = self
+            .world
+            .physics
+            .world
+            .motion(body)
+            .expect("active sortie body");
+        let surface_velocity = point_velocity(frame, actor.position);
+        let planet = &self.world.planets[0];
+        let (scripted_acceleration, external_gravity_at_center) =
+            self.world.sun.map_or((Vec2::ZERO, Vec2::ZERO), |sun| {
+                let inward = sun.position - frame.position;
+                let gravity = if inward.length_squared() > 1.0e-6 {
+                    inward.normalized() * (60.0 * GRAVITY * sun.mass / inward.length_squared())
+                } else {
+                    Vec2::ZERO
+                };
+                let scripted = if self.motion_preset == SurfaceMotionPreset::Orbit {
+                    inward * planet.orbit_omega.powi(2)
+                } else {
+                    Vec2::ZERO
+                };
+                (scripted, gravity)
+            });
+        let support = snapshot.and_then(|snapshot| snapshot.support);
+        SurfaceMotionObservation {
+            preset: self.motion_preset,
+            planet_position: frame.position,
+            planet_velocity: frame.linear_velocity,
+            planet_angle: frame.angle,
+            planet_spin: frame.angular_velocity,
+            scripted_acceleration,
+            external_gravity_at_center,
+            surface_velocity,
+            relative_velocity: self
+                .world
+                .physics
+                .world
+                .velocity_at_point(body, actor.position)
+                .unwrap()
+                - surface_velocity,
+            support_velocity: support.map(|contact| contact.velocity),
+            support_relative_speed: support.map(|contact| {
+                (self
+                    .world
+                    .physics
+                    .world
+                    .velocity_at_point(body, contact.position)
+                    .unwrap()
+                    - contact.velocity)
+                    .length()
+            }),
+        }
+    }
+
+    pub(super) fn record_motion_step(&mut self, before: StepSample, input: SurfaceSortieAction) {
+        let after = self.spaceling_snapshot();
+        let available = self.vehicle_available();
+        let ship = &self.world.ships[self.pilot.vehicle.0];
+        let frame = self.planet_motion();
+        let metrics = &mut self.motion_metrics;
+        metrics.on_foot_ticks += u64::from(after.is_some());
+        metrics.supported_ticks += u64::from(after.is_some_and(SpacelingSnapshot::grounded));
+        metrics.ship_landed_ticks += u64::from(self.landing.phase == LandingPhase::Landed);
+        if let (Some(before), Some(after)) = (before.snapshot, after) {
+            let jumps = after.jumps.saturating_sub(before.jumps);
+            metrics.jumps += jumps;
+            metrics.knockdowns += after.knockdowns.saturating_sub(before.knockdowns);
+            metrics.pilot_support_losses +=
+                u64::from(before.grounded() && !after.grounded() && jumps == 0);
+        }
+        metrics.ship_support_losses += u64::from(
+            before.landing.supported_feet > 0
+                && self.landing.supported_feet == 0
+                && ship.thrust == 0.0,
+        );
+        metrics.landings += u64::from(
+            before.landing.phase != LandingPhase::Landed
+                && self.landing.phase == LandingPhase::Landed,
+        );
+        metrics.departures += u64::from(
+            before.landing.phase == LandingPhase::Landed
+                && self.landing.phase != LandingPhase::Landed
+                && ship.thrust > 0.0,
+        );
+        // Called before service healing. A destroyed/transformed ship loses
+        // its remaining old health, even if its new pod starts with fresh life.
+        if before.ship_available {
+            metrics.ship_damage +=
+                (before.ship_health - if available { ship.life } else { 0.0 }).max(0.0);
+        }
+        let idle = if let Some(snapshot) = after {
+            snapshot.grounded() && snapshot.balance == SpacelingBalance::Balanced
+        } else {
+            self.landing.phase == LandingPhase::Landed
+        } && input.horizontal == 0.0
+            && !input.primary_held
+            && !input.interact_held
+            && !input.brake_held;
+        if idle {
+            let position = after.map_or(ship.position + SHIP_PIVOT, |snapshot| {
+                snapshot.motion.position
+            });
+            let local = (position - frame.position).rotate_radians(-frame.angle);
+            let on_foot = after.is_some();
+            let anchor = self
+                .idle_anchor
+                .filter(|(foot, _)| *foot == on_foot)
+                .map_or(local, |(_, anchor)| anchor);
+            self.idle_anchor = Some((on_foot, anchor));
+            metrics.idle_drift = local.distance_to(anchor);
+            metrics.max_idle_drift = metrics.max_idle_drift.max(metrics.idle_drift);
+        } else {
+            self.idle_anchor = None;
+            metrics.idle_drift = 0.0;
+        }
+    }
+}

--- a/scenarios/spacewars/src/surface_sortie/render.rs
+++ b/scenarios/spacewars/src/surface_sortie/render.rs
@@ -37,6 +37,15 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     let center = Vec2::new(camera.center.x, camera.center.y);
     let height = camera.height;
     let mut frame = RenderFrame::new(camera);
+    if let Some(sun) = state.world.sun {
+        circle(
+            &mut frame,
+            -21,
+            sun.position,
+            sun.radius,
+            RenderColor::rgb(1.0, 0.85, 0.25),
+        );
+    }
     let planet = &state.world.planets[0];
     let radius = planet.radius * BODY_BOUNDS_RADIUS_SCALE;
     circle(
@@ -127,7 +136,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     text(
         &mut frame,
         Vec2::new(center.x, title_y),
-        "SURFACE SORTIE  /  capture an outpost, repair, depart",
+        format!("SURFACE SORTIE  /  {}", state.motion_preset.label()),
         LIGHT,
         18.0,
     );
@@ -145,7 +154,11 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     text(
         &mut frame,
         center + Vec2::new(0.0, height * 0.31),
-        "Stand beside the amber terminal for 3s to capture.  Start / Esc: pause   R: restart",
+        format!(
+            "Planet {:.1}u/s / spin {:+.3}  |  Stand at terminal: capture  |  Start / Esc: pause",
+            observation.motion.planet_velocity.length(),
+            observation.motion.planet_spin
+        ),
         LIGHT,
         13.0,
     );
@@ -158,7 +171,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     };
     text(
         &mut frame,
-        center - Vec2::new(0.0, height * 0.29),
+        center - Vec2::new(0.0, height * 0.278),
         message,
         CYAN,
         16.0,
@@ -170,7 +183,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     );
     text(
         &mut frame,
-        center - Vec2::new(0.0, height * 0.348),
+        center - Vec2::new(0.0, height * 0.323),
         format!(
             "OUTPOST {ownership}  |  {:.0}%  |  {}  |  {:.1}u",
             post.capture_progress * 100.0,
@@ -186,7 +199,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     );
     text(
         &mut frame,
-        center - Vec2::new(0.0, height * 0.405),
+        center - Vec2::new(0.0, height * 0.369),
         format!(
             "{}  |  angle {:.0}°  |  descent {:+.1}  |  sideways {:+.1}  |  feet {}/2",
             observation.landing.phase.label(),
@@ -206,7 +219,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     );
     text(
         &mut frame,
-        center - Vec2::new(0.0, height * 0.463),
+        center - Vec2::new(0.0, height * 0.415),
         format!(
             "Ship {:.0}%  |  {}  |  hatch {:.1}u  |  bodies {}",
             ship.life / ship.life_max.max(1.0) * 100.0,
@@ -216,6 +229,21 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
         ),
         ORANGE,
         15.0,
+    );
+    let metrics = observation.motion_metrics;
+    text(
+        &mut frame,
+        center - Vec2::new(0.0, height * 0.465),
+        format!(
+            "Rel {:.1}u/s  |  lost support: pilot {} ship {}  |  idle drift {:.2}u  |  damage {:.1}",
+            observation.motion.relative_velocity.length(),
+            metrics.pilot_support_losses,
+            metrics.ship_support_losses,
+            metrics.idle_drift,
+            metrics.ship_damage
+        ),
+        LIGHT,
+        12.0,
     );
     frame
 }
@@ -235,6 +263,24 @@ pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> Rende
             stroke: Some(Stroke::new(RenderColor::rgb(0.36, 0.43, 0.52), 1.0)),
         }),
     );
+    if let Some(sun) = state.world.sun {
+        circle(
+            &mut map,
+            -19,
+            sun.position,
+            sun.radius,
+            RenderColor::rgb(1.0, 0.85, 0.25),
+        );
+        map.push_primitive(
+            -18,
+            RenderPrimitive::Circle(RenderCircle {
+                center: render_point(sun.position),
+                radius: state.world.planets[0].orbit_radius,
+                fill: None,
+                stroke: Some(Stroke::new(RenderColor::rgba(0.55, 0.6, 0.7, 0.45), 1.0)),
+            }),
+        );
+    }
     for planet in &state.world.planets {
         circle(
             &mut map,

--- a/scenarios/spacewars/src/surface_sortie/tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests.rs
@@ -3,6 +3,7 @@ use engine_rapier::world::{
     BodyId as PhysicsBodyId, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec,
 };
 
+mod motion_tests;
 mod outpost_tests;
 
 fn tick(state: &mut SurfaceSortieState, input: SurfaceSortieAction) {
@@ -20,7 +21,7 @@ fn idle(state: &mut SurfaceSortieState, ticks: usize) {
 }
 
 fn parked() -> SurfaceSortieState {
-    let mut state = SurfaceSortieScenario::init((), 7);
+    let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7);
     idle(&mut state, 120);
     assert!(state.vehicle_settled(), "{:?}", state.observation());
     state
@@ -33,7 +34,25 @@ fn approach(
     descent: f32,
     sideways: f32,
 ) -> SurfaceSortieState {
-    let mut state = SurfaceSortieScenario::init((), 7);
+    approach_in(
+        SurfaceMotionPreset::Stationary,
+        up_angle,
+        height,
+        tilt,
+        descent,
+        sideways,
+    )
+}
+
+fn approach_in(
+    preset: SurfaceMotionPreset,
+    up_angle: f32,
+    height: f32,
+    tilt: f32,
+    descent: f32,
+    sideways: f32,
+) -> SurfaceSortieState {
+    let mut state = SurfaceSortieScenario::init(preset, 7);
     state.controls_armed = true;
     let planet = state.world.planets[0];
     let up = Vec2::from_radians(up_angle);
@@ -325,9 +344,12 @@ fn spawn_inherits_rotating_surface_velocity_without_transporting_airborne_body()
     let snapshot = state.spaceling_snapshot().unwrap();
     assert_eq!(
         snapshot.motion.linear_velocity,
-        planet_surface_velocity(&planet, snapshot.motion.position)
+        motion::point_velocity(state.planet_motion(), snapshot.motion.position)
     );
-    assert_eq!(snapshot.motion.angular_velocity, planet.wrapper_omega);
+    assert_eq!(
+        snapshot.motion.angular_velocity,
+        state.planet_motion().angular_velocity
+    );
     assert_eq!(snapshot.contacts, 0);
     // In flight, changing the terrain angle must not teleport the actor.
     let body = state.pilot.body.as_ref().unwrap().body();
@@ -464,8 +486,8 @@ fn unsafe_exit_blocked_capsule_remote_or_airborne_boarding_and_lost_vehicle_are_
 
 #[test]
 fn restart_actions_and_observations_are_reproducible_and_malformed_actions_are_rejected() {
-    let mut a = SurfaceSortieScenario::init((), 3);
-    let mut b = SurfaceSortieScenario::init((), 3);
+    let mut a = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 3);
+    let mut b = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 3);
     for frame in 0..800 {
         let input = SurfaceSortieAction {
             interact_held: frame == 120 || frame == 600,
@@ -498,7 +520,15 @@ fn restart_actions_and_observations_are_reproducible_and_malformed_actions_are_r
         .is_none()
     );
     assert_eq!(
-        SurfaceSortieScenario::observe(&SurfaceSortieScenario::init((), 3)).payload,
-        SurfaceSortieScenario::observe(&SurfaceSortieScenario::init((), 3)).payload
+        SurfaceSortieScenario::observe(&SurfaceSortieScenario::init(
+            SurfaceMotionPreset::default(),
+            3
+        ))
+        .payload,
+        SurfaceSortieScenario::observe(&SurfaceSortieScenario::init(
+            SurfaceMotionPreset::default(),
+            3
+        ))
+        .payload
     );
 }

--- a/scenarios/spacewars/src/surface_sortie/tests/motion_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/motion_tests.rs
@@ -1,0 +1,483 @@
+use super::*;
+
+#[test]
+fn orbital_support_handles_opposite_and_faster_orbit_and_spin() {
+    for (orbit, spin) in [(0.11_f32, 0.08_f32), (-0.11, -0.08), (-0.065, 0.015)] {
+        let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::Orbit, 7);
+        let planet = &mut state.world.planets[0];
+        planet.orbit_omega = orbit;
+        planet.wrapper_omega = spin;
+        state.world.sun.as_mut().unwrap().mass =
+            orbit.powi(2) * planet.orbit_radius.powi(3) / (60.0 * GRAVITY);
+        state.world.ships[0].velocity =
+            planet_surface_velocity(planet, state.world.ships[0].position + SHIP_PIVOT);
+        state.world.ships[0].omega = spin;
+        idle(&mut state, 120);
+        assert!(
+            state.vehicle_settled(),
+            "{orbit}/{spin}: {:?}",
+            state.observation()
+        );
+        disembark(&mut state);
+        let mut supported = 0;
+        for _ in 0..3600 {
+            idle(&mut state, 1);
+            supported += usize::from(state.spaceling_snapshot().unwrap().grounded());
+        }
+        assert!(
+            supported > 3500,
+            "{orbit}/{spin}: {:?}",
+            state.observation()
+        );
+        assert_eq!(state.motion_metrics.ship_damage, 0.0);
+        assert_eq!(state.motion_metrics.knockdowns, 0);
+        assert!(
+            state.motion_metrics.max_idle_drift < 1.0,
+            "{orbit}/{spin}: {:?}",
+            state.motion_metrics
+        );
+        eprintln!(
+            "rates orbit={orbit} spin={spin}: {}",
+            serde_json::to_string(&state.motion_metrics).unwrap()
+        );
+    }
+}
+
+#[test]
+fn single_pilot_fixture_does_not_simulate_the_unused_ship_slot() {
+    for preset in [SurfaceMotionPreset::Stationary, SurfaceMotionPreset::Orbit] {
+        let mut state = SurfaceSortieScenario::init(preset, 7);
+        let inactive = state.world.physics.ship_body(1);
+        assert_eq!(state.world.physics.world.motion(inactive), None);
+        // Even an overlapping legacy slot cannot create contacts or reappear
+        // through reconciliation. Only the pilot's vehicle enters the field.
+        state.world.ships[1].position = state.world.ships[0].position;
+        idle(&mut state, 120);
+        assert_eq!(state.world.physics.world.motion(inactive), None);
+        assert!(state.vehicle_settled());
+        assert_eq!(state.motion_metrics.ship_damage, 0.0);
+        assert!(
+            !state
+                .world
+                .gravity_participants
+                .iter()
+                .any(|participant| { participant.id == tagged_gravity_id(GRAVITY_SHIP_TAG, 1) })
+        );
+    }
+}
+
+#[test]
+fn motion_metrics_preserve_damage_through_repair_and_reset_only_current_idle_drift() {
+    let mut state = parked();
+    idle(&mut state, 120);
+    let maximum = state.motion_metrics.max_idle_drift;
+    assert!(state.motion_metrics.idle_drift > 0.0);
+    assert!(state.idle_anchor.is_some());
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            brake_held: true,
+            ..SurfaceSortieAction::default()
+        },
+    );
+    assert_eq!(state.motion_metrics.idle_drift, 0.0);
+    assert_eq!(state.idle_anchor, None);
+    assert_eq!(state.motion_metrics.max_idle_drift, maximum);
+    idle(&mut state, 1);
+    assert!(state.idle_anchor.is_some());
+    assert_eq!(state.motion_metrics.idle_drift, 0.0);
+
+    // Isolate the counter's before/after contract from impact tuning. Recording
+    // happens before the repair service; even immediate healing cannot mask it.
+    let before = motion::StepSample::read(&state);
+    state.world.ships[0].life -= 10.0;
+    state.record_motion_step(before, SurfaceSortieAction::default());
+    assert_eq!(state.motion_metrics.ship_damage, 10.0);
+    state.outpost.owner = Some(state.pilot.owner);
+    let health = state.world.ships[0].life;
+    idle(&mut state, 120);
+    assert!(state.world.ships[0].life > health);
+    assert_eq!(state.motion_metrics.ship_damage, 10.0);
+
+    let before = motion::StepSample::read(&state);
+    let remaining = state.world.ships[0].life;
+    state.world.ships[0].change_to_escape_pod();
+    state.record_motion_step(before, SurfaceSortieAction::default());
+    assert_eq!(state.motion_metrics.ship_damage, 10.0 + remaining);
+}
+
+#[test]
+fn first_completed_surface_frame_has_the_presets_origin_velocity() {
+    for preset in [
+        SurfaceMotionPreset::Stationary,
+        SurfaceMotionPreset::Translating,
+        SurfaceMotionPreset::Orbit,
+    ] {
+        let mut state = SurfaceSortieScenario::init(preset, 7);
+        let origin = state.world.planets[0].position;
+        idle(&mut state, 1);
+        let motion = state.motion_observation();
+        let expected = (state.world.planets[0].position - origin) * 60.0;
+        assert!(
+            (motion.planet_velocity - expected).length() < 0.01,
+            "{preset:?}: {motion:?}"
+        );
+    }
+}
+
+#[test]
+fn orbital_approaches_land_from_eight_bearings_without_damage() {
+    for bearing in 0..8 {
+        let mut state = approach_in(
+            SurfaceMotionPreset::Orbit,
+            bearing as f32 * std::f32::consts::TAU / 8.0,
+            18.0,
+            5.0_f32.to_radians(),
+            5.0,
+            3.0,
+        );
+        for _ in 0..900 {
+            idle(&mut state, 1);
+            if state.vehicle_settled() {
+                break;
+            }
+        }
+        assert!(
+            state.vehicle_settled(),
+            "bearing={bearing} {:?}",
+            state.observation()
+        );
+        assert_eq!(state.motion_metrics.ship_damage, 0.0);
+        disembark(&mut state);
+        interact(&mut state);
+        assert_eq!(state.last_transfer, TransferResult::Boarded);
+    }
+}
+
+#[test]
+fn orbiting_jump_and_ship_takeoff_inherit_motion_then_fly_independently() {
+    let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::Orbit, 7);
+    idle(&mut state, 120);
+    disembark(&mut state);
+    let snapshot = state.spaceling_snapshot().unwrap();
+    let velocity = snapshot.motion.linear_velocity;
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..SurfaceSortieAction::default()
+        },
+    );
+    assert_eq!(state.motion_metrics.jumps, 1);
+    assert_eq!(
+        state.motion_metrics.pilot_support_losses, 0,
+        "a jump isn't unexpected support loss"
+    );
+    let after = state.spaceling_snapshot().unwrap();
+    let right = Vec2::new(snapshot.up.y, -snapshot.up.x);
+    assert!(
+        (after.motion.linear_velocity - velocity).dot(right).abs() < 0.2,
+        "inherit tangential momentum"
+    );
+    assert!(after.motion.linear_velocity.dot(snapshot.up) > velocity.dot(snapshot.up) + 4.0);
+    // After separation, neutral air control applies no linear change beyond
+    // the shared gravity field. Moving terrain must not carry a jumping actor.
+    idle(&mut state, 2);
+    for _ in 0..12 {
+        let before = state.spaceling_snapshot().unwrap();
+        assert!(!before.grounded());
+        idle(&mut state, 1);
+        let after = state.spaceling_snapshot().unwrap();
+        let expected = before.motion.linear_velocity + state.pilot.gravity / 60.0;
+        assert!(
+            (after.motion.linear_velocity - expected).length() < 1.0e-4,
+            "no air transport: {after:?}"
+        );
+    }
+    idle(&mut state, 180);
+    assert!(state.spaceling_snapshot().unwrap().grounded());
+
+    // A fresh, reproducible fixture exercises takeoff through player controls.
+    let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::Orbit, 7);
+    idle(&mut state, 120);
+    let before = state.world.ships[0].velocity;
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..SurfaceSortieAction::default()
+        },
+    );
+    assert!(
+        (state.world.ships[0].velocity - before).length() < 1.0,
+        "no hidden launch impulse"
+    );
+    assert_eq!(state.motion_metrics.departures, 1);
+    assert!(!state.world.physics.ship_is_constrained(0));
+    for _ in 0..100 {
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                primary_held: true,
+                ..SurfaceSortieAction::default()
+            },
+        );
+    }
+    assert!(state.landing.altitude > 25.0);
+    for _ in 0..10 {
+        let velocity = state.world.ships[0].velocity;
+        idle(&mut state, 1);
+        let expected = velocity + state.pilot.ship_gravity_delta;
+        assert!(
+            (state.world.ships[0].velocity - expected).length() < 1.0e-4,
+            "ship coasts independently outside assist range"
+        );
+    }
+}
+
+#[test]
+fn excessive_support_acceleration_causes_separation_and_stops_capture_and_repair() {
+    let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::Orbit, 7);
+    idle(&mut state, 120);
+    disembark(&mut state);
+    super::outpost_tests::walk_to(&mut state, super::outpost_tests::terminal_approach);
+    idle(&mut state, 40);
+    assert!(
+        state
+            .outpost
+            .observation(&state.world.planets[0])
+            .capture_progress
+            > 0.0
+    );
+    // Deliberately exceed both controllers' acceleration budgets. Do not add
+    // magnetic attachment to make this unsafe scripted trajectory "pass".
+    state.world.planets[0].orbit_omega = 0.8;
+    idle(&mut state, 30);
+    assert!(!state.spaceling_snapshot().unwrap().grounded());
+    assert!(!state.vehicle_settled());
+    assert_eq!(
+        state
+            .outpost
+            .observation(&state.world.planets[0])
+            .capture_progress,
+        0.0
+    );
+    assert!(state.motion_metrics.pilot_support_losses > 0);
+    state.outpost.owner = Some(state.pilot.owner);
+    let healed = state
+        .outpost
+        .observation(&state.world.planets[0])
+        .repaired_health;
+    idle(&mut state, 30);
+    assert_ne!(
+        state
+            .outpost
+            .observation(&state.world.planets[0])
+            .repair_status,
+        RepairStatus::Repairing
+    );
+    assert_eq!(
+        state
+            .outpost
+            .observation(&state.world.planets[0])
+            .repaired_health,
+        healed
+    );
+}
+
+#[test]
+fn orbital_motion_metrics_and_rendering_replay_and_restart_deterministically() {
+    for preset in [
+        SurfaceMotionPreset::Stationary,
+        SurfaceMotionPreset::Translating,
+        SurfaceMotionPreset::Orbit,
+    ] {
+        let mut a = SurfaceSortieScenario::init(preset, 123);
+        let mut b = SurfaceSortieScenario::init(preset, 123);
+        let initial = SurfaceSortieScenario::observe(&a).payload;
+        for frame in 0..500 {
+            let input = SurfaceSortieAction {
+                interact_held: frame == 120,
+                horizontal: if (250..300).contains(&frame) {
+                    1.0
+                } else {
+                    0.0
+                },
+                primary_held: frame == 350,
+                ..SurfaceSortieAction::default()
+            };
+            tick(&mut a, input);
+            tick(&mut b, input);
+            assert_eq!(a.observation(), b.observation());
+        }
+        let before = SurfaceSortieScenario::observe(&a).payload;
+        for _ in 0..3 {
+            SurfaceSortieScenario::render_frame(&a);
+            SurfaceSortieScenario::minimap_frame(&a, 9.0 / 16.0);
+            SurfaceSortieScenario::step(&mut a, &[], Duration::ZERO);
+        }
+        assert_eq!(SurfaceSortieScenario::observe(&a).payload, before);
+        assert_eq!(
+            SurfaceSortieScenario::observe(&SurfaceSortieScenario::init(preset, 123)).payload,
+            initial
+        );
+        assert_eq!(a.observation().version, 4);
+        assert!(a.motion_metrics.on_foot_ticks > 0);
+        assert_eq!(a.motion_metrics.jumps, 1);
+        assert_eq!(a.motion_metrics.ship_damage, 0.0);
+    }
+}
+
+#[test]
+fn orbital_frame_has_matched_external_gravity_without_a_follow_force() {
+    let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::Orbit, 7);
+    idle(&mut state, 1);
+    for _ in 0..120 {
+        let observation = state.motion_observation();
+        assert!(
+            (observation.scripted_acceleration - observation.external_gravity_at_center).length()
+                < 1.0e-5
+        );
+        assert!(observation.scripted_acceleration.length() > 0.9);
+        idle(&mut state, 1);
+    }
+    // Ordinary worlds do not necessarily have this agreement. The diagnostic
+    // exposes the difference; it does not silently subtract or add a force.
+    state.world.sun.as_mut().unwrap().mass *= 10.0;
+    let observation = state.motion_observation();
+    assert!(
+        (observation.scripted_acceleration - observation.external_gravity_at_center).length() > 8.0
+    );
+}
+
+#[test]
+fn landing_uses_completed_terrain_pose_while_the_next_pose_is_scheduled() {
+    let state = parked();
+    let planet = state.world.planets[0];
+    let before = LandingTelemetry::measure(&state.world.physics, 0, &planet);
+    let mut next = planet;
+    next.position += Vec2::new(20.0, -10.0);
+    next.wrapper_angle += 0.2;
+    // In the canonical step, scenario terrain already describes the next
+    // kinematic target when control reads the previous completed contacts.
+    let scheduled = LandingTelemetry::measure(&state.world.physics, 0, &next);
+    assert_eq!(before, scheduled);
+}
+
+#[test]
+fn a_sortie_with_a_sun_advances_planet_spin_only_once_per_tick() {
+    let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7);
+    state.world.sun = Some(SunState {
+        position: state.world.planets[0].position,
+        radius: 1.0,
+        mass: 0.0,
+        color: Color::YELLOW,
+    });
+    let before = state.world.planets[0].wrapper_angle;
+    let expected = before + state.world.planets[0].wrapper_omega / 60.0;
+    idle(&mut state, 1);
+    assert!((state.world.planets[0].wrapper_angle - expected).abs() < 1.0e-7);
+}
+
+#[test]
+fn orbiting_and_translating_sorties_stay_supported_without_actor_transport() {
+    for (preset, ticks) in [
+        (SurfaceMotionPreset::Translating, 1200),
+        (SurfaceMotionPreset::Orbit, 12000),
+    ] {
+        let mut state = SurfaceSortieScenario::init(preset, 7);
+        idle(&mut state, 120);
+        assert!(state.vehicle_settled(), "{:?}", state.observation());
+        disembark(&mut state);
+        let bodies = state.world.physics.world.body_count();
+        let colliders = state.world.physics.world.collider_count();
+        let health = state.world.ships[0].life;
+        let mut supported = 0;
+        let mut landed = 0;
+        let mut max_hatch_distance = 0.0_f32;
+        let started = Instant::now();
+        for _ in 0..ticks {
+            idle(&mut state, 1);
+            let snapshot = state.spaceling_snapshot().unwrap();
+            supported += usize::from(snapshot.grounded());
+            assert_eq!(state.world.physics.world.body_count(), bodies);
+            assert_eq!(state.world.physics.world.collider_count(), colliders);
+            landed += usize::from(state.vehicle_settled());
+            max_hatch_distance = max_hatch_distance.max(
+                snapshot
+                    .motion
+                    .position
+                    .distance_to(state.access_position()),
+            );
+        }
+        eprintln!(
+            "{preset:?}: supported={supported}/{ticks} landed={landed}/{ticks} hatch_max={max_hatch_distance:.3} health={} bodies={} ticks/s={:.0}",
+            state.world.ships[0].life,
+            state.world.physics.world.body_count(),
+            ticks as f64 / started.elapsed().as_secs_f64(),
+        );
+        assert!(supported > ticks * 98 / 100, "{:?}", state.observation());
+        assert!(landed > ticks * 98 / 100, "{:?}", state.observation());
+        assert!(max_hatch_distance < BOARDING_RANGE);
+        assert_eq!(state.spaceling_snapshot().unwrap().knockdowns, 0);
+        assert_eq!(state.world.ships[0].life, health);
+        assert_eq!(state.world.physics.world.body_count(), bodies);
+        assert_eq!(state.motion_metrics.ship_damage, 0.0);
+        assert_eq!(state.motion_metrics.pilot_support_losses, 0);
+        eprintln!(
+            "metrics: {}",
+            serde_json::to_string(&state.motion_metrics).unwrap()
+        );
+        interact(&mut state);
+        assert_eq!(state.last_transfer, TransferResult::Boarded);
+    }
+}
+
+#[test]
+fn physical_spin_matches_prescribed_motion_during_landing() {
+    let mut state = approach(
+        3.0 * std::f32::consts::TAU / 8.0,
+        18.0,
+        5.0_f32.to_radians(),
+        5.0,
+        3.0,
+    );
+    for _ in 0..900 {
+        idle(&mut state, 1);
+        let surface = state.planet_motion();
+        assert!(
+            (surface.angular_velocity - state.world.planets[0].wrapper_omega).abs() < 0.001,
+            "tick {}: prescribed spin {}, completed motion {surface:?}",
+            state.world.tick,
+            state.world.planets[0].wrapper_omega
+        );
+    }
+}
+
+#[test]
+fn frame_velocity_matches_motion_of_the_surface_not_its_offset_center_of_mass() {
+    let state = parked();
+    let planet = state.world.planets[0];
+    let frame = state.planet_motion();
+    for point in [
+        planet.position,
+        state.access_position(),
+        state.outpost.position(&planet),
+    ] {
+        let actual = state
+            .world
+            .physics
+            .world
+            .velocity_at_point(state.world.physics.planet_body(0), point)
+            .unwrap();
+        assert!((motion::point_velocity(frame, point) - actual).length() < 1.0e-6);
+        // Kinematic velocity is a finite-step difference of f32 poses near
+        // (500, 500), not the exact analytic endpoint derivative.
+        assert!(
+            (motion::point_velocity(frame, point) - planet_surface_velocity(&planet, point))
+                .length()
+                < 0.01,
+            "frame={frame:?} point={point:?}"
+        );
+    }
+}

--- a/scenarios/spacewars/src/surface_sortie/tests/outpost_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/outpost_tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-fn walk_to(state: &mut SurfaceSortieState, target: impl Fn(&SurfaceSortieState) -> Vec2) {
+pub(super) fn walk_to(
+    state: &mut SurfaceSortieState,
+    target: impl Fn(&SurfaceSortieState) -> Vec2,
+) {
     for _ in 0..600 {
         let snapshot = state.spaceling_snapshot().unwrap();
         let delta = target(state) - snapshot.motion.position;
@@ -20,7 +23,7 @@ fn walk_to(state: &mut SurfaceSortieState, target: impl Fn(&SurfaceSortieState) 
     panic!("could not walk to target: {:?}", state.observation());
 }
 
-fn terminal_approach(state: &SurfaceSortieState) -> Vec2 {
+pub(super) fn terminal_approach(state: &SurfaceSortieState) -> Vec2 {
     let planet = &state.world.planets[state.outpost.planet];
     let up = state
         .outpost
@@ -55,8 +58,8 @@ fn capture(state: &mut SurfaceSortieState) {
 
 #[test]
 fn outpost_capture_and_repair_replay_identically_and_do_not_advance_without_steps() {
-    let mut a = SurfaceSortieScenario::init((), 7);
-    let mut b = SurfaceSortieScenario::init((), 7);
+    let mut a = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7);
+    let mut b = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7);
     for frame in 0..650 {
         let observation = a.observation();
         let input = SurfaceSortieAction {
@@ -87,7 +90,7 @@ fn outpost_capture_and_repair_replay_identically_and_do_not_advance_without_step
         SurfaceSortieScenario::step(&mut a, &[], Duration::ZERO);
     }
     assert_eq!(a.observation(), before);
-    let fresh = SurfaceSortieScenario::init((), 7).observation();
+    let fresh = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7).observation();
     assert_eq!(fresh.outpost.owner, None);
     assert_eq!(fresh.outpost.capture_progress, 0.0);
     assert_eq!(fresh.outpost.repaired_health, 0.0);
@@ -96,7 +99,19 @@ fn outpost_capture_and_repair_replay_identically_and_do_not_advance_without_step
 
 #[test]
 fn outpost_round_trip_captures_repairs_and_departs_using_only_player_controls() {
-    let mut state = parked();
+    for preset in [SurfaceMotionPreset::Stationary, SurfaceMotionPreset::Orbit] {
+        round_trip(preset);
+    }
+}
+
+fn round_trip(preset: SurfaceMotionPreset) {
+    let mut state = SurfaceSortieScenario::init(preset, 7);
+    idle(&mut state, 120);
+    assert!(
+        state.vehicle_settled(),
+        "{preset:?}: {:?}",
+        state.observation()
+    );
     let initial = state.observation();
     assert_eq!(initial.ship_health, state.world.ships[0].life_max * 0.75);
     idle(&mut state, 360);


### PR DESCRIPTION
## Summary

Add `surface-sortie-orbit`, a controller-selectable orbital preset of the existing Surface Sortie scenario. Keep the stationary-center preset, controls, physical landing, and outpost loop. Ordinary Spacewars gameplay and frozen bot policies are unchanged.

Related to #41. This is another integration-evidence slice, not completion of spacelings, planetary infrastructure, or natural landing in the ordinary game.

## Changes

- Add deterministic stationary, translating (headless diagnostic), and orbit/spin presets. The orbital fixture's central source matches the prescribed path's acceleration at the planet center; dynamic actors receive the unmodified shared gravity field once.
- Reproduce and fix double planet-spin advancement and landing reads that mixed the next terrain target with completed contacts.
- Add the allocation-free `PhysicsWorld::velocity_at_point` query. Landing, boarding, and surface diagnostics now account for offset centers of mass and use completed physics motion.
- Stop simulating the legacy world's unused second ship in the single-pilot fixture. A faster-orbit regression exposed interference from that invisible craft.
- Add version-4 motion observations, deterministic support/drift/damage counters, a compact HUD row, and sun/orbit minimap context.
- Extend action-driven capture/repair/reboard/departure, multi-bearing landing, rendering, and real-window lifecycle coverage to the orbital preset. Document the acceleration/gravity compatibility boundary and manual playtest results.

No actor attachment, radial snapping, rover-style frame transport, additional gravity solve, or controller-force retuning is introduced.

## Validation

- [x] Rust 1.89 `cargo fmt --all -- --check` and `git diff --check`.
- [x] Rust 1.89 `cargo test --locked --workspace --all-targets`: 790 passed; 10 display-dependent tests ignored in that command.
- [x] Both Surface Sortie real-window workflows run separately: launcher selection, vector/raster lifecycle, pause, restart, return, and relaunch. The software backend verifies vector lifecycle/text, not vector geometry; client unit tests cover the scene models and raster geometry in landscape/portrait.
- [x] `navigation-v1` and `strategy-v1` deterministic baselines match (6 and 12 episodes).
- [x] Extended motion tests: 200-second orbital idle, faster/reverse orbit and spin, eight-bearing approaches, independent jump/takeoff, excessive-acceleration separation, stable body/collider counts, replay/restart, and metrics semantics.
- [x] Yocto Pi image built and deployed through the A/B updater. `surface-sortie-orbit` ran at approximately 60 FPS / 60 UPS with a Switch Pro controller connected; the user reported that playtesting seemed good.

The release idle test retained pilot support and ship landing on all 12,000 measured orbital ticks, with zero support losses, knockdowns, or damage and maximum recorded idle drift of 0.128 units. One local x86_64 run achieved about 98,000 headless ticks/s including assertions/diagnostic reads; this is not a rendered-FPS or population-scaling claim.

Rust 1.89 Clippy completes with existing warnings in unrelated code; this does not claim a warning-free workspace.

## Boundaries and follow-ups

- Generated Spacewars planets choose orbit/spin and gravity masses independently. This controlled preset does not establish natural landing on every generated planet.
- General multi-planet/multi-pilot support, pilot/vehicle damage and rescue rules, contested outposts, ordinary-game services/win conditions, and bot intent remain separate integration work.
- No terrain deformation, economy, rebuilding, new weapons, or live gameplay IPC API is added.

## Try it

```sh
cargo run -p engine-client -- --scenario surface-sortie-orbit
```

Or choose `surface-sortie-orbit` in the launcher. See `docs/surface-sortie.md` for controls, diagnostics, reproducible tests, and the motion boundary.
