### PR TITLE
Add two-player Surface Expedition with planet flags and recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ The local launcher currently has twelve entries across eight scenario families:
   layouts. Ordinary Spacewars and the shared controllers remain unchanged.
   **surface-expedition** enables planet-to-planet travel and flag-based planet
   claiming: land, disembark and wait 3 seconds; enemy flags must first be lowered
-  up close. Outposts/repair remain in the older lab fixtures. Choose **Settings →
+  up close. After ship loss, land and exit the escape pod (or continue with the
+  existing on-foot pilot), then stand on owned terrain for 8 seconds to rebuild.
+  Hold A+B+Down for 3 seconds for a deliberate loss drill.
+  Outposts/repair remain in the older lab fixtures. Choose **Settings →
   Players: 1 or 2** for solo or split-screen play using the same scenario. See
   [Surface Expedition](docs/surface-expedition.md).
 - **Falling** — the pinned MIT-licensed NES homebrew running on this repository's

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Below is a zoomed out view of a CTF game mode.
 
 ## Status
 
-The local launcher currently hosts seven playable scenarios:
+The local launcher currently has twelve entries across eight scenario families:
 
 - **Spacewars** — the two-player arcade reboot. Its ships, escape pods,
   asteroids, physical debris, projectiles, celestial bodies, spaceport sensors,
@@ -45,8 +45,11 @@ The local launcher currently hosts seven playable scenarios:
   gravity/motion gaps before ordinary-game integration. **surface-sortie-world**
   tries an explicit Surface V1 gravity/spin/orbit profile on those generated
   layouts. Ordinary Spacewars and the shared controllers remain unchanged.
-  **surface-expedition** enables planet-to-planet travel and independent
-  outposts on that experimental world. See [Surface Expedition](docs/surface-expedition.md).
+  **surface-expedition** enables planet-to-planet travel and flag-based planet
+  claiming: land, disembark and wait 3 seconds; enemy flags must first be lowered
+  up close. Outposts/repair remain in the older lab fixtures. Choose **Settings →
+  Players: 1 or 2** for solo or split-screen play using the same scenario. See
+  [Surface Expedition](docs/surface-expedition.md).
 - **Falling** — the pinned MIT-licensed NES homebrew running on this repository's
   Rust-native mapper-0 emulator, with pixel-perfect native video, exact-rational
   realtime pacing, and bounded 48 kHz device audio.

--- a/crates/engine-client/src/client_scenarios/spaceling_lab.rs
+++ b/crates/engine-client/src/client_scenarios/spaceling_lab.rs
@@ -82,7 +82,7 @@ impl ClientScenario for SpacelingLabClientScenario {
 }
 
 pub(super) fn spaceling_controls(input: &ClientInput) -> (f32, bool, bool) {
-    let (gamepad_walk, gamepad_jump, gamepad_shove) = input.spaceling_gamepad_input();
+    let (gamepad_walk, gamepad_jump, gamepad_shove) = input.spaceling_gamepad_input(0);
     let left = input.is_pressed(GameKey::P1TurnLeft) || input.is_pressed(GameKey::NesLeft);
     let right = input.is_pressed(GameKey::P1TurnRight) || input.is_pressed(GameKey::NesRight);
     let walk = match (left, right) {

--- a/crates/engine-client/src/client_scenarios/surface_sortie.rs
+++ b/crates/engine-client/src/client_scenarios/surface_sortie.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use engine_common::{Action, RenderFrame, Scenario, Settings, StepResult, TickModel};
+use scenario_spacewars::PlayerId;
 use scenario_spacewars::surface_sortie::{
     SurfaceMotionPreset, SurfaceSortieAction, SurfaceSortieScenario, SurfaceSortieState,
 };
@@ -10,7 +11,7 @@ use super::{
     ScenarioRegistration, ScenarioStartMode, spaceling_lab::spaceling_controls,
 };
 use crate::{
-    input::ClientInput,
+    input::{ClientInput, GameKey},
     render::{FrameLayout, Viewport},
 };
 
@@ -55,7 +56,7 @@ pub(super) const WORLD_REGISTRATION: ScenarioRegistration = ScenarioRegistration
 
 pub(super) const EXPEDITION_REGISTRATION: ScenarioRegistration = ScenarioRegistration {
     id: "surface-expedition",
-    controls_help: "Surface Expedition: fly between generated Surface V1 planets. Approach assistance follows the nearest surface; landing requires actual rear-foot support. Each planet has its own neutral outpost. Land, B / X to exit, walk to the amber terminal and stand still to capture. A friendly site repairs a nearby ship landed on that same planet. Return to the cyan hatch and B / X to board. A / Space thrusts or jumps; left/right turns or walks; Down / S brakes. Start / Esc pauses; R restarts. Minimap squares show each site's ownership. Single pilot, no combat, rescue or rebuilding; ordinary Spacewars is unchanged.",
+    controls_help: "Surface Expedition: land rear-first, B / X to get out, then stand still on the surface for 3 seconds to claim a neutral planet. Your flag is planted where you stand. An existing enemy flag must be approached (within 3 units) and lowered for 3 seconds before your own flag can rise for another 3 seconds. Opponents near the flag pause progress. Leaving, jumping or losing balance resets the unfinished stage; a fully lowered flag leaves the planet neutral. Minimap colors show planet ownership and triangles locate flags. A / Space thrusts or jumps; left/right turns or walks; Down / S brakes; B / X boards your own landed ship at the cyan hatch. Choose 1 or 2 players in Settings. P2 keyboard: numpad 4/6 turns/walks, 8 thrusts/jumps, 5 brakes, 2 boards/exits. Each assigned gamepad controls its own pilot; release controls after a transfer. Start / Esc pauses; R restarts. Ships start at full health. No outposts, repair, weapons, rescue or rebuilding; ordinary Spacewars is unchanged.",
     create: create_expedition,
     ..REGISTRATION
 };
@@ -66,13 +67,16 @@ struct SurfaceSortieClientScenario {
 
 fn create_expedition(
     seed: u64,
-    _settings: &Settings,
+    settings: &Settings,
     _viewport: Viewport,
     _mode: ScenarioStartMode,
     _asset: &ScenarioAsset,
 ) -> Result<Box<dyn ClientScenario>, ScenarioCreateError> {
     Ok(Box::new(SurfaceSortieClientScenario {
-        state: SurfaceSortieScenario::init_expedition(seed),
+        state: SurfaceSortieScenario::init_expedition(
+            seed,
+            settings.surface_expedition.players.count(),
+        ),
     }))
 }
 
@@ -143,25 +147,37 @@ impl ClientScenario for SurfaceSortieClientScenario {
         SurfaceSortieScenario::step(&mut self.state, actions, dt)
     }
     fn map_input(&self, input: &mut ClientInput, _benchmark: bool) -> Vec<Action> {
-        let (horizontal, primary_held, interact_held) = spaceling_controls(input);
-        vec![
-            SurfaceSortieAction {
-                horizontal,
-                primary_held,
-                interact_held,
-                brake_held: input.surface_sortie_brake_held(),
-            }
-            .encode(),
-        ]
+        (0..self.state.player_count())
+            .map(|player| {
+                let (horizontal, primary_held, interact_held) = surface_controls(input, player);
+                SurfaceSortieAction {
+                    horizontal,
+                    primary_held,
+                    interact_held,
+                    brake_held: input.surface_sortie_brake_held(player),
+                }
+                .encode(PlayerId::from_index(player).expect("bounded player seat"))
+            })
+            .collect()
     }
     fn render_frames(&self, _renderer: RenderBackend, viewport: Viewport) -> Vec<RenderFrame> {
-        vec![
-            SurfaceSortieScenario::render_frame(&self.state),
-            SurfaceSortieScenario::minimap_frame(&self.state, viewport.aspect_ratio()),
-        ]
+        let count = self.state.player_count();
+        let aspect = viewport.aspect_ratio() / count as f32;
+        let mut frames = Vec::with_capacity(count * 2);
+        for player in 0..count {
+            frames.push(SurfaceSortieScenario::player_frame(&self.state, player));
+        }
+        for player in 0..count {
+            frames.push(SurfaceSortieScenario::minimap_frame(
+                &self.state,
+                player,
+                aspect,
+            ));
+        }
+        frames
     }
     fn frame_layout(&self) -> FrameLayout {
-        FrameLayout::SinglePlayerWithMinimap
+        FrameLayout::PlayerViewsWithMinimaps
     }
     #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any {
@@ -173,11 +189,281 @@ impl ClientScenario for SurfaceSortieClientScenario {
     }
 }
 
+fn surface_controls(input: &ClientInput, player: usize) -> (f32, bool, bool) {
+    if player == 0 {
+        return spaceling_controls(input);
+    }
+    let (gamepad_walk, gamepad_primary, gamepad_interact) = input.spaceling_gamepad_input(player);
+    let horizontal = match (
+        input.is_pressed(GameKey::P2TurnLeft),
+        input.is_pressed(GameKey::P2TurnRight),
+    ) {
+        (true, false) => -1.0,
+        (false, true) => 1.0,
+        (true, true) => 0.0,
+        (false, false) => gamepad_walk,
+    };
+    (
+        horizontal,
+        input.is_pressed(GameKey::P2Thrust)
+            || input.is_pressed(GameKey::P2Laser)
+            || gamepad_primary,
+        input.is_pressed(GameKey::P2Reverse) || gamepad_interact,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::input::{GameKey, GamepadInput, GamepadSeatInput};
     use std::{cell::RefCell, rc::Rc};
+
+    #[test]
+    fn expedition_seats_have_independent_keyboard_pad_and_disconnect_controls() {
+        let pads = Rc::new(RefCell::new(GamepadInput::default()));
+        let mut input = ClientInput::new(Rc::clone(&pads));
+        let settings = Settings {
+            surface_expedition: engine_common::SurfaceExpeditionSettings {
+                players: engine_common::SurfaceExpeditionPlayers::Two,
+            },
+            ..Settings::default()
+        };
+        let scenario = EXPEDITION_REGISTRATION
+            .create(
+                0,
+                &settings,
+                Viewport::new(1280.0, 720.0),
+                ScenarioStartMode::Normal,
+            )
+            .unwrap();
+        input.press(GameKey::P2TurnLeft);
+        input.press(GameKey::P2Thrust);
+        input.press(GameKey::P2Reverse);
+        let actions = scenario.map_input(&mut input, false);
+        assert_eq!(actions.len(), 2);
+        assert_eq!(
+            SurfaceSortieAction::decode(&actions[0]),
+            Some((PlayerId::PLAYER_1, SurfaceSortieAction::default()))
+        );
+        assert_eq!(
+            SurfaceSortieAction::decode(&actions[1]),
+            Some((
+                PlayerId::PLAYER_2,
+                SurfaceSortieAction {
+                    horizontal: -1.0,
+                    primary_held: true,
+                    interact_held: true,
+                    brake_held: false,
+                }
+            ))
+        );
+        input.release(GameKey::P2TurnLeft);
+        input.release(GameKey::P2Thrust);
+        input.release(GameKey::P2Reverse);
+        pads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                dpad_right: true,
+                ..GamepadSeatInput::default()
+            },
+        );
+        pads.borrow_mut().set_seat(
+            1,
+            GamepadSeatInput {
+                connected: true,
+                dpad_left: true,
+                dpad_down: true,
+                south: true,
+                east: true,
+                ..GamepadSeatInput::default()
+            },
+        );
+        let actions = scenario.map_input(&mut input, false);
+        assert_eq!(
+            SurfaceSortieAction::decode(&actions[0])
+                .unwrap()
+                .1
+                .horizontal,
+            1.0
+        );
+        assert_eq!(
+            SurfaceSortieAction::decode(&actions[1]).unwrap().1,
+            SurfaceSortieAction {
+                horizontal: -1.0,
+                primary_held: true,
+                interact_held: true,
+                brake_held: true,
+            }
+        );
+        pads.borrow_mut().disconnect_seat(1);
+        let actions = scenario.map_input(&mut input, false);
+        assert_eq!(
+            SurfaceSortieAction::decode(&actions[1]).unwrap().1,
+            SurfaceSortieAction::default()
+        );
+        assert_eq!(
+            SurfaceSortieAction::decode(&actions[0])
+                .unwrap()
+                .1
+                .horizontal,
+            1.0
+        );
+        let solo = EXPEDITION_REGISTRATION
+            .create(
+                0,
+                &Settings::default(),
+                Viewport::new(1280.0, 720.0),
+                ScenarioStartMode::Normal,
+            )
+            .unwrap();
+        assert_eq!(solo.map_input(&mut input, false).len(), 1);
+        let fixture = REGISTRATION
+            .create(
+                0,
+                &settings,
+                Viewport::new(1280.0, 720.0),
+                ScenarioStartMode::Normal,
+            )
+            .unwrap();
+        assert_eq!(
+            fixture.map_input(&mut input, false).len(),
+            1,
+            "Expedition settings cannot change the pinned labs"
+        );
+    }
+
+    #[test]
+    fn expedition_two_player_frames_have_separate_cameras_maps_and_readable_huds() {
+        let mut scenario = SurfaceSortieClientScenario {
+            state: SurfaceSortieScenario::init_expedition(0, 2),
+        };
+        for _ in 0..120 {
+            scenario.step(&[], Duration::from_secs_f64(1.0 / 60.0));
+        }
+        for on_foot in [false, true] {
+            if on_foot {
+                scenario.step(
+                    &[PlayerId::PLAYER_1, PlayerId::PLAYER_2].map(|player| {
+                        SurfaceSortieAction {
+                            interact_held: true,
+                            ..Default::default()
+                        }
+                        .encode(player)
+                    }),
+                    Duration::from_secs_f64(1.0 / 60.0),
+                );
+                for player in 0..2 {
+                    assert_eq!(
+                        scenario.state.location(player),
+                        scenario_spacewars::surface_sortie::PilotLocation::OnFoot
+                    );
+                }
+            }
+            for viewport in [Viewport::new(1280.0, 720.0), Viewport::new(800.0, 1280.0)] {
+                let frames = scenario.render_frames(RenderBackend::Vector, viewport);
+                assert_eq!(frames.len(), 4);
+                assert_ne!(frames[0].camera.center, frames[1].camera.center);
+                let layout = scenario.frame_layout();
+                let panes = crate::render::frame_viewports(viewport, 4, layout);
+                assert_eq!(panes[0].width, viewport.width / 2.0);
+                assert_eq!(panes[1].x, viewport.width / 2.0);
+                for player in 0..2 {
+                    assert!(panes[player + 2].x >= panes[player].x);
+                    assert!(
+                        panes[player + 2].x + panes[player + 2].width
+                            <= panes[player].x + panes[player].width
+                    );
+                    let footprint = frames[player + 2]
+                        .ordered_layers()
+                        .into_iter()
+                        .find(|layer| layer.z == 0)
+                        .unwrap();
+                    let engine_common::RenderPrimitive::Polygon(polygon) = &footprint.primitives[0]
+                    else {
+                        panic!("camera footprint");
+                    };
+                    let width = polygon.points[1].x - polygon.points[0].x;
+                    assert!(
+                        (width - frames[player].camera.height * panes[player].aspect_ratio()).abs()
+                            < 0.001
+                    );
+                }
+                let presentation = crate::render::scene_presentation_from_frames_with_layout(
+                    &frames, viewport, layout,
+                );
+                assert_eq!(presentation.minimaps.len(), 2);
+                assert!(
+                    presentation
+                        .minimaps
+                        .iter()
+                        .all(|map| !map.primitives.is_empty())
+                );
+                let overlay = crate::render::raster_text_overlay(&frames, viewport, layout);
+                for player in 0..2 {
+                    let label = format!(
+                        "P{}  {}",
+                        player + 1,
+                        if on_foot { "ON FOOT" } else { "ABOARD" }
+                    );
+                    assert!(
+                        overlay
+                            .iter()
+                            .any(|primitive| primitive.text.starts_with(&label))
+                    );
+                }
+                let image = crate::raster::RasterRenderer::new().image_from_frames_with_layout(
+                    &frames,
+                    viewport,
+                    layout,
+                    crate::raster::RasterOptions::default(),
+                );
+                let pixels = image.to_rgb8().unwrap();
+                for player in 0..2 {
+                    let count = pixels
+                        .as_slice()
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, pixel)| {
+                            let x = i % pixels.width() as usize;
+                            let y = i / pixels.width() as usize;
+                            let own_color = if player == 0 {
+                                pixel.r > 200 && pixel.g < 80
+                            } else {
+                                pixel.g > 200 && pixel.r < 80
+                            };
+                            x / (pixels.width() as usize / 2) == player
+                                && y > pixels.height() as usize / 3
+                                && y < pixels.height() as usize * 3 / 4
+                                && own_color
+                                && pixel.b < 80
+                        })
+                        .count();
+                    assert!(
+                        count > 100,
+                        "player {player} geometry missing at {viewport:?}: {count}"
+                    );
+                }
+                if let Some(directory) = std::env::var_os("SPACEWARS_SORTIE_ARTIFACTS") {
+                    let directory = std::path::PathBuf::from(directory);
+                    std::fs::create_dir_all(&directory).unwrap();
+                    let file = std::fs::File::create(directory.join(format!(
+                        "expedition-pair-{}-foot-{on_foot}.png",
+                        viewport.width
+                    )))
+                    .unwrap();
+                    let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
+                    encoder.set_color(png::ColorType::Rgb);
+                    encoder.set_depth(png::BitDepth::Eight);
+                    encoder
+                        .write_header()
+                        .unwrap()
+                        .write_image_data(pixels.as_bytes())
+                        .unwrap();
+                }
+            }
+        }
+    }
 
     #[test]
     fn generated_diagnostic_is_selectable_reproducible_and_renders_the_whole_world() {
@@ -194,7 +480,7 @@ mod tests {
             assert_eq!(scenario.registration().id, "surface-sortie-generated");
             for _ in 0..60 {
                 scenario.step(
-                    &[SurfaceSortieAction::default().encode()],
+                    &[SurfaceSortieAction::default().encode(PlayerId::PLAYER_1)],
                     Duration::from_secs_f64(1.0 / 60.0),
                 );
             }
@@ -203,7 +489,7 @@ mod tests {
                 .downcast_ref::<SurfaceSortieClientScenario>()
                 .unwrap();
             assert_eq!(
-                scenario.state.observation().generated_case,
+                scenario.state.observation(0).generated_case,
                 Some(GeneratedSurfaceCase::new(seed, 0, 0))
             );
             let mut replay = SurfaceSortieClientScenario {
@@ -211,11 +497,11 @@ mod tests {
             };
             for _ in 0..60 {
                 replay.step(
-                    &[SurfaceSortieAction::default().encode()],
+                    &[SurfaceSortieAction::default().encode(PlayerId::PLAYER_1)],
                     Duration::from_secs_f64(1.0 / 60.0),
                 );
             }
-            assert_eq!(scenario.state.observation(), replay.state.observation());
+            assert_eq!(scenario.state.observation(0), replay.state.observation(0));
             for viewport in [Viewport::new(1280.0, 720.0), Viewport::new(1280.0, 1400.0)] {
                 let frames = scenario.render_frames(RenderBackend::Vector, viewport);
                 assert_eq!(
@@ -282,7 +568,7 @@ mod tests {
         pads.borrow_mut().set_seat(0, GamepadSeatInput::default());
         assert_eq!(
             scenario.map_input(&mut input, false),
-            vec![SurfaceSortieAction::default().encode()]
+            vec![SurfaceSortieAction::default().encode(PlayerId::PLAYER_1)]
         );
     }
 
@@ -295,7 +581,6 @@ mod tests {
         ]
         .map(|preset| SurfaceSortieScenario::init(preset, 0))
         .into_iter()
-        .chain([SurfaceSortieScenario::init_expedition(0)])
         {
             let mut scenario = SurfaceSortieClientScenario { state };
             let dt = Duration::from_secs_f64(1.0 / 60.0);
@@ -305,15 +590,15 @@ mod tests {
                         interact_held: frame == 60,
                         ..SurfaceSortieAction::default()
                     }
-                    .encode()],
+                    .encode(PlayerId::PLAYER_1)],
                     dt,
                 );
             }
             for _ in 0..600 {
-                let observation = scenario.state.observation();
+                let observation = scenario.state.observation(0);
                 if observation
                     .position
-                    .distance_to(observation.outpost.position)
+                    .distance_to(observation.outpost.as_ref().unwrap().position)
                     < 2.35
                 {
                     break;
@@ -323,53 +608,32 @@ mod tests {
                         horizontal: 1.0,
                         ..SurfaceSortieAction::default()
                     }
-                    .encode()],
+                    .encode(PlayerId::PLAYER_1)],
                     dt,
                 );
             }
             for _ in 0..60 {
-                scenario.step(&[SurfaceSortieAction::default().encode()], dt);
+                scenario.step(
+                    &[SurfaceSortieAction::default().encode(PlayerId::PLAYER_1)],
+                    dt,
+                );
             }
-            let partial = scenario.state.observation().outpost;
+            let partial = scenario.state.observation(0).outpost.unwrap();
             assert!(partial.capture_progress > 0.0 && partial.capture_progress < 1.0);
             let viewport = Viewport::new(1280.0, 720.0);
             check_render(&scenario, viewport, "on-foot-capturing");
             for _ in 0..180 {
-                scenario.step(&[SurfaceSortieAction::default().encode()], dt);
-            }
-            let observation = scenario.state.observation();
-            assert_eq!(observation.outpost.owner, Some(observation.owner));
-            assert!(observation.outpost.repaired_health > 0.0);
-            if scenario.state.travel_enabled() {
-                assert!(
-                    observation.outposts[1..]
-                        .iter()
-                        .all(|post| post.owner.is_none())
+                scenario.step(
+                    &[SurfaceSortieAction::default().encode(PlayerId::PLAYER_1)],
+                    dt,
                 );
-                let map = SurfaceSortieScenario::minimap_frame(&scenario.state, 16.0 / 9.0);
-                let sites = map
-                    .ordered_layers()
-                    .into_iter()
-                    .find(|layer| layer.z == 1)
-                    .unwrap();
-                let fills = sites
-                    .primitives
-                    .iter()
-                    .filter_map(|primitive| {
-                        if let engine_common::RenderPrimitive::Polygon(polygon) = primitive {
-                            polygon.fill.map(|fill| fill.color)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                assert_eq!(fills.len(), observation.outposts.len());
-                assert_ne!(
-                    fills[0], fills[1],
-                    "capturing one site must not recolor every site"
-                );
-                assert!(fills[1..].iter().all(|fill| *fill == fills[1]));
             }
+            let observation = scenario.state.observation(0);
+            assert_eq!(
+                observation.outpost.as_ref().unwrap().owner,
+                Some(observation.owner)
+            );
+            assert!(observation.outpost.as_ref().unwrap().repaired_health > 0.0);
             for viewport in [viewport, Viewport::new(1280.0, 1400.0)] {
                 let frames = scenario.render_frames(RenderBackend::Vector, viewport);
                 assert_eq!(
@@ -395,8 +659,8 @@ mod tests {
                 };
                 check_render(&scenario, viewport, name);
                 // Check the actual owner-colored flag, not just a text/model entry.
-                let up = observation.outpost.surface_normal;
-                let flag = observation.outpost.position
+                let up = observation.outpost.as_ref().unwrap().surface_normal;
+                let flag = observation.outpost.as_ref().unwrap().position
                     + up * 3.15
                     + engine_core::Vec2::new(up.y, -up.x) * 1.3;
                 let projected = frames[0].camera.world_to_viewport(
@@ -422,6 +686,150 @@ mod tests {
     }
 
     #[test]
+    fn expedition_flags_and_planet_ownership_render_without_outposts() {
+        use engine_common::{RenderColor, RenderPrimitive};
+        use scenario_spacewars::surface_sortie::PlanetClaimPhase;
+        let dt = Duration::from_secs_f64(1.0 / 60.0);
+        for players in [1, 2] {
+            let mut scenario = SurfaceSortieClientScenario {
+                state: SurfaceSortieScenario::init_expedition(0, players),
+            };
+            for _ in 0..120 {
+                scenario.step(&[], dt);
+            }
+            scenario.step(
+                &[SurfaceSortieAction {
+                    interact_held: true,
+                    ..Default::default()
+                }
+                .encode(PlayerId::PLAYER_1)],
+                dt,
+            );
+            for secured in [false, true] {
+                for _ in 0..if secured { 180 } else { 90 } {
+                    scenario.step(
+                        &[SurfaceSortieAction::default().encode(PlayerId::PLAYER_1)],
+                        dt,
+                    );
+                }
+                let observation = scenario.state.observation(0);
+                assert!(observation.outposts.is_empty());
+                assert!(observation.outpost.is_none());
+                let claim = observation.planet_claim.as_ref().unwrap();
+                let flag = claim.flag.unwrap();
+                assert_eq!(claim.owner, secured.then_some(PlayerId::PLAYER_1));
+                assert_eq!(
+                    claim.phase,
+                    if secured {
+                        PlanetClaimPhase::Idle
+                    } else {
+                        PlanetClaimPhase::Raising
+                    }
+                );
+                if !secured {
+                    assert!(flag.raised_fraction > 0.25 && flag.raised_fraction < 1.0);
+                }
+                for viewport in [
+                    Viewport::new(1280.0, 720.0),
+                    Viewport::new(800.0, 480.0),
+                    Viewport::new(800.0, 1280.0),
+                ] {
+                    let frames = scenario.render_frames(RenderBackend::Vector, viewport);
+                    assert_eq!(
+                        frames,
+                        scenario.render_frames(RenderBackend::Raster, viewport)
+                    );
+                    let layout = scenario.frame_layout();
+                    let panes = crate::render::frame_viewports(viewport, frames.len(), layout);
+                    let presentation = crate::render::scene_presentation_from_frames_with_layout(
+                        &frames, viewport, layout,
+                    );
+                    assert_eq!(presentation.minimaps.len(), players);
+                    let overlay = crate::render::raster_text_overlay(&frames, viewport, layout);
+                    assert!(overlay.iter().any(|p| p.text
+                        == if secured {
+                            "Planet 0: P1".to_owned()
+                        } else {
+                            format!("Planet 0: Neutral / raising {:.0}%", claim.progress * 100.0)
+                        }));
+                    assert!(
+                        overlay
+                            .iter()
+                            .all(|p| !p.text.to_lowercase().contains("terminal")
+                                && !p.text.to_lowercase().contains("repair"))
+                    );
+                    // Both overviews agree: only the claimed planet changes color.
+                    for map in &frames[players..] {
+                        let planets = map
+                            .ordered_layers()
+                            .into_iter()
+                            .find(|layer| layer.z == -10)
+                            .unwrap();
+                        assert_eq!(planets.primitives.len(), observation.planet_claims.len());
+                        for (planet, primitive) in planets.primitives.iter().enumerate() {
+                            let RenderPrimitive::Circle(circle) = primitive else {
+                                panic!("planet circle");
+                            };
+                            let color = circle.fill.unwrap().color;
+                            if secured && planet == 0 {
+                                assert_eq!(color, RenderColor::rgb(1.0, 0.0, 0.0));
+                            } else {
+                                assert_eq!(color, RenderColor::rgb(0.25, 0.93, 0.8));
+                            }
+                        }
+                        let markers = map
+                            .ordered_layers()
+                            .into_iter()
+                            .find(|layer| layer.z == 2)
+                            .unwrap();
+                        assert!(markers.primitives.iter().any(|p| matches!(p, RenderPrimitive::Polygon(polygon) if polygon.points.len() == 3 && polygon.fill.unwrap().color == RenderColor::rgb(1.0, 0.0, 0.0))));
+                    }
+                    let image = crate::raster::RasterRenderer::new().image_from_frames_with_layout(
+                        &frames,
+                        viewport,
+                        layout,
+                        crate::raster::RasterOptions::default(),
+                    );
+                    let pixels = image.to_rgb8().unwrap();
+                    // Sample inside the actual flag cloth, above the spaceling.
+                    let up = flag.normal;
+                    let point = flag.position
+                        + up * (0.45 + flag.raised_fraction * 2.7)
+                        + engine_core::Vec2::new(up.y, -up.x) * 0.6;
+                    let projected = frames[0].camera.world_to_viewport(
+                        engine_common::RenderPoint::new(point.x, point.y),
+                        panes[0].aspect_ratio(),
+                    );
+                    let x = (panes[0].x + projected.x * panes[0].width) as usize;
+                    let y = (panes[0].y + projected.y * panes[0].height) as usize;
+                    let pixel = pixels.as_slice()[y * pixels.width() as usize + x];
+                    assert!(
+                        pixel.r > 200 && pixel.g < 80 && pixel.b < 80,
+                        "missing flag cloth: players={players} secured={secured} viewport={viewport:?} {pixel:?}"
+                    );
+                    if let Some(directory) = std::env::var_os("SPACEWARS_SORTIE_ARTIFACTS") {
+                        let directory = std::path::PathBuf::from(directory);
+                        std::fs::create_dir_all(&directory).unwrap();
+                        let file = std::fs::File::create(directory.join(format!(
+                            "planet-claim-p{players}-secured-{secured}-{}x{}.png",
+                            viewport.width, viewport.height
+                        )))
+                        .unwrap();
+                        let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
+                        encoder.set_color(png::ColorType::Rgb);
+                        encoder.set_depth(png::BitDepth::Eight);
+                        encoder
+                            .write_header()
+                            .unwrap()
+                            .write_image_data(pixels.as_bytes())
+                            .unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn registered_fixture_renders_and_restarts_in_both_backends() {
         for registration in [
             &REGISTRATION,
@@ -440,7 +848,7 @@ mod tests {
                         interact_held: tick == 60,
                         ..SurfaceSortieAction::default()
                     }
-                    .encode()],
+                    .encode(PlayerId::PLAYER_1)],
                     Duration::from_secs_f64(1.0 / 60.0),
                 );
                 if tick == 59 {
@@ -466,7 +874,7 @@ mod tests {
                     .downcast_ref::<SurfaceSortieClientScenario>()
                     .unwrap()
                     .state
-                    .location(),
+                    .location(0),
                 scenario_spacewars::surface_sortie::PilotLocation::OnFoot
             ));
             let fresh = registration
@@ -497,7 +905,12 @@ mod tests {
         } else {
             "ABOARD"
         };
-        assert!(overlay.iter().any(|p| p.text.starts_with(label)));
+        let label = if scenario.registration().id == "surface-expedition" {
+            format!("P1  {label}")
+        } else {
+            label.to_owned()
+        };
+        assert!(overlay.iter().any(|p| p.text.starts_with(&label)));
         let image = RasterRenderer::new().image_from_frames_with_layout(
             &frames,
             viewport,
@@ -541,7 +954,7 @@ mod tests {
                 .downcast_ref::<SurfaceSortieClientScenario>()
                 .unwrap()
                 .state
-                .observation()
+                .observation(0)
                 .position;
             let projected = frames[0].camera.world_to_viewport(
                 engine_common::RenderPoint::new(position.x, position.y),

--- a/crates/engine-client/src/client_scenarios/surface_sortie.rs
+++ b/crates/engine-client/src/client_scenarios/surface_sortie.rs
@@ -56,7 +56,11 @@ pub(super) const WORLD_REGISTRATION: ScenarioRegistration = ScenarioRegistration
 
 pub(super) const EXPEDITION_REGISTRATION: ScenarioRegistration = ScenarioRegistration {
     id: "surface-expedition",
-    controls_help: "Surface Expedition: land rear-first, B / X to get out, then stand still on the surface for 3 seconds to claim a neutral planet. Your flag is planted where you stand. An existing enemy flag must be approached (within 3 units) and lowered for 3 seconds before your own flag can rise for another 3 seconds. Opponents near the flag pause progress. Leaving, jumping or losing balance resets the unfinished stage; a fully lowered flag leaves the planet neutral. Minimap colors show planet ownership and triangles locate flags. A / Space thrusts or jumps; left/right turns or walks; Down / S brakes; B / X boards your own landed ship at the cyan hatch. Choose 1 or 2 players in Settings. P2 keyboard: numpad 4/6 turns/walks, 8 thrusts/jumps, 5 brakes, 2 boards/exits. Each assigned gamepad controls its own pilot; release controls after a transfer. Start / Esc pauses; R restarts. Ships start at full health. No outposts, repair, weapons, rescue or rebuilding; ordinary Spacewars is unchanged.",
+    controls_help: concat!(
+        "Surface Expedition: land rear-first, B / X to get out, then stand still on the surface for 3 seconds to claim a neutral planet. Your flag is planted where you stand. An existing enemy flag must be approached (within 3 units) and lowered for 3 seconds before your own flag can rise for another 3 seconds. Opponents near the flag pause progress. Leaving, jumping or losing balance resets the unfinished stage; a fully lowered flag leaves the planet neutral. Minimap colors show planet ownership and triangles locate flags. ",
+        "A / Space thrusts or jumps; left/right turns or walks; Down / S brakes; B / X boards your own landed ship or pod at the cyan hatch. Choose 1 or 2 players in Settings. P2 keyboard: numpad 4/6 turns/walks, 8 thrusts/jumps, 5 brakes, 2 boards/exits. Each assigned gamepad controls its own pilot; release controls after transfers and vehicle loss/replacement. Start / Esc pauses; R restarts. ",
+        "Loss drill: hold A+B+Down (Space+X+S; P2 numpad 8+2+5) for 3 seconds to destroy your assigned full ship; release early to cancel. An occupied ship leaves a flyable pod; an empty ship leaves the existing spaceling alive, not an empty pod. Land the pod rear-first and exit, even on a neutral planet. With no full ship, stand still on an owned planet for 8 seconds to rebuild nearby; no outpost or flag proximity is required. Losing support, balance or ownership resets progress. If space is blocked, move to another clear spot. Board the replacement normally after it settles. Ships start at full health; pods and spacelings remain invulnerable in this lab. No outposts, repair, weapons, ship swapping or remote rescue; ordinary Spacewars is unchanged."
+    ),
     create: create_expedition,
     ..REGISTRATION
 };
@@ -824,6 +828,160 @@ mod tests {
                             .write_image_data(pixels.as_bytes())
                             .unwrap();
                     }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn expedition_recovery_is_playable_with_the_minimal_pad_and_visible_in_both_backends() {
+        use scenario_spacewars::ShipForm;
+        use scenario_spacewars::surface_sortie::{LandingPhase, PilotLocation};
+        let mut scenario = SurfaceSortieClientScenario {
+            state: SurfaceSortieScenario::init_expedition(0, 2),
+        };
+        let pads = Rc::new(RefCell::new(GamepadInput::default()));
+        let mut input = ClientInput::new(Rc::clone(&pads));
+        let advance =
+            |scenario: &mut SurfaceSortieClientScenario, input: &mut ClientInput, ticks| {
+                for _ in 0..ticks {
+                    let actions = scenario.map_input(input, false);
+                    scenario.step(&actions, Duration::from_secs_f64(1.0 / 60.0));
+                }
+            };
+        advance(&mut scenario, &mut input, 120);
+        pads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                south: true,
+                east: true,
+                dpad_down: true,
+                ..Default::default()
+            },
+        );
+        advance(&mut scenario, &mut input, 181);
+        assert_eq!(
+            scenario.state.observation(0).vehicle_form,
+            ShipForm::EscapePod
+        );
+        assert!(scenario.state.observation(1).ship_available);
+        pads.borrow_mut().set_seat(
+            0,
+            GamepadSeatInput {
+                connected: true,
+                ..Default::default()
+            },
+        );
+        advance(&mut scenario, &mut input, 300);
+        assert_eq!(
+            scenario.state.observation(0).landing.phase,
+            LandingPhase::Landed
+        );
+        for stage in ["pod", "rebuilding", "replacement"] {
+            if stage == "rebuilding" {
+                pads.borrow_mut().set_seat(
+                    0,
+                    GamepadSeatInput {
+                        connected: true,
+                        east: true,
+                        ..Default::default()
+                    },
+                );
+                advance(&mut scenario, &mut input, 1);
+                pads.borrow_mut().set_seat(
+                    0,
+                    GamepadSeatInput {
+                        connected: true,
+                        ..Default::default()
+                    },
+                );
+                advance(&mut scenario, &mut input, 400);
+                assert_eq!(
+                    scenario.state.observation(0).location,
+                    PilotLocation::OnFoot
+                );
+                let progress = scenario
+                    .state
+                    .observation(0)
+                    .recovery
+                    .unwrap()
+                    .rebuild_progress;
+                assert!(progress > 0.1 && progress < 0.9, "{progress}");
+            } else if stage == "replacement" {
+                advance(&mut scenario, &mut input, 500);
+                assert!(scenario.state.observation(0).ship_available);
+                assert_eq!(scenario.state.observation(0).recovery.unwrap().rebuilds, 1);
+            }
+            for viewport in [
+                Viewport::new(1280.0, 720.0),
+                Viewport::new(800.0, 480.0),
+                Viewport::new(800.0, 1280.0),
+            ] {
+                let frames = scenario.render_frames(RenderBackend::Raster, viewport);
+                assert_eq!(
+                    frames,
+                    scenario.render_frames(RenderBackend::Vector, viewport)
+                );
+                let presentation = crate::render::scene_presentation_from_frames_with_layout(
+                    &frames,
+                    viewport,
+                    scenario.frame_layout(),
+                );
+                assert_eq!(presentation.minimaps.len(), 2);
+                let labels =
+                    crate::render::raster_text_overlay(&frames, viewport, scenario.frame_layout());
+                assert!(labels.iter().any(|p| p.text.starts_with(if stage == "pod" {
+                    "P1  POD"
+                } else {
+                    "P1  ON FOOT"
+                })));
+                assert!(labels.iter().any(|p| p.text.starts_with("P2  ABOARD")));
+                assert!(
+                    !labels
+                        .iter()
+                        .any(|p| p.text.contains("Vehicle lost; restart"))
+                );
+                if stage == "rebuilding" {
+                    assert!(labels.iter().any(|p| p.text.starts_with("Rebuild ")));
+                }
+                let image = crate::raster::RasterRenderer::new().image_from_frames_with_layout(
+                    &frames,
+                    viewport,
+                    scenario.frame_layout(),
+                    crate::raster::RasterOptions::default(),
+                );
+                let pixels = image.to_rgb8().unwrap();
+                assert!(
+                    pixels
+                        .as_slice()
+                        .iter()
+                        .filter(|p| if stage == "pod" {
+                            // The existing pod mesh has a blue cockpit/nose.
+                            p.b > 200 && p.r < 80 && p.g < 80
+                        } else {
+                            p.r > 200 && p.g < 80 && p.b < 80
+                        })
+                        .count()
+                        > 20,
+                    "missing P1 actor: {stage} {viewport:?}"
+                );
+                if let Some(directory) = std::env::var_os("SPACEWARS_SORTIE_ARTIFACTS") {
+                    let directory = std::path::PathBuf::from(directory);
+                    std::fs::create_dir_all(&directory).unwrap();
+                    let file = std::fs::File::create(directory.join(format!(
+                        "recovery-{stage}-{}x{}.png",
+                        viewport.width, viewport.height
+                    )))
+                    .unwrap();
+                    let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
+                    encoder.set_color(png::ColorType::Rgb);
+                    encoder.set_depth(png::BitDepth::Eight);
+                    encoder
+                        .write_header()
+                        .unwrap()
+                        .write_image_data(pixels.as_bytes())
+                        .unwrap();
                 }
             }
         }

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -282,9 +282,9 @@ impl ClientInput {
         (throttle, brake, gamepad.south)
     }
 
-    pub(crate) fn spaceling_gamepad_input(&self) -> (f32, bool, bool) {
+    pub(crate) fn spaceling_gamepad_input(&self, player: usize) -> (f32, bool, bool) {
         let gamepads = self.gamepads.borrow();
-        let Some(gamepad) = gamepads.seat(0).filter(|gamepad| gamepad.connected) else {
+        let Some(gamepad) = gamepads.seat(player).filter(|gamepad| gamepad.connected) else {
             return (0.0, false, false);
         };
         let walk = match (gamepad.dpad_left, gamepad.dpad_right) {
@@ -296,14 +296,16 @@ impl ClientInput {
         (walk, gamepad.south, gamepad.east)
     }
 
-    pub(crate) fn surface_sortie_brake_held(&self) -> bool {
-        self.is_pressed(GameKey::P1Brake)
-            || self.is_pressed(GameKey::NesDown)
-            || self
-                .gamepads
-                .borrow()
-                .seat(0)
-                .is_some_and(|pad| pad.connected && pad.dpad_down)
+    pub(crate) fn surface_sortie_brake_held(&self, player: usize) -> bool {
+        (if player == 0 {
+            self.is_pressed(GameKey::P1Brake) || self.is_pressed(GameKey::NesDown)
+        } else {
+            self.is_pressed(GameKey::P2Brake)
+        }) || self
+            .gamepads
+            .borrow()
+            .seat(player)
+            .is_some_and(|pad| pad.connected && pad.dpad_down)
     }
 
     pub(crate) fn nes_controller_buttons(&self, player: usize) -> ControllerButtons {

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -782,6 +782,7 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
             spacewars_player_2: window.get_launcher_p2_controller().to_string(),
             pizza_desired_balls: window.get_launcher_pizza_desired_balls_text().to_string(),
             pizza_spawn_rate: window.get_launcher_pizza_spawn_rate_text().to_string(),
+            expedition_players: window.get_launcher_expedition_players().to_string(),
             clock_time_format: window.get_launcher_clock_time_format().to_string(),
             clock_event_profile: window.get_launcher_clock_event_profile().to_string(),
             clock_falling_enabled: window.get_launcher_clock_falling_enabled(),

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -592,6 +592,9 @@ fn show_launcher(
     window.set_launcher_raster_scale_text(SharedString::from(format_raster_scale(
         launch.raster_scale,
     )));
+    window.set_launcher_expedition_players(SharedString::from(
+        settings.surface_expedition.players.count().to_string(),
+    ));
     let setup = settings.spacewars.normalized();
     window.set_launcher_spacewars_preset(SharedString::from(preset_label_for_setup(&setup)));
     window.set_launcher_universe_radius_text(SharedString::from(setup.universe_radius.to_string()));
@@ -1191,6 +1194,7 @@ fn launcher_settings_item_count(window: &MainWindow) -> i32 {
         "clock" => 7,
         "falling" => 1,
         "nes" => 2,
+        "surface-expedition" => 4,
         _ => 3,
     }
 }
@@ -1226,6 +1230,14 @@ fn adjust_launcher_setting(window: &MainWindow, delta: i32) {
     }
 
     match window.get_launcher_scenario().as_str() {
+        "surface-expedition" if focus == 2 => {
+            let next = cycle_label(
+                window.get_launcher_expedition_players().as_str(),
+                &["1", "2"],
+                delta,
+            );
+            window.set_launcher_expedition_players(SharedString::from(next));
+        }
         "spacewars" => adjust_spacewars_launcher_setting(window, focus, delta),
         "pizza" => adjust_pizza_launcher_setting(window, focus, delta),
         "clock" => adjust_clock_launcher_setting(window, focus, delta),
@@ -1547,6 +1559,7 @@ struct LauncherSelections {
     clock: ClockSettings,
     spacewars: SpacewarsSettings,
     pizza: PizzaSettings,
+    surface_expedition: engine_common::SurfaceExpeditionSettings,
 }
 
 fn persist_launcher_settings(
@@ -1594,6 +1607,10 @@ fn persist_launcher_settings(
     }
     if settings.spacewars != spacewars {
         settings.spacewars = spacewars;
+        changed = true;
+    }
+    if settings.surface_expedition != selections.surface_expedition {
+        settings.surface_expedition = selections.surface_expedition;
         changed = true;
     }
     if settings.pizza != pizza {
@@ -1765,7 +1782,19 @@ fn launcher_selections_from_window(
     } else {
         current_settings.nes.selected_rom_id.clone()
     };
+    let surface_expedition = if launch.scenario == "surface-expedition" {
+        engine_common::SurfaceExpeditionSettings {
+            players: match window.get_launcher_expedition_players().as_str() {
+                "1" => engine_common::SurfaceExpeditionPlayers::One,
+                "2" => engine_common::SurfaceExpeditionPlayers::Two,
+                _ => return Err("Expedition needs one or two players.".to_owned()),
+            },
+        }
+    } else {
+        current_settings.surface_expedition
+    };
     Ok(LauncherSelections {
+        surface_expedition,
         launch,
         nes_rom_id,
         clock,
@@ -2586,6 +2615,9 @@ mod tests {
         let path = dir.path().join("settings.toml");
         let settings = Arc::new(RwLock::new(Settings::default()));
         let selections = LauncherSelections {
+            surface_expedition: engine_common::SurfaceExpeditionSettings {
+                players: engine_common::SurfaceExpeditionPlayers::Two,
+            },
             launch: EffectiveLaunch {
                 scenario: "spacewars".into(),
                 seed: 123,
@@ -2638,6 +2670,10 @@ mod tests {
         assert_eq!(reloaded.settings.launch.renderer, RendererSetting::Raster);
         assert_eq!(reloaded.settings.launch.raster_scale, 2.0);
         assert_eq!(reloaded.settings.spacewars, selections.spacewars);
+        assert_eq!(
+            reloaded.settings.surface_expedition,
+            selections.surface_expedition
+        );
         assert_eq!(reloaded.settings.pizza, selections.pizza);
         assert_eq!(reloaded.settings.clock, selections.clock);
         assert_eq!(

--- a/crates/engine-client/src/raster.rs
+++ b/crates/engine-client/src/raster.rs
@@ -216,19 +216,29 @@ impl RasterRenderer {
                     starfield_cache,
                     &mut timings,
                 );
-            } else if layout == FrameLayout::SinglePlayerWithMinimap && frames.len() == 2 {
-                let viewports =
-                    render::frame_viewports(Viewport::new(width as f32, height as f32), 2, layout);
-                let started = Instant::now();
-                canvas.draw_frame(&frames[0], viewports[0]);
-                timings.other_frames += started.elapsed();
-                draw_uncached_overview(
-                    &mut canvas,
-                    &frames[1],
-                    viewports[1],
-                    overview_buffers,
-                    &mut timings,
+            } else if layout == FrameLayout::PlayerViewsWithMinimaps
+                && matches!(frames.len(), 2 | 4)
+            {
+                let viewports = render::frame_viewports(
+                    Viewport::new(width as f32, height as f32),
+                    frames.len(),
+                    layout,
                 );
+                let players = frames.len() / 2;
+                let started = Instant::now();
+                for player in 0..players {
+                    canvas.draw_frame(&frames[player], viewports[player]);
+                }
+                timings.other_frames += started.elapsed();
+                for player in 0..players {
+                    draw_uncached_overview(
+                        &mut canvas,
+                        &frames[players + player],
+                        viewports[players + player],
+                        overview_buffers,
+                        &mut timings,
+                    );
+                }
             } else if !frames.is_empty() {
                 let viewports = render::frame_viewports(
                     Viewport::new(width as f32, height as f32),
@@ -2046,7 +2056,7 @@ mod tests {
         let mut minimap = RenderFrame::new(camera);
         let frames = [player.clone(), minimap.clone()];
         let viewport = Viewport::new(100.0, 100.0);
-        let layout = FrameLayout::SinglePlayerWithMinimap;
+        let layout = FrameLayout::PlayerViewsWithMinimaps;
         let pane = render::frame_viewports(viewport, 2, layout)[1];
         let x = (pane.x + pane.width * 0.5).round() as usize;
         let y = (pane.y + pane.height * 0.5).round() as usize;

--- a/crates/engine-client/src/render.rs
+++ b/crates/engine-client/src/render.rs
@@ -32,8 +32,8 @@ pub(crate) const MIN_SPACEWARS_OVERVIEW_OBJECT_DIAMETER: f32 = 2.0;
 pub enum FrameLayout {
     EqualHorizontal,
     SpacewarsLocalPlay,
-    /// One full-window camera with a translucent overview below the top HUD.
-    SinglePlayerWithMinimap,
+    /// One or two player cameras, followed by their translucent overview frames.
+    PlayerViewsWithMinimaps,
 }
 
 pub struct VectorPresentation {
@@ -156,7 +156,9 @@ pub fn scene_presentation_from_frames_with_layout(
     {
         let is_minimap = match layout {
             FrameLayout::SpacewarsLocalPlay => frames.len() >= 4 && (2..4).contains(&index),
-            FrameLayout::SinglePlayerWithMinimap => frames.len() == 2 && index == 1,
+            FrameLayout::PlayerViewsWithMinimaps => {
+                matches!(frames.len(), 2 | 4) && index >= frames.len() / 2
+            }
             FrameLayout::EqualHorizontal => false,
         };
         if is_minimap {
@@ -189,21 +191,28 @@ pub(crate) fn frame_viewports(
 ) -> Vec<Viewport> {
     match layout {
         FrameLayout::EqualHorizontal => viewport.split_horizontally(count),
-        FrameLayout::SinglePlayerWithMinimap => {
-            if count != 2 {
+        FrameLayout::PlayerViewsWithMinimaps => {
+            if !matches!(count, 2 | 4) {
                 return viewport.split_horizontally(count);
             }
-            let size = viewport.height.min(viewport.width) * 0.25;
-            let margin = (viewport.height * 0.02).clamp(4.0, 16.0).min(size * 0.2);
-            vec![
-                viewport,
-                Viewport::with_origin(
-                    viewport.x + viewport.width - size - margin,
-                    viewport.y + viewport.height * 0.25,
+            let players = count / 2;
+            let panes = viewport.split_horizontally(players);
+            let mut result = panes.clone();
+            for pane in panes {
+                let size = if players == 1 {
+                    pane.height.min(pane.width) * 0.25
+                } else {
+                    (pane.height * 0.25).min(pane.width * 0.4)
+                };
+                let margin = (pane.height * 0.02).clamp(4.0, 16.0).min(size * 0.2);
+                result.push(Viewport::with_origin(
+                    pane.x + pane.width - size - margin,
+                    pane.y + pane.height * 0.25,
                     size,
                     size,
-                ),
-            ]
+                ));
+            }
+            result
         }
         FrameLayout::SpacewarsLocalPlay => {
             if count < 4 {
@@ -277,8 +286,8 @@ pub(crate) fn raster_text_overlay(
         .iter()
         .zip(frame_viewports(viewport, frames.len(), layout))
         .take(
-            if layout == FrameLayout::SinglePlayerWithMinimap && frames.len() == 2 {
-                1
+            if layout == FrameLayout::PlayerViewsWithMinimaps && matches!(frames.len(), 2 | 4) {
+                frames.len() / 2
             } else {
                 frames.len()
             },
@@ -907,7 +916,7 @@ mod tests {
             Viewport::new(1280.0, 720.0),
             Viewport::with_origin(12.0, 20.0, 720.0, 1280.0),
         ] {
-            let layout = FrameLayout::SinglePlayerWithMinimap;
+            let layout = FrameLayout::PlayerViewsWithMinimaps;
             let panes = frame_viewports(viewport, 2, layout);
             assert_eq!(panes[0], viewport);
             let presentation =

--- a/crates/engine-client/src/settings.rs
+++ b/crates/engine-client/src/settings.rs
@@ -260,6 +260,30 @@ mod tests {
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
+    fn previous_settings_default_to_one_expedition_player_and_both_counts_round_trip() {
+        use engine_common::SurfaceExpeditionPlayers;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.toml");
+        fs::write(&path, "[launch]\nscenario = \"surface-expedition\"\n").unwrap();
+        let mut loaded = load_settings(&path).unwrap();
+        assert_eq!(loaded.status, LoadStatus::Migrated);
+        assert_eq!(loaded.settings.launch.scenario, "surface-expedition");
+        assert_eq!(
+            loaded.settings.surface_expedition.players,
+            SurfaceExpeditionPlayers::One
+        );
+        for players in [SurfaceExpeditionPlayers::Two, SurfaceExpeditionPlayers::One] {
+            loaded.settings.surface_expedition.players = players;
+            save_settings(&loaded.settings, &path).unwrap();
+            let reloaded = load_settings(&path).unwrap();
+            assert_eq!(reloaded.status, LoadStatus::Existing);
+            assert_eq!(reloaded.settings.surface_expedition.players, players);
+            assert_eq!(reloaded.settings.launch.scenario, "surface-expedition");
+        }
+    }
+
+    #[test]
     fn previous_clock_settings_default_to_calm_and_profiles_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("settings.toml");

--- a/crates/engine-client/src/ui_activation.rs
+++ b/crates/engine-client/src/ui_activation.rs
@@ -119,6 +119,7 @@ fn launcher_setting_target(control_id: &str) -> Option<ActivationTarget> {
         "launcher.settings.renderer" | "launcher.settings.nes.cartridge" => 0,
         "launcher.settings.raster-scale" => 1,
         "launcher.settings.spacewars.preset"
+        | "launcher.settings.expedition.players"
         | "launcher.settings.pizza.desired-balls"
         | "launcher.settings.clock.time-format" => 2,
         "launcher.settings.spacewars.planets"

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -56,6 +56,7 @@ pub(crate) struct UiInventoryContext {
     pub(crate) scenario_error: Option<String>,
     pub(crate) renderer: String,
     pub(crate) raster_scale: String,
+    pub(crate) expedition_players: String,
     pub(crate) spacewars_preset: String,
     pub(crate) spacewars_planets: String,
     pub(crate) spacewars_asteroids: String,
@@ -300,6 +301,29 @@ fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
                 "launcher.settings.clock.event-profile",
                 "launcher.settings.clock.falling",
                 "launcher.settings.clock.color-cycle",
+                "launcher.settings.back",
+            ]
+        }
+        "surface-expedition" => {
+            push_choice(
+                &mut controls,
+                "launcher.settings.renderer",
+                &context.renderer,
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.raster-scale",
+                &format!("{}×", context.raster_scale),
+            );
+            push_choice(
+                &mut controls,
+                "launcher.settings.expedition.players",
+                &context.expedition_players,
+            );
+            &[
+                "launcher.settings.renderer",
+                "launcher.settings.raster-scale",
+                "launcher.settings.expedition.players",
                 "launcher.settings.back",
             ]
         }
@@ -653,11 +677,17 @@ mod tests {
             ("rover-lab", 6, "launcher.settings.raster-scale"),
             ("falling", 2, "launcher.settings.back"),
             ("nes", 4, "launcher.settings.nes.cartridge"),
+            (
+                "surface-expedition",
+                8,
+                "launcher.settings.expedition.players",
+            ),
         ];
 
         for (scenario, control_count, selected) in cases {
             let mut context = context(scenario);
             context.launcher_settings_focus_index = match scenario {
+                "surface-expedition" => 2,
                 "spacewars" => 6,
                 "pizza" => 3,
                 "clock" => 5,

--- a/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
+++ b/crates/engine-client/tests/ui_control_functional/spaceling_lab.rs
@@ -56,16 +56,49 @@ fn surface_expedition_launch_pause_restart_and_both_renderers() {
     lab_lifecycle(
         "surface-expedition",
         "surface-expedition-lifecycle",
-        assert_raster_sortie_visible,
+        assert_raster_expedition_visible,
+    );
+}
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn surface_expedition_two_players_settings_and_lifecycle() {
+    lab_lifecycle_with_players(
+        "surface-expedition",
+        "surface-expedition-two-players",
+        assert_raster_pair_visible,
+        2,
     );
 }
 
 fn lab_lifecycle(scenario: &str, test_name: &'static str, assert_visible: fn(&Path)) {
+    lab_lifecycle_with_players(scenario, test_name, assert_visible, 1);
+}
+
+fn lab_lifecycle_with_players(
+    scenario: &str,
+    test_name: &'static str,
+    assert_visible: fn(&Path),
+    players: usize,
+) {
     run_functional_test(test_name, |harness| {
         let ready = harness.wait_until_ready();
         let mut state = harness.activate_until_scenario(scenario, ready);
         for renderer in ["vector", "raster"] {
             state = harness.activate_guarded("launcher.settings", &state);
+            if scenario == "surface-expedition" {
+                let expected = players.to_string();
+                if control_value(&state, "launcher.settings.expedition.players.next")
+                    != Some(expected.as_str())
+                {
+                    state = harness
+                        .activate_guarded("launcher.settings.expedition.players.next", &state);
+                }
+                assert_eq!(
+                    control_value(&state, "launcher.settings.expedition.players.next"),
+                    Some(expected.as_str())
+                );
+            }
             if control_value(&state, "launcher.settings.renderer.next") != Some(renderer) {
                 state = harness.activate_guarded("launcher.settings.renderer.next", &state);
             }
@@ -131,11 +164,74 @@ fn lab_lifecycle(scenario: &str, test_name: &'static str, assert_visible: fn(&Pa
                 TRANSITION_TIMEOUT,
             );
             assert_eq!(state.selected_scenario, scenario);
+            if scenario == "surface-expedition" {
+                state = harness.activate_guarded("launcher.settings", &state);
+                assert_eq!(
+                    control_value(&state, "launcher.settings.expedition.players.next"),
+                    Some(players.to_string().as_str())
+                );
+                state = harness.activate_guarded("launcher.settings.back", &state);
+            }
         }
     });
 }
 
+fn assert_raster_pair_visible(path: &Path) {
+    let mut decoder = png::Decoder::new(File::open(path).unwrap());
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().unwrap();
+    let mut buffer = vec![0; reader.output_buffer_size()];
+    let frame = reader.next_frame(&mut buffer).unwrap();
+    let channels = match frame.color_type {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        other => panic!("unexpected {other:?}"),
+    };
+    let mut ships = [0; 2];
+    let mut maps = [0; 2];
+    for (index, pixel) in buffer[..frame.buffer_size()]
+        .chunks_exact(channels)
+        .enumerate()
+    {
+        let x = index % frame.width as usize;
+        let y = index / frame.width as usize;
+        let player = usize::from(x >= frame.width as usize / 2);
+        if y > frame.height as usize / 3 && y < frame.height as usize * 3 / 4 {
+            let own_color = if player == 0 {
+                pixel[0] > 200 && pixel[1] < 80
+            } else {
+                pixel[1] > 200 && pixel[0] < 80
+            };
+            if own_color && pixel[2] < 80 {
+                ships[player] += 1;
+            }
+        }
+        let local_x = x - player * (frame.width as usize / 2);
+        if local_x > frame.width as usize * 3 / 10
+            && y >= frame.height as usize / 4
+            && y < frame.height as usize / 2
+            && pixel[0] < 100
+            && pixel[1] > 130
+            && pixel[2] > 100
+        {
+            maps[player] += 1;
+        }
+    }
+    for player in 0..2 {
+        assert!(ships[player] > 100, "P{player} ship missing: {ships:?}");
+        assert!(maps[player] > 20, "P{player} minimap missing: {maps:?}");
+    }
+}
+
 fn assert_raster_sortie_visible(path: &Path) {
+    assert_raster_surface_visible(path, true);
+}
+
+fn assert_raster_expedition_visible(path: &Path) {
+    assert_raster_surface_visible(path, false);
+}
+
+fn assert_raster_surface_visible(path: &Path, has_outpost: bool) {
     let mut decoder = png::Decoder::new(File::open(path).unwrap());
     decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
     let mut reader = decoder.read_info().unwrap();
@@ -152,7 +248,7 @@ fn assert_raster_sortie_visible(path: &Path) {
     let mut diagnostics_pixels = 0;
     let mut minimap_planet_pixels = 0;
     let mut outpost_pixels = 0;
-    let mut outpost_hud_pixels = 0;
+    let mut mission_hud_pixels = 0;
     for (index, pixel) in buffer[..frame.buffer_size()]
         .chunks_exact(channels)
         .enumerate()
@@ -173,7 +269,7 @@ fn assert_raster_sortie_visible(path: &Path) {
                 outpost_pixels += 1;
             }
             if y > height * 4 / 5 {
-                outpost_hud_pixels += 1;
+                mission_hud_pixels += 1;
             }
         }
         // The overview sits below the top HUD at the right. Its planet stays
@@ -189,13 +285,17 @@ fn assert_raster_sortie_visible(path: &Path) {
         }
     }
     assert!(ship_pixels > 100, "missing initial ship: {ship_pixels}");
+    if has_outpost {
+        assert!(
+            outpost_pixels > 40,
+            "missing amber outpost: {outpost_pixels}"
+        );
+    } else {
+        assert_eq!(outpost_pixels, 0, "Expedition must not spawn a terminal");
+    }
     assert!(
-        outpost_pixels > 40,
-        "missing amber outpost: {outpost_pixels}"
-    );
-    assert!(
-        outpost_hud_pixels > 40,
-        "missing outpost capture HUD: {outpost_hud_pixels}"
+        mission_hud_pixels > 40,
+        "missing capture/claim HUD: {mission_hud_pixels}"
     );
     assert!(
         minimap_planet_pixels > 40,

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -293,6 +293,7 @@ export component MainWindow inherits Window {
     in-out property <string> launcher-asteroids-enabled: "on";
     in-out property <string> launcher-asteroid-probability-text: "20.0";
     in-out property <string> launcher-player-health-text: "100";
+    in-out property <string> launcher-expedition-players: "1";
     in-out property <string> launcher-p2-controller: "human";
     in-out property <string> launcher-p1-zoom-text: "320";
     in-out property <string> launcher-p2-zoom-text: "320";
@@ -1146,7 +1147,7 @@ export component MainWindow inherits Window {
                             y: 9px;
                             width: parent.width - 28px;
                             height: 24px;
-                            text: root.launcher-scenario == "spacewars" ? "Two-player orbital combat and planet capture" : root.launcher-scenario == "pizza" ? "Interactive many-body collision sandbox" : root.launcher-scenario == "clock" ? "Low-resolution clock driven by local device time" : root.launcher-scenario == "falling" ? "Rust-native NES homebrew game" : root.launcher-scenario == "nes" ? "User-supplied NES cartridge library" : "Rapier rover and wheel mechanics lab";
+                            text: root.launcher-scenario == "spacewars" ? "Two-player orbital combat and planet capture" : root.launcher-scenario == "pizza" ? "Interactive many-body collision sandbox" : root.launcher-scenario == "clock" ? "Low-resolution clock driven by local device time" : root.launcher-scenario == "falling" ? "Rust-native NES homebrew game" : root.launcher-scenario == "nes" ? "User-supplied NES cartridge library" : root.launcher-scenario == "surface-expedition" ? "Land, disembark and raise your planet's flag" : root.launcher-scenario == "spaceling-lab" ? "Spaceling movement and recovery lab" : root.launcher-scenario == "rover-lab" ? "Rapier rover and wheel mechanics lab" : "Physical landing and surface interaction lab";
                             color: #e6edf7;
                             font-size: 15px;
                         }
@@ -1156,7 +1157,7 @@ export component MainWindow inherits Window {
                             y: 38px;
                             width: parent.width - 28px;
                             height: 22px;
-                            text: root.launcher-scenario == "spacewars" ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled + "  ·  P2 " + root.launcher-p2-controller) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : root.launcher-scenario == "clock" ? (root.launcher-clock-time-format + "  ·  local time  ·  " + root.launcher-clock-event-profile + " events") : root.launcher-scenario == "falling" ? "256×224 native video  ·  bounded 48 kHz audio" : root.launcher-scenario == "nes" ? (root.launcher-nes-rom-name + "  ·  " + root.launcher-nes-rom-status) : "A semi-interactive mechanics scenario";
+                            text: root.launcher-scenario == "spacewars" ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled + "  ·  P2 " + root.launcher-p2-controller) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : root.launcher-scenario == "clock" ? (root.launcher-clock-time-format + "  ·  local time  ·  " + root.launcher-clock-event-profile + " events") : root.launcher-scenario == "falling" ? "256×224 native video  ·  bounded 48 kHz audio" : root.launcher-scenario == "nes" ? (root.launcher-nes-rom-name + "  ·  " + root.launcher-nes-rom-status) : root.launcher-scenario == "surface-expedition" ? (root.launcher-expedition-players + " player(s)  ·  shared Surface V1 world  ·  no weapons") : "A semi-interactive mechanics scenario";
                             color: #9fb4cc;
                             font-size: 13px;
                         }
@@ -1377,6 +1378,25 @@ export component MainWindow inherits Window {
                     }
 
                     ChoiceRow {
+                        visible: root.launcher-scenario == "surface-expedition";
+                        x: 0px;
+                        y: 104px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Players";
+                        value: root.launcher-expedition-players;
+                        selected: root.launcher-settings-focus-index == 2;
+                        previous => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 2;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
                         visible: root.launcher-scenario == "pizza";
                         x: 0px;
                         y: 104px;
@@ -1542,7 +1562,7 @@ export component MainWindow inherits Window {
                         width: 150px;
                         height: 44px;
                         text: "Back";
-                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 7 : root.launcher-scenario == "clock" ? 6 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : 2);
+                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 7 : root.launcher-scenario == "clock" ? 6 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : root.launcher-scenario == "surface-expedition" ? 3 : 2);
                         activated => {
                             root.launcher-settings-visible = false;
                         }

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -126,9 +126,34 @@ pub struct Settings {
     pub clock: ClockSettings,
     pub nes: NesSettings,
     pub spacewars: SpacewarsSettings,
+    pub surface_expedition: SurfaceExpeditionSettings,
     pub pizza: PizzaSettings,
     pub runtime: RuntimeSettings,
     pub last_scenario: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SurfaceExpeditionSettings {
+    pub players: SurfaceExpeditionPlayers,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SurfaceExpeditionPlayers {
+    #[default]
+    #[serde(rename = "one")]
+    One,
+    #[serde(rename = "two")]
+    Two,
+}
+
+impl SurfaceExpeditionPlayers {
+    pub fn count(self) -> usize {
+        match self {
+            Self::One => 1,
+            Self::Two => 2,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/design/reboot-rust-slint.md
+++ b/docs/design/reboot-rust-slint.md
@@ -639,3 +639,12 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - M32e: ✅ Following positive multiplayer Pi playtesting, simplify Expedition to planet claims without infrastructure: stand on the surface for three seconds to raise a flag; approach an enemy flag to lower it for three seconds before a fresh raise. Preserve local contests, interrupted-stage rules, real contact attachment, both minimaps and the pinned outpost reference tests. No flag bodies/colliders; no Expedition repair service.
 - Manual playtesting: the simplified flag-loop build was deployed to the Pi, verified at about 60 FPS / 60 UPS, and received positive user feedback on 2026-09-07.
 - Boundary: no weapons, ship swapping, rescue/rebuilding, bots, terrain changes or ordinary Spacewars docking changes. See [Surface Expedition](../surface-expedition.md).
+
+### M33: Expedition vehicle recovery
+
+- M33a: ✅ Separate occupied/empty ship loss: retain the same pilot in a flyable pod or on foot, without phantom pods. Opt in only for Expedition; retain ordinary Spacewars behavior.
+- M33b: ✅ Add pod rear feet and natural landing/transfer gates, plus an eight-second owned-surface rebuild policy independent of outposts and flags. Use bounded local clearance queries, surface-frame velocity and normal boarding after a replacement settles.
+- M33c: ✅ Add the hold A+B+Down loss drill, neutral-input gates, per-seat lifecycle/progress counters and pod/rebuild HUDs in observation version 10. Regress the action-only recovery journey, moving planets, repeated two-seat loss/rebuild, blocked placement and replay.
+- Deployment: recovery is installed in Pi slot B, preserving the accepted flag build in slot A. The installed binary checksum and unchanged settings were verified; two-player Expedition and an actual screenshot were checked at about 60 FPS / 60 UPS with zero service restarts.
+- Manual acceptance: the user reported the basic recovery loop working full circle on the Pi, including occupied scuttling while flying and landed, pod landing, disembarking, claiming and returning to a full ship. Existing rebuild progress/instructions are retained. Empty-ship scuttling and broader multiplayer failure cases were not explicitly reported as manually tested.
+- Boundary: no pilot damage/elimination, weapons, ship swapping, remote rescue, bots, terrain changes or ordinary-game docking changes. Pods/spacelings remain invulnerable. See [Expedition recovery](../surface-expedition.md#ship-loss-and-recovery).

--- a/docs/design/reboot-rust-slint.md
+++ b/docs/design/reboot-rust-slint.md
@@ -629,3 +629,13 @@ Physics fidelity should follow the 2008 behavior, even though the reboot should 
 - M31c: ✅ Exercise action-only A-to-B capture/repair journeys on stationary/translating spinning planets, generated arrivals, wrong-planet services/support, stable lifecycle and deterministic replay. Preserve pinned compatibility probes and ordinary-game behavior.
 - M31d: ✅ Deploy to the Pi, verify launcher/pause/restart and sampled 60 FPS / 60 UPS, and receive positive initial user playtesting feedback on 2026-09-07.
 - Boundary: single pilot/vehicle, one intact site per planet, no combat/rescue/rebuilding. Broader controller, generated-route and long-duration checks remain open; multi-pilot and bot integration follow. See [Surface Expedition](../surface-expedition.md).
+
+### M32: Two-player Surface Expedition
+
+- M32a: ✅ Evolve the existing Expedition entry with a persisted 1/2-player setting, defaulting to one. Preserve the single-pilot pinned Sortie and compatibility presets.
+- M32b: ✅ Give each pilot independent assigned-ship, control, transfer, landing and diagnostic state. Share one Rapier world, gravity solve and physics step; bound capsule lifecycle to one external body per pilot and reject occupied hatch exits.
+- M32c: ✅ Add per-seat split-screen cameras, HUDs and translucent minimaps. Address Surface control actions by player and expose per-player observations (initially version 8, now 9 with planet claims and optional focused outpost).
+- M32d: ✅ Resolve physically eligible opposing claimants together, pause contested progress, prevent borrowed partial claims, and repair only friendly landed vehicles. Regress independent controls, same-planet transfer cycles, capture/repair, replay, migration and real client lifecycle. Preserve ordinary navigation/strategy baselines.
+- M32e: ✅ Following positive multiplayer Pi playtesting, simplify Expedition to planet claims without infrastructure: stand on the surface for three seconds to raise a flag; approach an enemy flag to lower it for three seconds before a fresh raise. Preserve local contests, interrupted-stage rules, real contact attachment, both minimaps and the pinned outpost reference tests. No flag bodies/colliders; no Expedition repair service.
+- Manual playtesting: the simplified flag-loop build was deployed to the Pi, verified at about 60 FPS / 60 UPS, and received positive user feedback on 2026-09-07.
+- Boundary: no weapons, ship swapping, rescue/rebuilding, bots, terrain changes or ordinary Spacewars docking changes. See [Surface Expedition](../surface-expedition.md).

--- a/docs/design/spacelings.md
+++ b/docs/design/spacelings.md
@@ -302,6 +302,44 @@ playtesting. Weapons, pilot/vehicle loss, rescue, rebuilding, bot surface intent
 and terrain integration are not part of this slice. See
 [Surface Expedition](../surface-expedition.md#two-player-expedition).
 
+## Ninth slice: Expedition vehicle loss and recovery
+
+Implemented on the same `surface-expedition-multiplayer` branch, after the
+playtested multiplayer/flag checkpoint `9c8d841`. Only Expedition enables this
+policy; the pinned Sortie/outpost fixtures and ordinary Spacewars keep their
+previous loss rules.
+
+Occupied ship loss keeps the same pilot aboard an escape pod, preserving the
+assembly origin, velocity (including the existing death impulse) and physical
+spin across the different mesh pivots. Empty ship loss removes the vehicle
+without inventing a second pilot or empty pod. Pods gain scaled rear feet and
+the same contact-based transfer/flight controller, independent of ownership.
+A short owner-fragment collision grace prevents breakup overlap from slamming
+the new pod into the terrain. It does not disable terrain collisions.
+
+An on-foot pilot without a full ship can rebuild after eight seconds of real,
+balanced, slow contact with owned terrain. No infrastructure or flag proximity
+is required. Eligibility loss resets the interval; nearby blocked placement
+retains completion and retries at a bounded cadence. New hulls require local
+terrain rays and conservative clearance, inherit the local moving frame, and
+must settle before normal boarding. The capsule remains external throughout.
+The assigned vehicle slot stays stable; loss/rebuild counters distinguish
+physical assembly generations. Observation version 10 exposes this lifecycle.
+
+A three-second A+B+Down scuttle chord makes occupied and empty ship loss
+repeatable with the existing minimal controller. Recovery, clearance, repeated
+two-seat lifecycle and action-only journey tests run alongside the unchanged
+ordinary-game baselines. One shared physics step and gravity solve are retained.
+Pods/spacelings remain invulnerable; pilot death, weapons, remote rescue and
+bot intents are separate work. The expansion was deployed to the Pi's slot B
+and smoke-checked at about 60 FPS / 60 UPS with unchanged settings and no service
+restarts. The user then reported a successful full-circle recovery playtest:
+occupied scuttling in flight and while landed, pod landing, disembarking,
+claiming and return to a full ship. Empty-ship scuttling and broader multiplayer
+failure cases retain automated coverage without a specific manual acceptance
+claim. The existing rebuild progress/instruction UI is retained. See
+[Expedition recovery](../surface-expedition.md#ship-loss-and-recovery).
+
 ## Planet and ship direction
 
 The continuous surface and external berth from PR #40 fix the interior-bay

--- a/docs/design/spacelings.md
+++ b/docs/design/spacelings.md
@@ -266,6 +266,42 @@ new boundaries. The initial Pi deployment and user playtest on 2026-09-07 were
 positive. This does not yet prove all generated routes, multiplayer, combat or
 rescue rules. See [Surface Expedition](../surface-expedition.md).
 
+## Eighth slice: two-player surface expedition
+
+Implemented on `surface-expedition-multiplayer`. The existing Expedition
+entry gains a persisted 1/2-player setting, defaulting to one; the pinned
+Sortie and compatibility presets remain single-pilot configurations. Each
+seat has stable pilot/vehicle identities, controls, transfer and landing
+state, telemetry, camera and minimap. Boarding is limited to the assigned
+ship. One pilot's transfer/release gate cannot consume the other's input.
+
+All active ships and spacelings inhabit one Rapier world with one shared
+gravity solve and physics step. After successful initial multiplayer Pi
+playtesting, Expedition's objective was simplified: land, disembark and stand
+still for three seconds to claim the planet. An enemy flag requires proximity
+and three seconds of lowering, then a fresh three seconds to raise a replacement.
+Ownership remains with the defender while lowering, then neutral while raising.
+Opposing eligible pilots near a flag pause progress; interrupted stages reset
+without undoing a completed neutralization or sharing time between claimants.
+
+Flags attach at the actual contact point/normal in the planet's local frame,
+without nominal-radius projection or extra physics bodies/colliders. Expedition
+starts ships at full health and creates no outposts or repair services. The
+outpost model and its multi-pilot contest/repair tests remain as future
+infrastructure references, independent of planet ownership. Observation version
+9 provides a `players` array, focused/full planet claims and an optional focused
+outpost. Ordinary Spacewars protocols are unchanged.
+
+Regressions cover repeated same-planet transfers with stationary and moving
+centers, blocked exits, independent control gates, no foreign-ship boarding,
+contested capture and owner-specific repair, deterministic action ordering,
+settings migration, and split-screen rendering/lifecycle. The frozen ordinary
+navigation and strategy suites still match. The preceding outpost-based
+multiplayer and simplified flag-loop builds both received positive Pi
+playtesting. Weapons, pilot/vehicle loss, rescue, rebuilding, bot surface intents
+and terrain integration are not part of this slice. See
+[Surface Expedition](../surface-expedition.md#two-player-expedition).
+
 ## Planet and ship direction
 
 The continuous surface and external berth from PR #40 fix the interior-bay

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -76,14 +76,26 @@ manual check.
 All four Surface Sortie presets (stationary center, orbital, untuned generated
 world, and experimental Surface V1 generated world), plus **surface-expedition**, use the same
 launcher/pause/restart workflow with both renderers;
-their raster checks require the ship, amber outpost, capture/landing HUD,
-and minimap planet. The client unit tests also render the disembarked spaceling,
-capture progress, and owner-colored flag in landscape/portrait, and check that
-capturing an Expedition site does not recolor the other minimap sites, while
+their raster checks require the ship, capture/landing HUD, and minimap planet.
+Only the pinned Sortie fixtures require an amber outpost; Expedition explicitly
+has none. Client unit tests render the disembarked spaceling, capture progress
+and flag in landscape/portrait and Pi-sized frames, and verify that raising
+an Expedition flag only recolors its planet after completion, while
 `scenario-spacewars` exercises the physical exit/walk/capture/repair/return/board/
 departure loop and input gating on stationary, orbital, and sampled Surface V1
-generated terrain. See
+generated terrain. The newer planet-claim regressions separately cover
+proximity-only flag lowering, a fresh replacement timer, contests, actual
+support, interrupted stages and an action-only two-planet claiming journey. See
 [Surface Sortie](surface-sortie.md) for the manual controls and retained images.
+
+Surface Expedition also has a two-player workflow. It changes **Settings →
+Players** from 1 to 2 through the public control inventory, verifies the
+persisted choice across launch/return, exercises both renderers and
+pause/restart, and checks that the raster screenshot contains both
+player-colored ships and both minimaps. Adapter tests cover independently
+addressed keyboard/gamepad input, disconnect, camera footprints, both HUDs and
+landscape/portrait images. Actual simultaneous two-controller gameplay still
+requires a manual check; this workflow does not inject a physical controller.
 
 The harness uses Slint's software backend, which does not draw vector paths.
 Selecting vector verifies host lifecycle and text there, not vector geometry.

--- a/docs/surface-compatibility.md
+++ b/docs/surface-compatibility.md
@@ -100,8 +100,11 @@ prescribed center acceleration, and effective inward/lateral acceleration at
 ship spawn. Units are world units/s² and rad/s, not pixels or per-tick deltas.
 The ship's legacy gravity query point is offset from its Rapier origin; both
 points are reported, and the diagnostic field is checked against the real
-shared solver. Scenario observations are now version 7 (profile identity was
-added in version 6; version 7 adds travel/support and outpost inventory);
+shared solver. Scenario observations are now version 9 (profile identity was
+added in version 6; version 7 adds travel/support and outpost inventory;
+version 8 wraps per-player views in a `players` array; version 9 adds Expedition
+planet claims and makes the focused outpost optional). These compatibility
+fixtures remain single-pilot configurations;
 compatibility reports retain their version 2 schema with an additive
 `final_landing.planet` frame identifier.
 Old case identifiers without `profile` deserialize as raw, not Surface V1.
@@ -217,9 +220,9 @@ adopting a world policy in ordinary Spacewars. Keep the raw comparison and
 uncompensated free-flight behavior available during that decision.
 
 The opt-in [Surface Expedition](surface-expedition.md) now exercises travel
-between planets with one pilot and independent outposts; it does not change
+between planets with one or two pilots and flag-based planet claiming; it does not change
 these pinned comparison cases or adopt the profile in ordinary Spacewars.
 
-After agreeing that policy: generalize to multiple pilots/vehicles, decide loss
-and rescue/rebuild rules, connect contested services, and add versioned bot
+After agreeing that policy: decide loss and rescue/rebuild rules, connect
+future services independently of planet ownership, and add versioned bot
 surface intents. Economy and deformable terrain remain separate work.

--- a/docs/surface-compatibility.md
+++ b/docs/surface-compatibility.md
@@ -100,10 +100,11 @@ prescribed center acceleration, and effective inward/lateral acceleration at
 ship spawn. Units are world units/s² and rad/s, not pixels or per-tick deltas.
 The ship's legacy gravity query point is offset from its Rapier origin; both
 points are reported, and the diagnostic field is checked against the real
-shared solver. Scenario observations are now version 9 (profile identity was
+shared solver. Scenario observations are now version 10 (profile identity was
 added in version 6; version 7 adds travel/support and outpost inventory;
 version 8 wraps per-player views in a `players` array; version 9 adds Expedition
-planet claims and makes the focused outpost optional). These compatibility
+planet claims and makes the focused outpost optional; version 10 adds vehicle
+form and optional Expedition recovery telemetry). These compatibility
 fixtures remain single-pilot configurations;
 compatibility reports retain their version 2 schema with an additive
 `final_landing.planet` frame identifier.

--- a/docs/surface-expedition.md
+++ b/docs/surface-expedition.md
@@ -92,6 +92,54 @@ does not interrupt or arm the other. A hatch exit occupied by another spaceling
 is blocked, including transfers in the same physics tick. Spacelings and both
 ships collide in the same Rapier world.
 
+### Ship loss and recovery
+
+Expedition now keeps the pilot and vehicle lifecycles separate:
+
+- Destroying an **occupied ship** leaves that same pilot aboard a flyable escape
+  pod. Pods use the same bounded flight assist and a scaled pair of rear feet;
+  they must actually land and settle before B / X can disembark. Planet ownership
+  is not required to fly, land or exit a pod.
+- Destroying an **empty ship** leaves its existing on-foot spaceling alive.
+  The dead ship disappears; it does not create an empty pod or a second creature.
+- Without a full ship, stand balanced and still on an **owned planet for 8
+  seconds** to rebuild. You can first claim a neutral planet using the normal
+  flag rules. Rebuilding requires no outpost or flag proximity. Jumping, losing
+  support/balance, moving too quickly or losing ownership resets unfinished
+  construction. Standing on a ship or unrelated platform does not qualify.
+- A replacement appears nearby, at full health, with local surface velocity and
+  spin. It must settle naturally; walk to its cyan hatch and board normally.
+  Its pilot remains on foot, and an old pod is removed when the replacement is
+  created. There is never more than one live assigned vehicle per seat.
+
+The HUD reports pod landing, eligibility, rebuild progress and blocked space.
+Placement tries at most four local terrain rays and conservative hull/foot
+clearance checks. It prefers putting the hatch toward the waiting spaceling.
+If all sites are blocked, progress stays at 100% and placement retries every
+half-second while eligibility remains valid. Move along the surface to select
+a different build site; moving fast enough resets the timer.
+
+For a deliberate **loss drill**, hold **A + B + Down together for 3 seconds**
+(P1 keyboard: Space + X + S; P2: numpad 8 + 2 + 5). The chord destroys your
+assigned full ship, even when you are on foot; it never destroys a pod.
+Release early to cancel. While charging, the chord consumes movement/transfer
+input. Release all controls after loss or replacement before continuing.
+Try it both aboard and after disembarking. The drill is an Expedition testing
+affordance, not a weapon or a new ordinary-game control.
+
+Breakup pieces remain physical and visible. For their first half-second they
+cannot hit the surviving owner vehicle or spacelings, allowing initially
+overlapping pieces to disperse. Terrain, debris and opponent-vehicle collisions
+remain active, then normal fragment collisions resume. This exception applies
+only to owner-tagged breakup fragments in the recovery-enabled fixture.
+
+This is deliberately not a complete survival system: **pods and spacelings are
+still invulnerable**, and there is no pilot death/elimination, combat, ship
+swapping, remote rescue or recovery of a living full ship stranded elsewhere.
+The recovery build has been deployed and smoke-checked on the Pi as described
+below. The user subsequently reported that the basic recovery loop worked
+full circle on the device.
+
 ### Initial Pi playtest (2026-09-07)
 
 The earlier single-player and then two-player **outpost-based** Expedition
@@ -99,8 +147,8 @@ builds were deployed to `spacewars.local` through the normal A/B updater.
 The two-player build was observed near 60 FPS / 60 UPS with no service
 restarts; launcher selection, pause/restart and screenshots were checked.
 The user reported successful playtesting, then requested this simpler flag
-loop. That feedback accepts the preceding travel/multiplayer work, **not this
-new flag loop**, which still needs a fresh device playtest.
+loop. That first feedback accepted the preceding travel/multiplayer work;
+the flag loop was then tested separately as described below.
 
 The flag-loop build was subsequently deployed on the same day to slot A
 (`/dev/sda2`), preserving the preceding build in slot B. The installed client
@@ -109,6 +157,25 @@ Expedition was launched and sampled at 60.1 FPS / 60.1 UPS with zero service
 restarts. Both controllers were detected, and an actual 800×480 screenshot
 confirmed the new claim HUD. The user subsequently reported that the flag-loop
 playtest seemed good; this is initial acceptance, not exhaustive route coverage.
+
+The recovery expansion was subsequently built from the working tree after
+`9c8d841` and deployed through the same updater to slot B (`/dev/sda3`), retaining
+the accepted flag build in slot A. The installed client checksum matched the
+fresh package (`ced27785fc6b72ab7022400d552accfbad464c70a3e2e2d89d770259858e91c8`).
+Settings were byte-for-byte unchanged and persistent data remained mounted.
+Two-player Expedition was launched with seed 0 and raster scale 2, sampled at
+60.1 FPS / 60.1 UPS, and an 800×480 screenshot confirmed both landed ships,
+HUDs and minimaps. Both gamepads were detected; the service stayed active with
+zero restarts, including after the screenshot. This is deployment verification,
+separate from the subsequent manual playtest.
+
+The user then reported successful scuttling both in flight and while landed
+aboard a full ship, followed by pod landing, disembarking, claiming a planet
+and returning to a full ship. The existing rebuild percentage and "stand still"
+guidance were visible; no additional UI polish was requested. This accepts the
+basic occupied-ship recovery loop, not exhaustive route or multiplayer failure
+coverage. Scuttling an empty ship while its pilot is already on foot remains
+automatically tested but was not explicitly included in that manual report.
 
 ## Approach is not support
 
@@ -144,12 +211,15 @@ Each completed tick samples each pilot's real support once, then updates the
 small planet list. Scratch space is bounded to two seats. Approach selection
 is allocation-free; the landing feet query their local Rapier contacts. There
 are no all-object scans, extra physics steps or extra gravity solves. An
-outside pilot adds one capsule; boarding removes only that capsule. Ships
-remain present. Expedition no longer spawns physical outpost terminals.
+outside pilot adds one capsule; boarding removes only that capsule. Healthy
+ships remain present while unoccupied. Loss removes or replaces the vehicle
+assembly, and rebuilding reuses the assigned slot with a fresh full assembly.
+Recovery adds bounded per-seat checks, not another physics step or gravity
+solve. Expedition no longer spawns physical outpost terminals.
 
 ## Observations and verification
 
-Scenario observations are version **9**, with a top-level `version` and
+Scenario observations are version **10**, with a top-level `version` and
 `players` array in seat order. Each view retains stable pilot/owner/vehicle IDs,
 input/transfer gates, landing and motion metrics, `travel_enabled`,
 `ship_support_planet` and `pilot_support_planet`.
@@ -168,10 +238,19 @@ Surface action V2 addresses a player explicitly; malformed/inactive seats
 are ignored and continuous input persists separately per seat. These
 observations do not add a live IPC telemetry endpoint.
 
+Version 10 adds `vehicle_form` and optional `recovery` per player (null in
+the pinned non-recovery fixtures). `ship_available` still means an intact full
+ship, not a pod; a live pod remains accessible through the usual landed transfer
+gate. Recovery reports status, build planet, required/progress times, ships
+lost, pod ejections, completed rebuilds, interrupted rebuilds and blocked
+placement attempts. Stable vehicle IDs identify the assigned slot, not a
+particular hull generation; the counters distinguish losses and replacements.
+
 ```sh
 cargo test --locked --release -p scenario-spacewars surface_sortie::claim::tests
 cargo test --locked --release -p scenario-spacewars travel_tests -- --nocapture
 cargo test --locked --release -p scenario-spacewars multiplayer_tests
+cargo test --locked --release -p scenario-spacewars recovery_tests
 
 # Retained comparison: unchanged criteria and pinned outpost fixtures
 cargo run --locked --release -p scenario-spacewars --example surface_compatibility -- \
@@ -212,11 +291,28 @@ Clippy completes with pre-existing warnings outside the surface changes.
 The separate Pi deployment smoke check is recorded above; it does not replace
 manual controller and flag-loop playtesting.
 
+Recovery regressions add an input-only pod → landing → disembark → neutral
+claim → rebuild → board → takeoff journey, pod landings at twelve controlled
+motion/bearing combinations, empty-ship loss, preserved identity/velocity/spin,
+independent two-seat loss gates and repeated/replayed rebuilding. Policy checks
+cover lost ownership/support/balance, relative speed, blocked placement/retries,
+surface-frame spawn velocity, neutral input gates and read-only rendering.
+Client tests use the minimal gamepad mapping and check pod/rebuild/replacement
+HUDs and both renderers at desktop, Pi-sized and portrait resolutions.
+
+Validation including recovery (2026-09-07, Rust 1.89): **861** workspace/all-target
+tests and all **14** real UI workflows pass. Both frozen ordinary-game suites
+still match; Windows client and ARM64 scenario compile checks pass. Clippy
+reports only the existing warnings outside the changed surface paths. Device
+playtesting subsequently accepted the basic occupied-ship recovery loop above.
+All **16** recovery tests also pass in the optimized release build.
+
 ## Remaining integration
 
-Loss/rescue/rebuild rules and versioned bot surface intents remain separate
+Pilot survival/remote rescue and versioned bot surface intents remain separate
 work. There is no combat, ship swapping, economy or ordinary-game docking
-change here. A lost assigned ship can still require a restart. Surface V1's
+change here. An unreachable living ship or stranded airborne spaceling can
+still require a restart. Surface V1's
 passive-approach failures, mutual-field mismatch, arbitrary generated routes
 and long-idle support drift remain known limits. Ownership is now deliberately
 simpler than future outposts, resources and services.

--- a/docs/surface-expedition.md
+++ b/docs/surface-expedition.md
@@ -1,138 +1,222 @@
 # Surface Expedition
 
-An opt-in, single-pilot planet-to-planet loop on the experimental Surface V1
-world. Choose **surface-expedition** in the launcher, or run:
+An opt-in, one- or two-player planet-to-planet loop on the experimental Surface
+V1 world. Choose **surface-expedition** in the launcher, or run:
 
 ```sh
 cargo run -p engine-client -- --scenario surface-expedition --seed 0
 ```
 
-The original Surface Sortie presets and the raw/profile compatibility runner
-remain pinned to their selected planet. Expedition uses the same scenario,
-controllers, Rapier world, gravity solve, and natural landing rules, with travel
-enabled and one intact outpost per generated planet. Ordinary Spacewars is
-unchanged. See [Surface Sortie](surface-sortie.md) for the full controls and
-[Surface V1](surface-compatibility.md#surface-v1-experiment) for world parameters
-and known physical limits.
+In the launcher's **Settings → Players**, choose **1** (the default) or **2**.
+The choice persists and applies to direct launches too:
+
+```toml
+[surface_expedition]
+players = "two" # "one" is the default, including for older settings files
+```
+
+This evolves the existing Expedition entry, not a new scenario. It shares the
+Surface Sortie controllers, Rapier world, gravity solve and natural landing
+rules, with travel enabled. **Planet claiming does not require an outpost.**
+The older terminal/capture/repair model remains in the pinned Sortie and
+compatibility fixtures for future infrastructure work. Ordinary Spacewars,
+its docking rules, services, bots and protocols are unchanged.
+
+See [Surface Sortie](surface-sortie.md) for landing controls and
+[Surface V1](surface-compatibility.md#surface-v1-experiment) for the experimental
+world parameters and known physical limits.
 
 ## Playtest the loop
 
-1. Settle on the starting planet. B / X disembarks; release controls afterward.
-2. Walk to the amber terminal and stand still for three seconds to capture it.
-   Its flag and minimap square change to your color. A friendly site repairs
-   your nearby landed ship, without claiming the whole planet.
-3. Return to the cyan hatch, board with B / X, and take off with A / Space.
-4. Fly to a different planet using the minimap. The HUD's approach-planet index
-   updates automatically; no target-selection button is needed.
-5. Brake with Down / S and point the nose away from the destination planet.
-   Settle rear-first, then exit and capture its separate terminal. Find a clear
-   walking route from the hatch: the parked hull and terminal are solid.
-6. Reboard and depart. The first site's ownership remains recorded; its repair
-   service does not follow you to another planet.
+1. Land rear-first and settle on both rear feet. B / X disembarks; release
+   controls afterward. The ship must be physically landed to enter or exit.
+2. On a neutral planet, stand still on the actual surface for **3 seconds**.
+   A flag rises at your contact point, and the planet becomes yours when it
+   reaches the top. There is no terminal to find and no extra capture button.
+3. On an enemy-owned planet, walk **within 3 world units of the existing flag**.
+   Stand still for **3 seconds to lower it**, then **another 3 seconds to raise
+   your replacement**. Landing elsewhere cannot remotely remove a flag.
+4. Return to your own cyan hatch, board with B / X and take off with A / Space.
+5. Fly to another planet using the minimap, brake with Down / S, face away from
+   the surface, land and repeat. Previously claimed planets stay yours.
 
-Left/right turns aboard and walks on foot; A / Space thrusts aboard and jumps
-on foot. Start / Esc pauses. R or the pause menu restarts with the same seed and
-fresh ownership. Controller mappings and neutral-after-transfer gating are
-shared with Surface Sortie.
+Left/right turns aboard and walks on foot; A / Space thrusts or jumps.
+Start / Esc pauses. R or the pause menu restarts the same seed with fresh
+ownership. Ships start at full health. This loop has **no repair service**.
+
+### Flag and contest rules
+
+Claims require real contact with that planet's terrain, a balanced spaceling,
+and support-point relative speed at most 1 world unit/s. Standing on a nearby
+ship or unrelated platform does not count. Flag proximity is measured from
+the actual surface contact point to the flag base, not from the ship.
+
+While an enemy flag is lowering, its owner still owns the planet. Once fully
+lowered, the planet becomes neutral and a new flag starts at height zero at
+the claimant's contact point. No time spent lowering counts toward raising.
+The replacement must finish rising before ownership changes to the attacker.
+
+Leaving eligibility, jumping, walking too quickly, boarding or being knocked
+down resets the **unfinished stage**. Interrupted lowering restores the
+defender's still-owned flag; interrupted raising removes the unfinished flag.
+A completed lowering stays completed: the planet remains neutral if the
+attacker subsequently leaves. Partial progress never transfers to another
+claimant.
+
+Opposing eligible spacelings near an existing flag pause progress. A distant
+defender, or an airborne/knocked-down defender, cannot block it. A contest
+preserves partial time only while its claimant still qualifies. Before a
+neutral planet has any flag, simultaneous eligible claimants contest rather
+than winning by seat iteration order; one must yield before raising begins.
+
+The HUD shows ownership, lowering/raising progress and why progress is blocked.
+Minimap planet colors show completed ownership; triangles locate flags, even
+while raising or lowering. A rising flag does not prematurely recolor the
+planet. Flags move and rotate with their planet at their original contact
+location.
+
+### Two-player expedition
+
+Each pilot has its own assigned ship, input state, landing gate, transfer
+history and motion diagnostics. Players start near separate planets when the
+layout permits; they can travel to the same planet and physically meet there.
+Each split-screen pane follows its active actor with its own HUD and minimap.
+World physics and ownership are shared.
+
+Assigned gamepads use Left/Right, A, B and Down. Keyboard P1 uses A/D, Space,
+X and S; P2 uses numpad 4/6 to turn/walk, 8 to thrust/jump, 2 to board/exit and
+5 to brake. Existing gamepad assignment and reconnect rules still apply.
+
+Only your own ship can be boarded. One pilot's neutral-after-transfer gate
+does not interrupt or arm the other. A hatch exit occupied by another spaceling
+is blocked, including transfers in the same physics tick. Spacelings and both
+ships collide in the same Rapier world.
 
 ### Initial Pi playtest (2026-09-07)
 
-The current Expedition build was deployed to `spacewars.local` through the
-normal A/B updater. The kiosk ran the scenario at a sampled 60 FPS / 60 updates
-per second, with no service restarts; launcher selection, pause and round
-restart were verified through the public control API. The user then reported
-that playtesting worked. This is initial device acceptance, not an exhaustive
-controller, generated-route, or long-duration stability check.
+The earlier single-player and then two-player **outpost-based** Expedition
+builds were deployed to `spacewars.local` through the normal A/B updater.
+The two-player build was observed near 60 FPS / 60 UPS with no service
+restarts; launcher selection, pause/restart and screenshots were checked.
+The user reported successful playtesting, then requested this simpler flag
+loop. That feedback accepts the preceding travel/multiplayer work, **not this
+new flag loop**, which still needs a fresh device playtest.
+
+The flag-loop build was subsequently deployed on the same day to slot A
+(`/dev/sda2`), preserving the preceding build in slot B. The installed client
+checksum matched the new package; settings were unchanged. Two-player
+Expedition was launched and sampled at 60.1 FPS / 60.1 UPS with zero service
+restarts. Both controllers were detected, and an actual 800×480 screenshot
+confirmed the new claim HUD. The user subsequently reported that the flag-loop
+playtest seemed good; this is initial acceptance, not exhaustive route coverage.
 
 ## Approach is not support
 
-The approach frame is chosen by distance to **planet surface**, not distance to
-its center. Real rear-foot contact takes priority. A two-world-unit hysteresis
-avoids selection chatter near a free-space boundary; it never extends contact
-or grants a landed state. Selection uses completed Rapier terrain poses before
-control and again after the physics step, not the next prescribed target pose.
+Approach selection uses distance to planet **surface**, with real rear-foot
+contact taking priority. Two-world-unit hysteresis prevents chatter in free
+space; it never extends contact or grants a landed state. Selection reads
+completed Rapier terrain poses, not the next prescribed target.
 
-Landing still requires two qualifying rear-foot contacts, the existing angle,
-speed and spin limits, and 0.25 seconds of settling **on the same planet**.
-Changing planet resets accumulated settling time. Proximity or a nose/hull
-collision alone cannot allow a transfer.
+Landing still needs two qualifying rear-foot contacts, the existing angle,
+speed and spin limits, and 0.25 seconds of settling on the same planet.
+Changing planet resets settling time. Proximity or a nose/hull collision
+cannot allow a transfer.
 
-The hatch is projected beside the ship onto its current approach/landing
-planet, but is usable only after the physical landing gate passes. Boarding
-also requires the spaceling to be balanced, slow, nearby, and supported by
-that same planet's terrain or terminal. An unrelated platform near the hatch
-does not qualify. On-foot diagnostics and site focus follow the creature's
-support; in flight they use its nearest surface, independently of the parked
-ship's approach frame. No actor is attached, transported, or given a new force.
+Boarding needs a balanced, slow, nearby spaceling supported by the landed
+ship's planet. On-foot diagnostics follow the spaceling's support; in flight
+they use its nearest surface independently of the parked ship. No actor is
+attached, transported, or given a new force by claiming.
 
-## Independent sites and cost
+## Ownership, attachment and cost
 
-Each site has a stable ID, planet index, local surface location, capture state,
-owner, and repair accounting. Every site updates independently. Capture uses
-the spaceling's real contact identity; repair requires the ship to be landed
-on **that site's planet**, as well as friendly ownership and service range.
-Being near a foreign planet's friendly site is insufficient.
+The canonical owner is the existing planet ownership field. Each planet has
+a small claim record: optional flag attachment, current stage/claimant/time,
+seat-relative eligibility and capture/neutralization counters. Infrastructure
+is not a prerequisite for ownership and can be added independently later.
 
-This experiment creates exactly one site per planet. That is fixture content,
-not a requirement that every future claim needs a neutral outpost. Multiple
-sites on one planet, contested multiplayer service arbitration, destruction,
-and economy remain separate work.
+A flag stores the actual support point and normal in the completed planet
+body's local frame. Rendering transforms those back to world space; it does
+not reproject onto a nominal radius. A flag adds **no body or collider**.
+This attachment contract leaves room for noncircular terrain; handling terrain
+removal or migrating support between fragments remains future work.
 
-A site adds one collider to its existing kinematic planet and no new body.
-Approach selection is allocation-free and linear in the small planet list;
-the two landing feet use their local Rapier contacts. Spaceling support identity
-is decoded directly from its contact ID. There are no all-object scans, extra
-physics steps, or extra gravity solves. Aboard/on-foot body counts still differ
-by exactly one capsule.
+Each completed tick samples each pilot's real support once, then updates the
+small planet list. Scratch space is bounded to two seats. Approach selection
+is allocation-free; the landing feet query their local Rapier contacts. There
+are no all-object scans, extra physics steps or extra gravity solves. An
+outside pilot adds one capsule; boarding removes only that capsule. Ships
+remain present. Expedition no longer spawns physical outpost terminals.
 
 ## Observations and verification
 
-Scenario observations are version **7**. They add `travel_enabled`,
-`ship_support_planet`, `pilot_support_planet`, and the complete `outposts` list.
-`landing.planet` identifies the approach/contact frame, while
-`motion.planet` identifies the active actor's diagnostic frame. `outpost` remains
-the currently focused site's convenient HUD view; it is not the full world
-inventory. `generated_case` identifies the **starting** fixture, not the current
-destination. Planet indices are zero-based; site IDs start at one.
+Scenario observations are version **9**, with a top-level `version` and
+`players` array in seat order. Each view retains stable pilot/owner/vehicle IDs,
+input/transfer gates, landing and motion metrics, `travel_enabled`,
+`ship_support_planet` and `pilot_support_planet`.
+
+`planet_claim` is the active actor's focused planet view; `planet_claims` is
+the complete inventory. Each reports owner, claimant, phase, progress, required
+seconds/range, eligibility status, flag world position/normal/raised fraction
+and capture/neutralization counters. `outpost` is now optional: null in
+Expedition, populated in pinned fixtures. Expedition's `outposts` list is
+empty; those older fixtures retain their inventory and repair telemetry.
+
+`landing.planet` is the ship's approach/contact frame; `motion.planet` is the
+active actor's diagnostic frame. `generated_case` identifies the starting
+fixture, not the current destination. Planet indices are zero-based.
+Surface action V2 addresses a player explicitly; malformed/inactive seats
+are ignored and continuous input persists separately per seat. These
+observations do not add a live IPC telemetry endpoint.
 
 ```sh
+cargo test --locked --release -p scenario-spacewars surface_sortie::claim::tests
 cargo test --locked --release -p scenario-spacewars travel_tests -- --nocapture
+cargo test --locked --release -p scenario-spacewars multiplayer_tests
 
-# Existing comparison, unchanged physical criteria and pinned fixtures:
+# Retained comparison: unchanged criteria and pinned outpost fixtures
 cargo run --locked --release -p scenario-spacewars --example surface_compatibility -- \
   --profile both --seeds 4
 
-# Real client lifecycle and screenshot checks on an existing X display:
+# Real client workflows on an existing X display
 cargo test --locked -p engine-client --test ui_control_functional surface_expedition -- \
-  --ignored --test-threads=1 --nocapture
+  --ignored --test-threads=1
 ```
 
-The full journey test uses two controlled, spinning planets, repeated with
-translating centers. After initial fixture construction it uses **only player
-actions** to capture A, board, launch, coast, brake/turn, land on B, disembark,
-capture/repair, reboard and depart. It verifies both sites remain owned, no
-planet is implicitly claimed, both repairs occur, identities/body counts stay
-stable, four transfers occur, and ship damage stays zero. The sampled routes
-complete in about 36 simulated seconds; wall-clock timing is not a test gate.
-The scripted test pilot is not installed as a gameplay autopilot or bot brain.
+Flag regressions cover neutral raising, nearby-only enemy lowering, a full
+fresh replacement timer, interruptions, local contests, order independence,
+wrong-planet and unrelated-platform support, walking/jumping/knockdown,
+exact attachment through translation/rotation, and real physical land/exit/
+claim/reboard cycles at twelve motion/bearing combinations. A second pilot
+landing on the far side cannot lower the flag until physically supported
+near it.
 
-Separate generated-arrival tests start near nonzero-index planets with a stale
-departure frame, then establish real support, exit and reboard there. Other
-checks cover nearest-surface selection and hysteresis, settling-time reset,
-foreign-site repair rejection, unrelated-platform boarding rejection,
-deterministic replay, restart, site collider counts, and independent minimap
-ownership colors. The real UI workflow covers launcher, both renderer choices,
-pause, restart, return and relaunch; software-backend vector limitations are
-documented in [Functional UI tests](functional-tests.md).
+A controlled two-planet journey uses only player actions after fixture setup:
+claim A, board, launch, coast, brake/turn, land on B, claim, reboard and depart.
+It runs with stationary and translating centers and spinning surfaces,
+preserving both flags, identities and body counts, with four transfers and no
+ship damage. The original outpost/capture/repair journey remains a separate
+reference test. The scripted test pilot is not a gameplay autopilot.
 
-The controlled routes are not a guarantee that every generated planet pair is
-easy to traverse. Surface V1's passive-approach failures, mutual-field mismatch
-and long-idle drift remain tracked limitations. Landing too far from a site's
-24-unit service range requires walking and/or relocating the ship.
+Client checks cover one/two-player input, disconnect, cameras, minimap
+footprints, ownership colors and actual flag raster pixels at desktop,
+portrait and 800×480 Pi-sized resolutions. Real UI workflows exercise both
+renderer choices, launcher, settings persistence, pause, restart and relaunch.
+See [Functional UI tests](functional-tests.md) for software-backend vector
+limitations. Hardware/controller feel remains a manual check.
+
+Validation of the multiplayer + flag loop (2026-09-07, Rust 1.89): **844**
+workspace/all-target tests and all **14** real UI workflows pass. Frozen
+ordinary-game `navigation-v1` (6 episodes) and `strategy-v1` (12 episodes)
+baselines match. Windows client and ARM64 scenario compile checks pass.
+Clippy completes with pre-existing warnings outside the surface changes.
+The separate Pi deployment smoke check is recorded above; it does not replace
+manual controller and flag-loop playtesting.
 
 ## Remaining integration
 
-Next come multiple independent pilots/vehicles, explicit loss/rescue/rebuild
-rules, contested services, and versioned bot surface intents. Damage or loss
-of this experiment's only vehicle can still require a restart; there is no
-combat, rescue, ship swapping, economy, or new ordinary-game docking policy.
+Loss/rescue/rebuild rules and versioned bot surface intents remain separate
+work. There is no combat, ship swapping, economy or ordinary-game docking
+change here. A lost assigned ship can still require a restart. Surface V1's
+passive-approach failures, mutual-field mismatch, arbitrary generated routes
+and long-idle support drift remain known limits. Ownership is now deliberately
+simpler than future outposts, resources and services.

--- a/docs/surface-sortie.md
+++ b/docs/surface-sortie.md
@@ -197,10 +197,12 @@ include landing phase, clearance, angle, relative speeds/spin, foot count,
 assist strength, and settling duration for future runners. Outpost observations
 add identity, position/normal, owner, active claimant, capture eligibility and
 progress, capture count, repair eligibility/range, and cumulative health
-restored. The current JSON envelope is version 9 with a `players` array;
+restored. The current JSON envelope is version 10 with a `players` array;
 these pinned presets contain only seat 0. Version 9 makes `outpost` optional
 and adds `planet_claim`/`planet_claims` for Expedition; pinned outpost fixtures
-retain their existing behavior. This does not add a live IPC
+retain their existing behavior. Version 10 adds `vehicle_form` and optional
+Expedition recovery telemetry (`recovery` is null in these pinned fixtures).
+This does not add a live IPC
 telemetry API.
 
 Landing regressions fly gentle approaches at eight bearings, verify physical
@@ -278,7 +280,7 @@ version 4; version 5 adds the optional `generated_case` identifier; version 6
 adds its explicit gravity/motion `profile`; version 7 adds travel, explicit
 support/frame planet IDs and the complete outpost inventory; version 8 wraps
 independent seat views in a `players` array; version 9 adds planet claims and
-an optional focused outpost):
+an optional focused outpost; version 10 adds vehicle form and optional recovery):
 
 - completed planet position, origin velocity, angle/spin, active-body
   surface-relative velocity, and actual support-point velocity/relative speed;

--- a/docs/surface-sortie.md
+++ b/docs/surface-sortie.md
@@ -35,7 +35,7 @@ not a new ordinary-game default. Both generated presets start on planet 0,
 initially away from the sun. See the [profile comparison](surface-compatibility.md#surface-v1-experiment)
 for parameters, results, and remaining approach/long-idle limits.
 
-For travel between those planets and separate outposts, choose
+For travel between those planets and flag-based planet claiming, choose
 **surface-expedition**. It adds dynamic approach/support selection to the same
 scenario; the four original presets remain pinned compatibility fixtures.
 See [Surface Expedition](surface-expedition.md) for that opt-in loop and scope.
@@ -192,12 +192,16 @@ Headless regressions cover exit/walk/jump/return/reboard without pose shortcuts,
 ship health and creature identity preservation, one-body lifecycle, velocity
 inheritance, no airborne transport, blocked exits, unsafe/remote boarding,
 held-input gating in both directions, and reproducible actions/restarts. Typed
-`SurfaceSortieState::observation()` and version-4 JSON scenario observations
+`SurfaceSortieState::observation(player)` and JSON scenario observations
 include landing phase, clearance, angle, relative speeds/spin, foot count,
 assist strength, and settling duration for future runners. Outpost observations
 add identity, position/normal, owner, active claimant, capture eligibility and
 progress, capture count, repair eligibility/range, and cumulative health
-restored. This does not add a live IPC telemetry API.
+restored. The current JSON envelope is version 9 with a `players` array;
+these pinned presets contain only seat 0. Version 9 makes `outpost` optional
+and adds `planet_claim`/`planet_claims` for Expedition; pinned outpost fixtures
+retain their existing behavior. This does not add a live IPC
+telemetry API.
 
 Landing regressions fly gentle approaches at eight bearings, verify physical
 takeoff/return, contact-only boarding, the settling interval, sideways damping,
@@ -272,7 +276,9 @@ not retune those orbits, gravity, rovers, ships, or bots.
 Typed/JSON observations include `motion` and `motion_metrics` (introduced in
 version 4; version 5 adds the optional `generated_case` identifier; version 6
 adds its explicit gravity/motion `profile`; version 7 adds travel, explicit
-support/frame planet IDs and the complete outpost inventory):
+support/frame planet IDs and the complete outpost inventory; version 8 wraps
+independent seat views in a `players` array; version 9 adds planet claims and
+an optional focused outpost):
 
 - completed planet position, origin velocity, angle/spin, active-body
   surface-relative velocity, and actual support-point velocity/relative speed;

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -1339,6 +1339,9 @@ impl SpacewarsScenario {
                 continue;
             }
             if experimental {
+                if ship.dead {
+                    continue;
+                }
                 // The fixture's bounded flight controller owns control impulses;
                 // retain visual exhaust without the legacy brake/turn velocity edits.
                 ship.update_exhaust_trails(dt);
@@ -1357,7 +1360,7 @@ impl SpacewarsScenario {
         finish_spaceport_ejections(state, dt);
         let new_shells = spawn_cannon_shells(state, dt);
         state.debris.extend(new_shells);
-        handle_ship_deaths(state);
+        handle_ship_deaths_with_surface_pilots(state, surface_pilots);
 
         let lifecycle_started = Instant::now();
         let lifecycle = reconcile_physics(state, dt);
@@ -1371,7 +1374,7 @@ impl SpacewarsScenario {
         };
         let gravity_time = gravity_started.elapsed();
 
-        for pilot in surface_pilots {
+        for pilot in surface_pilots.iter_mut() {
             pilot.control_vehicle(
                 &mut state.physics,
                 &state.ships[pilot.vehicle_index()],
@@ -1388,7 +1391,7 @@ impl SpacewarsScenario {
         let collision_started = Instant::now();
         update_ship_lasers(state);
         state.laser_hits = resolve_laser_hits(state);
-        handle_ship_deaths(state);
+        handle_ship_deaths_with_surface_pilots(state, surface_pilots);
 
         let contacts = state.physics.contacts();
         let port_intersections = state.physics.spaceport_contacts();
@@ -1398,7 +1401,7 @@ impl SpacewarsScenario {
             resolve_physics_spaceport_contacts(state, &port_intersections)
         };
         resolve_physics_collisions(state, &contacts, &accepted_ports);
-        handle_ship_deaths(state);
+        handle_ship_deaths_with_surface_pilots(state, surface_pilots);
         handle_rover_deaths(state);
 
         spawn_debris_breakup_fragments(state);
@@ -2442,10 +2445,11 @@ fn apply_world_gravity_with_pilots(
         ships
             .iter()
             .enumerate()
-            .filter(|(index, _)| {
+            .filter(|(index, ship)| {
                 !physics.ship_is_constrained(*index)
                     && (pilots.is_empty()
-                        || pilots.iter().any(|pilot| pilot.vehicle_index() == *index))
+                        || (!ship.dead
+                            && pilots.iter().any(|pilot| pilot.vehicle_index() == *index)))
             })
             .map(|(index, ship)| {
                 GravityParticipant::target(
@@ -3306,22 +3310,41 @@ fn resolve_particle_body_collision(
     particle.velocity = (particle.velocity - normal * (2.0 * particle.velocity.dot(normal))) * 0.5;
 }
 
+#[cfg(test)]
 fn handle_ship_deaths(state: &mut SpacewarsState) {
+    handle_ship_deaths_with_surface_pilots(state, &mut []);
+}
+
+fn handle_ship_deaths_with_surface_pilots(
+    state: &mut SpacewarsState,
+    pilots: &mut [surface_sortie::SurfacePilot],
+) {
     let mut fragments = Vec::new();
 
-    for ship in &mut state.ships {
+    for (index, ship) in state.ships.iter_mut().enumerate() {
         if !ship.dead || ship.fragmented || ship.form != ShipForm::Ship {
             continue;
         }
 
-        fragments.extend(ship_breakup_fragments(
-            ship,
-            state.seed,
-            state.tick,
-            fragments.len() as u64,
-        ));
+        let survivor = pilots
+            .iter_mut()
+            .find(|pilot| pilot.vehicle_index() == index && pilot.recovery_enabled());
+        let mut breakup =
+            ship_breakup_fragments(ship, state.seed, state.tick, fragments.len() as u64);
+        if survivor.is_some() {
+            // Expedition's transient fragment filter protects the new pod and
+            // external creatures while the initially overlapping pieces disperse.
+            for fragment in &mut breakup {
+                fragment.owner_id = Some(ship.owner_id);
+            }
+        }
+        fragments.extend(breakup);
         ship.fragmented = true;
-        ship.change_to_escape_pod();
+        if let Some(pilot) = survivor {
+            pilot.vehicle_destroyed(ship);
+        } else {
+            ship.change_to_escape_pod();
+        }
     }
 
     state.debris.extend(fragments);

--- a/scenarios/spacewars/src/lib.rs
+++ b/scenarios/spacewars/src/lib.rs
@@ -1279,7 +1279,7 @@ impl Scenario for SpacewarsScenario {
     }
 
     fn step(state: &mut Self::State, actions: &[Action], dt: Duration) -> StepResult {
-        Self::step_with_surface_pilot(state, actions, dt, None)
+        Self::step_with_surface_pilots(state, actions, dt, &mut [])
     }
 
     fn observe(_state: &Self::State) -> Observation {
@@ -1300,13 +1300,13 @@ impl Scenario for SpacewarsScenario {
 impl SpacewarsScenario {
     // The opt-in fixture shares this exact physics step. Ordinary Spacewars
     // passes no pilot and retains its existing services and observation model.
-    fn step_with_surface_pilot(
+    fn step_with_surface_pilots(
         state: &mut SpacewarsState,
         actions: &[Action],
         dt: Duration,
-        mut surface_pilot: Option<&mut surface_sortie::SurfacePilot>,
+        surface_pilots: &mut [surface_sortie::SurfacePilot],
     ) -> StepResult {
-        let experimental = surface_pilot.is_some();
+        let experimental = !surface_pilots.is_empty();
         state.last_step_metrics = SpacewarsStepMetrics::default();
         if state.winner.is_some() {
             return StepResult::default();
@@ -1331,16 +1331,14 @@ impl SpacewarsScenario {
 
         let universe_radius = state.config.universe_radius as f32;
         for (index, ship) in state.ships.iter_mut().enumerate() {
-            if surface_pilot
-                .as_ref()
-                .is_some_and(|pilot| pilot.vehicle_index() != index)
+            if experimental
+                && !surface_pilots
+                    .iter()
+                    .any(|pilot| pilot.vehicle_index() == index)
             {
                 continue;
             }
-            if surface_pilot
-                .as_ref()
-                .is_some_and(|pilot| pilot.vehicle_index() == index)
-            {
+            if experimental {
                 // The fixture's bounded flight controller owns control impulses;
                 // retain visual exhaust without the legacy brake/turn velocity edits.
                 ship.update_exhaust_trails(dt);
@@ -1366,14 +1364,14 @@ impl SpacewarsScenario {
         let lifecycle_time = lifecycle_started.elapsed();
 
         let gravity_started = Instant::now();
-        let gravity = if let Some(pilot) = surface_pilot.as_deref_mut() {
-            apply_world_gravity_with_pilot(state, Some(pilot), dt)
+        let gravity = if experimental {
+            apply_world_gravity_with_pilots(state, surface_pilots, dt)
         } else {
             apply_world_gravity(state)
         };
         let gravity_time = gravity_started.elapsed();
 
-        if let Some(pilot) = surface_pilot {
+        for pilot in surface_pilots {
             pilot.control_vehicle(
                 &mut state.physics,
                 &state.ships[pilot.vehicle_index()],
@@ -2378,12 +2376,12 @@ fn body_mass(radius: f32) -> f32 {
 }
 
 fn apply_world_gravity(state: &mut SpacewarsState) -> GravityStepMetrics {
-    apply_world_gravity_with_pilot(state, None, state.config.delta_time())
+    apply_world_gravity_with_pilots(state, &mut [], state.config.delta_time())
 }
 
-fn apply_world_gravity_with_pilot(
+fn apply_world_gravity_with_pilots(
     state: &mut SpacewarsState,
-    mut pilot: Option<&mut surface_sortie::SurfacePilot>,
+    pilots: &mut [surface_sortie::SurfacePilot],
     dt: f32,
 ) -> GravityStepMetrics {
     let SpacewarsState {
@@ -2400,7 +2398,7 @@ fn apply_world_gravity_with_pilot(
         ..
     } = state;
     gravity_participants.clear();
-    if let Some(pilot) = pilot.as_deref_mut() {
+    for pilot in pilots.iter_mut() {
         pilot.ship_gravity_delta = Vec2::ZERO;
     }
 
@@ -2416,7 +2414,7 @@ fn apply_world_gravity_with_pilot(
         // actors and contacts still describe the completed step. Sample the
         // same current frame for gravity and controls. Legacy gameplay retains
         // its established integration order and deterministic baselines.
-        let position = if pilot.is_some() {
+        let position = if !pilots.is_empty() {
             physics
                 .world
                 .motion(physics.planet_body(index))
@@ -2431,12 +2429,14 @@ fn apply_world_gravity_with_pilot(
             planet.mass,
         )
     }));
-    if let Some(snapshot) = pilot.as_deref().and_then(|pilot| pilot.snapshot(physics)) {
-        gravity_participants.push(GravityParticipant::target(
-            tagged_gravity_id(GRAVITY_SURFACE_PILOT_TAG, 0),
-            snapshot.motion.position,
-            1.0,
-        ));
+    for pilot in pilots.iter() {
+        if let Some(snapshot) = pilot.snapshot(physics) {
+            gravity_participants.push(GravityParticipant::target(
+                tagged_gravity_id(GRAVITY_SURFACE_PILOT_TAG, pilot.owner.index() as u64),
+                snapshot.motion.position,
+                1.0,
+            ));
+        }
     }
     gravity_participants.extend(
         ships
@@ -2444,9 +2444,8 @@ fn apply_world_gravity_with_pilot(
             .enumerate()
             .filter(|(index, _)| {
                 !physics.ship_is_constrained(*index)
-                    && pilot
-                        .as_ref()
-                        .is_none_or(|pilot| pilot.vehicle_index() == *index)
+                    && (pilots.is_empty()
+                        || pilots.iter().any(|pilot| pilot.vehicle_index() == *index))
             })
             .map(|(index, ship)| {
                 GravityParticipant::target(
@@ -2531,7 +2530,10 @@ fn apply_world_gravity_with_pilot(
         }
         match tag {
             GRAVITY_SURFACE_PILOT_TAG => {
-                if let Some(pilot) = pilot.as_deref_mut() {
+                if let Some(pilot) = pilots
+                    .iter_mut()
+                    .find(|pilot| pilot.owner.index() as u64 == payload)
+                {
                     // Spacewars' historical gravity scale is a per-fixed-tick
                     // velocity delta. Convert it to acceleration for the
                     // controller's disturbance reference, then apply it once.
@@ -2540,9 +2542,9 @@ fn apply_world_gravity_with_pilot(
             }
             GRAVITY_SHIP_TAG => {
                 let index = usize::try_from(payload).expect("ship gravity id fits usize");
-                if let Some(pilot) = pilot
-                    .as_deref_mut()
-                    .filter(|pilot| pilot.vehicle_index() == index)
+                if let Some(pilot) = pilots
+                    .iter_mut()
+                    .find(|pilot| pilot.vehicle_index() == index)
                 {
                     pilot.ship_gravity_delta = output.velocity_delta;
                 }

--- a/scenarios/spacewars/src/physics.rs
+++ b/scenarios/spacewars/src/physics.rs
@@ -39,6 +39,13 @@ const OUTPOST_TERMINAL_ROLE: ColliderRole = ColliderRole::new(9);
 
 pub(super) const LANDING_FOOT_RADIUS: f32 = 0.45;
 pub(super) const LANDING_FEET: [Vec2; 2] = [Vec2::new(-3.0, -5.0), Vec2::new(3.0, -5.0)];
+const RECOVERY_BREAKUP_GRACE_TICKS: u64 = 30;
+pub(super) fn surface_landing_geometry(form: ShipForm) -> ([Vec2; 2], f32) {
+    match form {
+        ShipForm::Ship => (LANDING_FEET, LANDING_FOOT_RADIUS),
+        ShipForm::EscapePod => ([Vec2::new(-0.7, -0.65), Vec2::new(0.7, -0.65)], 0.2),
+    }
+}
 pub(super) const OUTPOST_TERMINAL_HALF_SIZE: Vec2 = Vec2::new(0.7, 1.1);
 
 pub(super) fn is_planet_surface_support(collider: ColliderId, planet: usize) -> bool {
@@ -182,6 +189,7 @@ pub(super) struct SpacewarsPhysics {
     docked_planets: [Option<usize>; 2],
     // Opt-in physical landing assembly; ordinary Spacewars retains its berths.
     surface_ships: Option<Vec<usize>>,
+    surface_recovery: bool,
     tick: u64,
     contact_last_seen: BTreeMap<(MechanicalEntity, MechanicalEntity), u64>,
     pre_step_motions: BTreeMap<MechanicalEntity, BodyMotion>,
@@ -222,6 +230,7 @@ impl SpacewarsPhysics {
             ship_keys: [None, None],
             docked_planets: [None, None],
             surface_ships: None,
+            surface_recovery: false,
             tick: 0,
             contact_last_seen: BTreeMap::new(),
             pre_step_motions: BTreeMap::new(),
@@ -316,21 +325,9 @@ impl SpacewarsPhysics {
                 .as_ref()
                 .is_some_and(|active| active.contains(&index))
             {
-                self.docked_planets[index] = None;
-                let key = ShipColliderKey {
-                    form: ship.form,
-                    wing_theta: ship.wing_theta.to_bits(),
-                    docked: false,
-                    compact: false,
-                    constrained: false,
-                };
-                if self.ship_keys[index] != Some(key) {
-                    lifecycle.removed += usize::from(self.world.remove_entity(ship_entity(index)));
-                    lifecycle.added +=
-                        usize::from(self.insert_ship(index, ship, false, false, false));
-                } else {
-                    synchronize_ship_to_physics(&mut self.world, index, ship);
-                }
+                let changed = self.reconcile_surface_vehicle(index, ship);
+                lifecycle.added += changed.added;
+                lifecycle.removed += changed.removed;
                 continue;
             }
             // A pod is captured automatically so it can rebuild. A full ship
@@ -467,6 +464,78 @@ impl SpacewarsPhysics {
 
     pub(super) fn ship_body(&self, index: usize) -> PhysicsBodyId {
         primary_body(ship_entity(index))
+    }
+
+    pub(super) fn enable_surface_recovery(&mut self) {
+        self.surface_recovery = true;
+    }
+
+    pub(super) fn surface_vehicle_changed(&self, index: usize, ship: &ShipState) -> bool {
+        self.ship_keys[index].map(|key| key.form) != (!ship.dead).then_some(ship.form)
+    }
+
+    /// Materialize a loss/replacement without another physics step or touching
+    /// terrain targets. Ordinary ships retain their existing lifecycle path.
+    pub(super) fn reconcile_surface_vehicle(
+        &mut self,
+        index: usize,
+        ship: &ShipState,
+    ) -> PhysicsLifecycle {
+        debug_assert!(
+            self.surface_ships
+                .as_ref()
+                .is_some_and(|active| active.contains(&index))
+        );
+        let mut lifecycle = PhysicsLifecycle::default();
+        let next = (!ship.dead).then_some(ShipColliderKey {
+            form: ship.form,
+            wing_theta: ship.wing_theta.to_bits(),
+            docked: false,
+            compact: false,
+            constrained: false,
+        });
+        self.docked_planets[index] = None;
+        if self.ship_keys[index] != next {
+            lifecycle.removed += usize::from(self.world.remove_entity(ship_entity(index)));
+            self.ship_keys[index] = None;
+            // Replacement contacts belong to the new assembly, not its old hull.
+            self.contact_last_seen.retain(|(a, b), _| {
+                *a != MechanicalEntity::Ship(index) && *b != MechanicalEntity::Ship(index)
+            });
+            if next.is_some() {
+                lifecycle.added += usize::from(self.insert_ship(index, ship, false, false, false));
+            }
+        } else if next.is_some() {
+            synchronize_ship_to_physics(&mut self.world, index, ship);
+        }
+        lifecycle
+    }
+
+    pub(super) fn landing_geometry(&self, index: usize) -> ([Vec2; 2], f32) {
+        surface_landing_geometry(self.ship_keys[index].map_or(ShipForm::Ship, |key| key.form))
+    }
+
+    pub(super) fn surface_vehicle_clearance_radius(ship: &ShipState) -> f32 {
+        let (feet, radius) = surface_landing_geometry(ship.form);
+        ship_collision_hull(ship)
+            .iter()
+            .map(|p| p.length())
+            .chain(feet.map(|p| p.length() + radius))
+            .fold(0.0, f32::max)
+            + 0.1
+    }
+
+    pub(super) fn surface_vehicle_space_is_clear(
+        &self,
+        ship: &ShipState,
+        center: Vec2,
+        radius: f32,
+    ) -> bool {
+        let mut groups = ship_collision_groups(ship, false);
+        groups.filter =
+            (groups.filter & !(GROUP_BODY | GROUP_SPACEPORT_SENSOR)) | GROUP_ROVER_SURFACE;
+        self.world
+            .capsule_is_clear(center, 0.0, 0.0, radius, groups)
     }
 
     pub(super) fn planet_body(&self, index: usize) -> PhysicsBodyId {
@@ -855,7 +924,16 @@ impl SpacewarsPhysics {
 
             let key = DebrisColliderKey {
                 signature: debris_signature(item),
-                armed: item.spawn_tick < tick,
+                armed: if self.surface_recovery
+                    && item.kind == DebrisKind::Fragment
+                    && item.owner_id.is_some()
+                {
+                    // Half a second at the scenario's fixed 60 Hz. Keep collisions
+                    // with terrain/debris/opponent vehicles during breakup grace.
+                    tick.saturating_sub(item.spawn_tick) >= RECOVERY_BREAKUP_GRACE_TICKS
+                } else {
+                    item.spawn_tick < tick
+                },
             };
             if self.debris_keys.get(&item.physics_id) != Some(&key) {
                 let entity = PhysicsId::new(item.physics_id);
@@ -993,7 +1071,7 @@ impl SpacewarsPhysics {
             .as_ref()
             .is_some_and(|active| active.contains(&index))
         {
-            surface_ship_colliders(entity, ship)
+            surface_ship_colliders(entity, ship, self.surface_recovery)
         } else {
             ship_colliders(entity, ship, docked, compact)
         };
@@ -1249,7 +1327,11 @@ fn ship_colliders(
     colliders
 }
 
-fn surface_ship_colliders(entity: PhysicsId, ship: &ShipState) -> Vec<ColliderSpec> {
+fn surface_ship_colliders(
+    entity: PhysicsId,
+    ship: &ShipState,
+    pod_landing: bool,
+) -> Vec<ColliderSpec> {
     let mut colliders = ship_colliders(entity, ship, false, false);
     let hull = &mut colliders[0];
     hull.friction = 0.8;
@@ -1259,12 +1341,11 @@ fn surface_ship_colliders(entity: PhysicsId, ship: &ShipState) -> Vec<ColliderSp
         | GROUP_ROVER_SURFACE;
     hull.solver_groups = hull.collision_groups;
     let groups = hull.collision_groups;
-    if ship.form == ShipForm::Ship {
-        for (part, position) in LANDING_FEET.into_iter().enumerate() {
-            let mut foot = ColliderSpec::ball(
-                collider_id(entity, LANDING_FOOT_ROLE, part as u16),
-                LANDING_FOOT_RADIUS,
-            );
+    if ship.form == ShipForm::Ship || pod_landing {
+        let (feet, radius) = surface_landing_geometry(ship.form);
+        for (part, position) in feet.into_iter().enumerate() {
+            let mut foot =
+                ColliderSpec::ball(collider_id(entity, LANDING_FOOT_ROLE, part as u16), radius);
             foot.local_position = position;
             // Small feet extend behind the hull; no overlapping hull pieces,
             // extra bodies/joints, or changes to the ship's inertial mass.
@@ -1324,19 +1405,19 @@ fn ship_collision_hull(ship: &ShipState) -> Vec<Vec2> {
     lower
 }
 
-fn ship_pivot(form: ShipForm) -> Vec2 {
+pub(super) fn ship_pivot(form: ShipForm) -> Vec2 {
     match form {
         ShipForm::Ship => SHIP_PIVOT,
         ShipForm::EscapePod => POD_PIVOT,
     }
 }
 
-fn physical_angular_velocity(ship: &ShipState) -> f32 {
+pub(super) fn physical_angular_velocity(ship: &ShipState) -> f32 {
     let scale = 1.0 - ship.turn_power / ship.delta_time.max(f32::EPSILON);
     ship.omega * scale
 }
 
-fn control_angular_velocity(ship: &ShipState, physical: f32) -> f32 {
+pub(super) fn control_angular_velocity(ship: &ShipState, physical: f32) -> f32 {
     let scale = 1.0 - ship.turn_power / ship.delta_time.max(f32::EPSILON);
     if scale.abs() <= f32::EPSILON {
         0.0

--- a/scenarios/spacewars/src/physics.rs
+++ b/scenarios/spacewars/src/physics.rs
@@ -72,7 +72,7 @@ const GROUP_ALL_SOLIDS: u32 =
 pub(super) fn spaceling_collision_groups() -> CollisionGroups {
     CollisionGroups::new(
         GROUP_SPACELING,
-        GROUP_ROVER_SURFACE | GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_WORLD,
+        GROUP_ROVER_SURFACE | GROUP_ALL_SHIPS | GROUP_DEBRIS | GROUP_WORLD | GROUP_SPACELING,
     )
 }
 
@@ -181,7 +181,7 @@ pub(super) struct SpacewarsPhysics {
     ship_keys: [Option<ShipColliderKey>; 2],
     docked_planets: [Option<usize>; 2],
     // Opt-in physical landing assembly; ordinary Spacewars retains its berths.
-    surface_ship: Option<usize>,
+    surface_ships: Option<Vec<usize>>,
     tick: u64,
     contact_last_seen: BTreeMap<(MechanicalEntity, MechanicalEntity), u64>,
     pre_step_motions: BTreeMap<MechanicalEntity, BodyMotion>,
@@ -221,7 +221,7 @@ impl SpacewarsPhysics {
             sun_radius: None,
             ship_keys: [None, None],
             docked_planets: [None, None],
-            surface_ship: None,
+            surface_ships: None,
             tick: 0,
             contact_last_seen: BTreeMap::new(),
             pre_step_motions: BTreeMap::new(),
@@ -302,12 +302,20 @@ impl SpacewarsPhysics {
         }
 
         for (index, ship) in ships.iter_mut().enumerate() {
-            if self.surface_ship.is_some_and(|active| index != active) {
+            if self
+                .surface_ships
+                .as_ref()
+                .is_some_and(|active| !active.contains(&index))
+            {
                 // The single-pilot fixture retains the legacy two-slot data
                 // layout, but does not simulate an invisible second craft.
                 continue;
             }
-            if self.surface_ship == Some(index) {
+            if self
+                .surface_ships
+                .as_ref()
+                .is_some_and(|active| active.contains(&index))
+            {
                 self.docked_planets[index] = None;
                 let key = ShipColliderKey {
                     form: ship.form,
@@ -416,19 +424,18 @@ impl SpacewarsPhysics {
             .is_some_and(|key| key.constrained)
     }
 
-    /// Configure the single-vehicle fixture, including physical landing feet.
-    pub(super) fn enable_surface_sortie(&mut self, index: usize, ship: &ShipState) {
-        self.surface_ship = Some(index);
-        for other in 0..self.ship_keys.len() {
-            if other != index {
-                self.world.remove_entity(ship_entity(other));
-                self.ship_keys[other] = None;
-                self.docked_planets[other] = None;
+    /// Configure the fixture's active vehicles, with real landing feet and no ports.
+    /// Called only during setup, before any actors occupy or leave these ships.
+    pub(super) fn enable_surface_sortie(&mut self, indices: &[usize], ships: &[ShipState]) {
+        self.surface_ships = Some(indices.to_vec());
+        for (index, ship) in ships.iter().enumerate().take(self.ship_keys.len()) {
+            self.world.remove_entity(ship_entity(index));
+            self.ship_keys[index] = None;
+            self.docked_planets[index] = None;
+            if indices.contains(&index) {
+                assert!(self.insert_ship(index, ship, false, false, false));
             }
         }
-        self.docked_planets[index] = None;
-        self.world.remove_entity(ship_entity(index));
-        assert!(self.insert_ship(index, ship, false, false, false));
     }
 
     /// An intact terminal attached to existing terrain: one collider, no new body.
@@ -981,7 +988,11 @@ impl SpacewarsPhysics {
         constrained: bool,
     ) -> bool {
         let entity = ship_entity(index);
-        let colliders = if self.surface_ship == Some(index) {
+        let colliders = if self
+            .surface_ships
+            .as_ref()
+            .is_some_and(|active| active.contains(&index))
+        {
             surface_ship_colliders(entity, ship)
         } else {
             ship_colliders(entity, ship, docked, compact)

--- a/scenarios/spacewars/src/surface_sortie.rs
+++ b/scenarios/spacewars/src/surface_sortie.rs
@@ -8,6 +8,7 @@ use engine_rapier::{
     world::PhysicsId,
 };
 
+mod claim;
 pub mod compatibility;
 mod landing;
 mod motion;
@@ -15,6 +16,9 @@ mod outpost;
 mod profiles;
 mod render;
 mod travel;
+pub use claim::{
+    PlanetClaimObservation, PlanetClaimPhase, PlanetClaimStatus, PlanetFlagObservation,
+};
 pub use landing::{LandingPhase, LandingTelemetry};
 pub use motion::{SurfaceMotionMetrics, SurfaceMotionObservation, SurfaceMotionPreset};
 pub use outpost::{CaptureStatus, OutpostId, OutpostObservation, RepairStatus};
@@ -22,8 +26,10 @@ pub use profiles::GeneratedSurfaceProfile;
 #[cfg(test)]
 mod tests;
 
-const CONTROL_V1: u32 = 0x5355_0001;
-const PILOT_PHYSICS_ID: PhysicsId = PhysicsId::new(40_000);
+const CONTROL_V2: u32 = 0x5355_0002;
+fn pilot_physics_id(player: PlayerId) -> PhysicsId {
+    PhysicsId::new(40_000 + player.index() as u64)
+}
 const SURFACE_RADIUS: f32 = 60.0;
 const BOARDING_RANGE: f32 = 3.0;
 const SETTLED_SPEED: f32 = 2.0;
@@ -83,34 +89,39 @@ pub struct SurfaceSortieAction {
 }
 
 impl SurfaceSortieAction {
-    pub fn encode(self) -> Action {
+    pub fn encode(self, player: PlayerId) -> Action {
         let mut payload = self.horizontal.to_le_bytes().to_vec();
         payload.extend([
             self.primary_held as u8,
             self.interact_held as u8,
             self.brake_held as u8,
         ]);
-        Action::scenario(CONTROL_V1, payload)
+        payload.push(player.index() as u8);
+        Action::scenario(CONTROL_V2, payload)
     }
 
-    pub fn decode(action: &Action) -> Option<Self> {
+    pub fn decode(action: &Action) -> Option<(PlayerId, Self)> {
         let Action::Scenario {
-            kind: CONTROL_V1,
+            kind: CONTROL_V2,
             payload,
         } = action
         else {
             return None;
         };
-        if payload.len() != 7 || payload[4..].iter().any(|&value| value > 1) {
+        if payload.len() != 8 || payload[4..7].iter().any(|&value| value > 1) {
             return None;
         }
         let horizontal = f32::from_le_bytes(payload[..4].try_into().ok()?);
-        horizontal.is_finite().then_some(Self {
-            horizontal: horizontal.clamp(-1.0, 1.0),
-            primary_held: payload[4] != 0,
-            interact_held: payload[5] != 0,
-            brake_held: payload[6] != 0,
-        })
+        let player = PlayerId::from_index(payload[7] as usize)?;
+        horizontal.is_finite().then_some((
+            player,
+            Self {
+                horizontal: horizontal.clamp(-1.0, 1.0),
+                primary_held: payload[4] != 0,
+                interact_held: payload[5] != 0,
+                brake_held: payload[6] != 0,
+            },
+        ))
     }
 }
 
@@ -118,21 +129,22 @@ pub struct SurfaceSortieState {
     world: SpacewarsState,
     motion_preset: SurfaceMotionPreset,
     generated_case: Option<compatibility::GeneratedSurfaceCase>,
+    pilots: Vec<SurfacePilot>,
+    outposts: Vec<outpost::SurfaceOutpost>,
+    claims: Vec<claim::SurfacePlanetClaim>,
+}
+
+pub(super) struct SurfacePilot {
     motion_metrics: SurfaceMotionMetrics,
     idle_anchor: Option<(bool, Vec2)>,
-    pilot: SurfacePilot,
     input: SurfaceSortieAction,
     interact_was_held: bool,
     controls_armed: bool,
     transfers: u64,
     last_transfer: TransferResult,
     landing: LandingTelemetry,
-    outposts: Vec<outpost::SurfaceOutpost>,
-}
-
-pub(super) struct SurfacePilot {
     id: SpacelingId,
-    owner: PlayerId,
+    pub(super) owner: PlayerId,
     vehicle: VehicleId,
     /// Approach frame, not proof of contact or permission to board/repair.
     planet: usize,
@@ -146,6 +158,30 @@ pub(super) struct SurfacePilot {
 }
 
 impl SurfacePilot {
+    fn new(owner: PlayerId, planet: usize, travel_enabled: bool) -> Self {
+        Self {
+            id: SpacelingId(owner.index() as u64 + 1),
+            owner,
+            vehicle: VehicleId(owner.index()),
+            planet,
+            travel_enabled,
+            body: None,
+            control: SpacelingControl::default(),
+            gravity: Vec2::ZERO,
+            facing: 1.0,
+            gait_phase: 0.0,
+            ship_gravity_delta: Vec2::ZERO,
+            motion_metrics: SurfaceMotionMetrics::default(),
+            idle_anchor: None,
+            input: SurfaceSortieAction::default(),
+            interact_was_held: false,
+            controls_armed: false,
+            transfers: 0,
+            last_transfer: TransferResult::Ready,
+            landing: LandingTelemetry::default(),
+        }
+    }
+
     pub(super) fn snapshot(
         &self,
         physics: &physics::SpacewarsPhysics,
@@ -167,6 +203,12 @@ impl SurfacePilot {
                 .apply_velocity_delta(body.body(), velocity_delta, true);
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SurfaceSessionObservation {
+    pub version: u32,
+    pub players: Vec<SurfaceSortieObservation>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -196,39 +238,45 @@ pub struct SurfaceSortieObservation {
     pub controls_armed: bool,
     pub physical_bodies: usize,
     pub landing: LandingTelemetry,
-    pub outpost: OutpostObservation,
+    pub outpost: Option<OutpostObservation>,
     pub outposts: Vec<OutpostObservation>,
+    pub planet_claim: Option<PlanetClaimObservation>,
+    pub planet_claims: Vec<PlanetClaimObservation>,
     pub motion: SurfaceMotionObservation,
     pub motion_metrics: SurfaceMotionMetrics,
 }
 
 impl SurfaceSortieState {
-    pub fn spaceling_snapshot(&self) -> Option<SpacelingSnapshot> {
-        self.pilot.snapshot(&self.world.physics)
+    pub fn player_count(&self) -> usize {
+        self.pilots.len()
     }
 
-    pub fn location(&self) -> PilotLocation {
-        if self.pilot.body.is_some() {
+    pub fn spaceling_snapshot(&self, player: usize) -> Option<SpacelingSnapshot> {
+        self.pilots[player].snapshot(&self.world.physics)
+    }
+
+    pub fn location(&self, player: usize) -> PilotLocation {
+        if self.pilots[player].body.is_some() {
             PilotLocation::OnFoot
         } else {
-            PilotLocation::Aboard(self.pilot.vehicle)
+            PilotLocation::Aboard(self.pilots[player].vehicle)
         }
     }
 
-    pub fn observation(&self) -> SurfaceSortieObservation {
-        let ship = &self.world.ships[self.pilot.vehicle.0];
-        let snapshot = self.spaceling_snapshot();
+    pub fn observation(&self, player: usize) -> SurfaceSortieObservation {
+        let ship = &self.world.ships[self.pilots[player].vehicle.0];
+        let snapshot = self.spaceling_snapshot(player);
         SurfaceSortieObservation {
-            version: 7,
+            version: 9,
             generated_case: self.generated_case,
             travel_enabled: self.travel_enabled(),
-            ship_support_planet: self.ship_support_planet(),
-            pilot_support_planet: self.pilot_support_planet(),
+            ship_support_planet: self.ship_support_planet(player),
+            pilot_support_planet: self.pilot_support_planet(player),
             tick: self.world.tick,
-            spaceling: self.pilot.id,
-            owner: self.pilot.owner,
-            vehicle: self.pilot.vehicle,
-            location: self.location(),
+            spaceling: self.pilots[player].id,
+            owner: self.pilots[player].owner,
+            vehicle: self.pilots[player].vehicle,
+            location: self.location(player),
             position: snapshot.map_or(ship.position, |s| s.motion.position),
             velocity: snapshot.map_or(ship.velocity, |s| s.motion.linear_velocity),
             angle: snapshot.map_or(ship.rotation_radians, |s| s.motion.angle),
@@ -241,38 +289,42 @@ impl SurfaceSortieState {
             jumps: snapshot.map_or(0, |s| s.jumps),
             ship_position: ship.position,
             ship_health: ship.life,
-            ship_available: self.vehicle_available(),
-            access_position: self.access_position(),
-            transfers: self.transfers,
-            last_transfer: self.last_transfer,
-            controls_armed: self.controls_armed,
+            ship_available: self.vehicle_available(player),
+            access_position: self.access_position(player),
+            transfers: self.pilots[player].transfers,
+            last_transfer: self.pilots[player].last_transfer,
+            controls_armed: self.pilots[player].controls_armed,
             physical_bodies: self.world.physics.world.body_count(),
-            landing: self.landing,
+            landing: self.pilots[player].landing,
             outpost: self
-                .focused_outpost()
-                .observation(&self.world.planets[self.focused_outpost().planet]),
+                .focused_outpost(player)
+                .map(|post| post.observation(&self.world.planets[post.planet], player)),
             outposts: self
                 .outposts
                 .iter()
-                .map(|post| post.observation(&self.world.planets[post.planet]))
+                .map(|post| post.observation(&self.world.planets[post.planet], player))
                 .collect(),
-            motion: self.motion_observation(),
-            motion_metrics: self.motion_metrics,
+            planet_claim: self.claim_observation(self.motion_planet_index(player), player),
+            planet_claims: (0..self.claims.len())
+                .filter_map(|planet| self.claim_observation(planet, player))
+                .collect(),
+            motion: self.motion_observation(player),
+            motion_metrics: self.pilots[player].motion_metrics,
         }
     }
 
-    fn access_up(&self) -> Vec2 {
-        let ship = &self.world.ships[self.pilot.vehicle.0];
+    fn access_up(&self, player: usize) -> Vec2 {
+        let ship = &self.world.ships[self.pilots[player].vehicle.0];
         // A surface access point beside the *actual* ship. No elevated berth
         // or fixed planet marker; the physical landing gate is checked first.
         let hatch =
             ship.position + SHIP_PIVOT + Vec2::new(8.0, -5.0).rotate_radians(ship.rotation_radians);
-        (hatch - self.world.planets[self.pilot.planet].position).normalized()
+        (hatch - self.world.planets[self.pilots[player].planet].position).normalized()
     }
 
-    fn access_position(&self) -> Vec2 {
-        let planet = &self.world.planets[self.pilot.planet];
-        planet.position + self.access_up() * (planet.radius * BODY_BOUNDS_RADIUS_SCALE)
+    fn access_position(&self, player: usize) -> Vec2 {
+        let planet = &self.world.planets[self.pilots[player].planet];
+        planet.position + self.access_up(player) * (planet.radius * BODY_BOUNDS_RADIUS_SCALE)
     }
 
     fn spec() -> SpacelingSpec {
@@ -282,31 +334,38 @@ impl SurfaceSortieState {
         }
     }
 
-    fn vehicle_available(&self) -> bool {
-        let ship = &self.world.ships[self.pilot.vehicle.0];
-        !ship.dead && ship.form == ShipForm::Ship && ship.owner_id == self.pilot.owner.index()
+    fn vehicle_available(&self, player: usize) -> bool {
+        let ship = &self.world.ships[self.pilots[player].vehicle.0];
+        !ship.dead
+            && ship.form == ShipForm::Ship
+            && ship.owner_id == self.pilots[player].owner.index()
     }
 
-    fn vehicle_settled(&self) -> bool {
-        self.landing.phase == LandingPhase::Landed
+    fn vehicle_settled(&self, player: usize) -> bool {
+        self.pilots[player].landing.phase == LandingPhase::Landed
     }
 
-    fn try_transfer(&mut self) -> TransferResult {
-        if !self.vehicle_available() {
+    fn try_transfer(&mut self, player: usize) -> TransferResult {
+        if !self.vehicle_available(player) {
             return TransferResult::VehicleUnavailable;
         }
-        if !self.vehicle_settled() {
+        if !self.vehicle_settled(player) {
             return TransferResult::ShipNotSettled;
         }
-        if let Some(snapshot) = self.spaceling_snapshot() {
-            if snapshot.motion.position.distance_to(self.access_position()) > BOARDING_RANGE {
+        if let Some(snapshot) = self.spaceling_snapshot(player) {
+            if snapshot
+                .motion
+                .position
+                .distance_to(self.access_position(player))
+                > BOARDING_RANGE
+            {
                 return TransferResult::TooFar;
             }
             let relative = snapshot.motion.linear_velocity
-                - motion::point_velocity(self.planet_motion(), snapshot.motion.position);
+                - motion::point_velocity(self.planet_motion(player), snapshot.motion.position);
             if !snapshot.grounded()
                 || !snapshot.support.is_some_and(|support| {
-                    physics::is_planet_surface_support(support.collider, self.pilot.planet)
+                    physics::is_planet_surface_support(support.collider, self.pilots[player].planet)
                 })
                 || snapshot.balance != SpacelingBalance::Balanced
                 || relative.length() > SETTLED_SPEED
@@ -315,14 +374,28 @@ impl SurfaceSortieState {
             }
             // The creature remains alive/owned; only its external physical
             // representation disappears while it occupies the existing ship.
-            self.world.physics.world.remove_entity(PILOT_PHYSICS_ID);
-            self.pilot.body = None;
+            self.world
+                .physics
+                .world
+                .remove_entity(pilot_physics_id(self.pilots[player].owner));
+            self.pilots[player].body = None;
             TransferResult::Boarded
         } else {
             let spec = Self::spec();
-            let up = self.access_up();
-            let position = self.access_position() + up * (spec.half_height() + 0.12);
+            let up = self.access_up(player);
+            let position = self.access_position(player) + up * (spec.half_height() + 0.12);
             let angle = rotation_for_direction(up);
+            // Rapier's broad-phase queries describe the completed step. A capsule
+            // inserted by another seat's transfer this tick is not indexed yet.
+            // Reserve a conservative capsule-sized clearance using the bounded
+            // pilot list and authoritative body poses, without another physics step.
+            if self.pilots.iter().any(|pilot| {
+                pilot.snapshot(&self.world.physics).is_some_and(|snapshot| {
+                    snapshot.motion.position.distance_to(position) < spec.half_height() * 2.0 + 0.04
+                })
+            }) {
+                return TransferResult::ExitBlocked;
+            }
             if !self.world.physics.world.capsule_is_clear(
                 position,
                 angle,
@@ -334,21 +407,21 @@ impl SurfaceSortieState {
             }
             let Some(body) = SpacelingAssembly::insert(
                 &mut self.world.physics.world,
-                PILOT_PHYSICS_ID,
+                pilot_physics_id(self.pilots[player].owner),
                 position,
                 angle,
                 spec,
             ) else {
                 return TransferResult::ExitBlocked;
             };
-            let surface = self.planet_motion();
+            let surface = self.planet_motion(player);
             self.world.physics.world.set_velocity(
                 body.body(),
                 motion::point_velocity(surface, position),
                 surface.angular_velocity,
                 true,
             );
-            self.pilot.body = Some(body);
+            self.pilots[player].body = Some(body);
             TransferResult::Exited
         }
     }
@@ -404,7 +477,7 @@ impl Scenario for SurfaceSortieScenario {
         world.sun = motion_preset.configure(&mut planet);
         world.planets = vec![planet];
         world.rover_builds = vec![RoverBuildState::default()];
-        Self::on_surface(world, motion_preset, 0, Vec2::Y, -0.34)
+        Self::on_surface(world, motion_preset, 0, Vec2::Y, Some(-0.34))
     }
 
     fn step(state: &mut SurfaceSortieState, actions: &[Action], dt: Duration) -> StepResult {
@@ -412,101 +485,114 @@ impl Scenario for SurfaceSortieScenario {
         if dt.is_zero() {
             return StepResult::default();
         }
-        if let Some(input) = actions
-            .iter()
-            .filter_map(SurfaceSortieAction::decode)
-            .next_back()
-        {
-            state.input = input;
+        for (player, input) in actions.iter().filter_map(SurfaceSortieAction::decode) {
+            if let Some(pilot) = state.pilots.get_mut(player.index()) {
+                pilot.input = input;
+            }
         }
-        let input = state.input;
-        let before = motion::StepSample::read(state);
-        let mut effective = SurfaceSortieAction::default();
-        if !state.controls_armed {
-            state.controls_armed = input == SurfaceSortieAction::default();
-        } else {
-            effective = input;
-            if input.interact_held && !state.interact_was_held {
-                state.last_transfer = state.try_transfer();
-                if matches!(
-                    state.last_transfer,
-                    TransferResult::Exited | TransferResult::Boarded
-                ) {
-                    state.transfers += 1;
-                    state.controls_armed = false;
-                    effective = SurfaceSortieAction::default();
+        // Bounded seat-local samples; no per-tick actor collection allocation.
+        let samples: [_; SPACEWARS_PLAYER_COUNT] = std::array::from_fn(|player| {
+            (player < state.player_count()).then(|| motion::StepSample::read(state, player))
+        });
+        let mut effective_inputs = [SurfaceSortieAction::default(); SPACEWARS_PLAYER_COUNT];
+        for (player, effective) in effective_inputs
+            .iter_mut()
+            .enumerate()
+            .take(state.player_count())
+        {
+            let input = state.pilots[player].input;
+            if !state.pilots[player].controls_armed {
+                state.pilots[player].controls_armed = input == SurfaceSortieAction::default();
+            } else {
+                *effective = input;
+                if input.interact_held && !state.pilots[player].interact_was_held {
+                    let result = state.try_transfer(player);
+                    state.pilots[player].last_transfer = result;
+                    if matches!(result, TransferResult::Exited | TransferResult::Boarded) {
+                        state.pilots[player].transfers += 1;
+                        state.pilots[player].controls_armed = false;
+                        *effective = SurfaceSortieAction::default();
+                    }
                 }
             }
-        }
-        state.interact_was_held = input.interact_held;
-        let on_foot = state.pilot.body.is_some();
-        state.pilot.control = if on_foot {
-            SpacelingControl {
-                walk: effective.horizontal,
-                jump_held: effective.primary_held,
+            let pilot = &mut state.pilots[player];
+            pilot.interact_was_held = input.interact_held;
+            let on_foot = pilot.body.is_some();
+            pilot.control = if on_foot {
+                SpacelingControl {
+                    walk: effective.horizontal,
+                    jump_held: effective.primary_held,
+                }
+            } else {
+                SpacelingControl::default()
+            };
+            if effective.horizontal.abs() > 0.01 {
+                pilot.facing = effective.horizontal.signum();
             }
-        } else {
-            SpacelingControl::default()
-        };
-        if effective.horizontal.abs() > 0.01 {
-            state.pilot.facing = effective.horizontal.signum();
+            let ship = &mut state.world.ships[pilot.vehicle.0];
+            ship.set_thrust(if !on_foot && effective.primary_held {
+                1.0
+            } else {
+                0.0
+            });
+            ship.set_turn(if on_foot { 0.0 } else { effective.horizontal });
+            ship.set_brake(if !on_foot && effective.brake_held {
+                1.0
+            } else {
+                0.0
+            });
+            ship.set_laser(false);
+            ship.set_cannon(false);
         }
-        let ship = &mut state.world.ships[state.pilot.vehicle.0];
-        ship.set_thrust(if !on_foot && effective.primary_held {
-            1.0
-        } else {
-            0.0
-        });
-        ship.set_turn(if on_foot { 0.0 } else { effective.horizontal });
-        ship.set_brake(if !on_foot && effective.brake_held {
-            1.0
-        } else {
-            0.0
-        });
-        ship.set_laser(false);
-        ship.set_cannon(false);
-        // Schedule terrain exactly once. Actors are never transported with it;
-        // controls, gravity, and Rapier contacts own their dynamic motion.
+        // Schedule terrain, solve gravity, and step Rapier exactly once for all seats.
         let dt = dt.as_secs_f32();
         for planet in &mut state.world.planets {
             state.motion_preset.advance(planet, state.world.sun, dt);
         }
-        let result = SpacewarsScenario::step_with_surface_pilot(
+        let result = SpacewarsScenario::step_with_surface_pilots(
             &mut state.world,
             &[],
             Duration::from_secs_f32(dt),
-            Some(&mut state.pilot),
+            &mut state.pilots,
         );
-        state
-            .pilot
-            .select_approach_planet(&state.world.physics, &state.world.planets);
-        state.landing.update(
-            &state.world.physics,
-            state.pilot.vehicle.0,
-            state.pilot.planet,
-            &state.world.planets[state.pilot.planet],
-            &state.world.ships[state.pilot.vehicle.0],
-            dt,
-        );
-        if let Some(snapshot) = state.spaceling_snapshot() {
-            state.pilot.gait_phase = (state.pilot.gait_phase
-                + snapshot.relative_speed.abs() * dt * 5.0)
-                .rem_euclid(std::f32::consts::TAU);
+        for (player, (before, effective)) in samples.into_iter().zip(effective_inputs).enumerate() {
+            let Some(before) = before else { continue };
+            let pilot = &mut state.pilots[player];
+            pilot.select_approach_planet(&state.world.physics, &state.world.planets);
+            pilot.landing.update(
+                &state.world.physics,
+                pilot.vehicle.0,
+                pilot.planet,
+                &state.world.planets[pilot.planet],
+                &state.world.ships[pilot.vehicle.0],
+                dt,
+            );
+            if let Some(snapshot) = pilot.snapshot(&state.world.physics) {
+                pilot.gait_phase = (pilot.gait_phase + snapshot.relative_speed.abs() * dt * 5.0)
+                    .rem_euclid(std::f32::consts::TAU);
+            }
+            state.record_motion_step(player, before, effective);
         }
-        state.record_motion_step(before, effective);
-        // Services consume completed physical support/landing, never create it.
+        // Resolve all claimants together, then service each eligible vehicle once.
         state.update_outpost(Duration::from_secs_f32(dt));
+        state.update_planet_claims(Duration::from_secs_f32(dt));
         result
     }
 
     fn observe(state: &SurfaceSortieState) -> Observation {
         Observation {
-            payload: serde_json::to_vec(&state.observation()).expect("finite sortie observation"),
+            payload: serde_json::to_vec(&SurfaceSessionObservation {
+                version: 9,
+                players: (0..state.player_count())
+                    .map(|player| state.observation(player))
+                    .collect(),
+            })
+            .expect("finite sortie observation"),
         }
     }
 
     fn render_frame(state: &SurfaceSortieState) -> RenderFrame {
-        render::frame(state)
+        render::frame(state, 0)
     }
 
     fn tick_model() -> TickModel {
@@ -520,7 +606,7 @@ impl SurfaceSortieScenario {
         motion_preset: SurfaceMotionPreset,
         planet_index: usize,
         up: Vec2,
-        terminal_angle: f32,
+        terminal_angle: Option<f32>,
     ) -> SurfaceSortieState {
         let planet = world.planets[planet_index];
         // Begin just above the rear feet. Only initial placement is prescribed;
@@ -539,49 +625,43 @@ impl SurfaceSortieScenario {
             world.sun,
             &world.planets,
         );
-        world.physics.enable_surface_sortie(0, &world.ships[0]);
+        world.physics.enable_surface_sortie(&[0], &world.ships);
         world.spaceport_contacts.clear();
-        let outpost = outpost::SurfaceOutpost::new(
-            OutpostId(planet_index as u64 + 1),
-            planet_index,
-            terminal_angle,
-        );
-        assert!(
-            world
-                .physics
-                .insert_surface_terminal(planet_index, planet.radius, terminal_angle)
-        );
+        let outposts = terminal_angle
+            .into_iter()
+            .map(|angle| {
+                assert!(
+                    world
+                        .physics
+                        .insert_surface_terminal(planet_index, planet.radius, angle)
+                );
+                outpost::SurfaceOutpost::new(
+                    OutpostId(planet_index as u64 + 1),
+                    planet_index,
+                    angle,
+                )
+            })
+            .collect();
         SurfaceSortieState {
             world,
             motion_preset,
             generated_case: None,
-            motion_metrics: SurfaceMotionMetrics::default(),
-            idle_anchor: None,
-            pilot: SurfacePilot {
-                id: SpacelingId(1),
-                owner: PlayerId::PLAYER_1,
-                vehicle: VehicleId(0),
-                planet: planet_index,
-                travel_enabled: false,
-                body: None,
-                control: SpacelingControl::default(),
-                gravity: Vec2::ZERO,
-                facing: 1.0,
-                gait_phase: 0.0,
-                ship_gravity_delta: Vec2::ZERO,
-            },
-            input: SurfaceSortieAction::default(),
-            interact_was_held: false,
-            controls_armed: false,
-            transfers: 0,
-            last_transfer: TransferResult::Ready,
-            landing: LandingTelemetry::default(),
-            outposts: vec![outpost],
+            pilots: vec![SurfacePilot::new(PlayerId::PLAYER_1, planet_index, false)],
+            outposts,
+            claims: Vec::new(),
         }
     }
 
+    pub fn player_frame(state: &SurfaceSortieState, player: usize) -> RenderFrame {
+        render::frame(state, player)
+    }
+
     /// Fixed-scale north-up world context; the client overlays this second frame.
-    pub fn minimap_frame(state: &SurfaceSortieState, viewport_aspect: f32) -> RenderFrame {
-        render::minimap(state, viewport_aspect)
+    pub fn minimap_frame(
+        state: &SurfaceSortieState,
+        player: usize,
+        viewport_aspect: f32,
+    ) -> RenderFrame {
+        render::minimap(state, player, viewport_aspect)
     }
 }

--- a/scenarios/spacewars/src/surface_sortie.rs
+++ b/scenarios/spacewars/src/surface_sortie.rs
@@ -14,6 +14,7 @@ mod landing;
 mod motion;
 mod outpost;
 mod profiles;
+mod recovery;
 mod render;
 mod travel;
 pub use claim::{
@@ -23,6 +24,7 @@ pub use landing::{LandingPhase, LandingTelemetry};
 pub use motion::{SurfaceMotionMetrics, SurfaceMotionObservation, SurfaceMotionPreset};
 pub use outpost::{CaptureStatus, OutpostId, OutpostObservation, RepairStatus};
 pub use profiles::GeneratedSurfaceProfile;
+pub use recovery::{SurfaceRecoveryObservation, SurfaceRecoveryStatus};
 #[cfg(test)]
 mod tests;
 
@@ -143,6 +145,7 @@ pub(super) struct SurfacePilot {
     transfers: u64,
     last_transfer: TransferResult,
     landing: LandingTelemetry,
+    recovery: Option<recovery::SurfaceRecovery>,
     id: SpacelingId,
     pub(super) owner: PlayerId,
     vehicle: VehicleId,
@@ -179,6 +182,7 @@ impl SurfacePilot {
             transfers: 0,
             last_transfer: TransferResult::Ready,
             landing: LandingTelemetry::default(),
+            recovery: None,
         }
     }
 
@@ -232,6 +236,8 @@ pub struct SurfaceSortieObservation {
     pub ship_position: Vec2,
     pub ship_health: f32,
     pub ship_available: bool,
+    pub vehicle_form: ShipForm,
+    pub recovery: Option<SurfaceRecoveryObservation>,
     pub access_position: Vec2,
     pub transfers: u64,
     pub last_transfer: TransferResult,
@@ -267,7 +273,7 @@ impl SurfaceSortieState {
         let ship = &self.world.ships[self.pilots[player].vehicle.0];
         let snapshot = self.spaceling_snapshot(player);
         SurfaceSortieObservation {
-            version: 9,
+            version: 10,
             generated_case: self.generated_case,
             travel_enabled: self.travel_enabled(),
             ship_support_planet: self.ship_support_planet(player),
@@ -290,6 +296,11 @@ impl SurfaceSortieState {
             ship_position: ship.position,
             ship_health: ship.life,
             ship_available: self.vehicle_available(player),
+            vehicle_form: ship.form,
+            recovery: self.pilots[player]
+                .recovery
+                .as_ref()
+                .map(|r| r.observation()),
             access_position: self.access_position(player),
             transfers: self.pilots[player].transfers,
             last_transfer: self.pilots[player].last_transfer,
@@ -317,8 +328,14 @@ impl SurfaceSortieState {
         let ship = &self.world.ships[self.pilots[player].vehicle.0];
         // A surface access point beside the *actual* ship. No elevated berth
         // or fixed planet marker; the physical landing gate is checked first.
-        let hatch =
-            ship.position + SHIP_PIVOT + Vec2::new(8.0, -5.0).rotate_radians(ship.rotation_radians);
+        let local = if ship.form == ShipForm::Ship {
+            Vec2::new(8.0, -5.0)
+        } else {
+            Vec2::new(2.8, -0.65)
+        };
+        let hatch = ship.position
+            + physics::ship_pivot(ship.form)
+            + local.rotate_radians(ship.rotation_radians);
         (hatch - self.world.planets[self.pilots[player].planet].position).normalized()
     }
 
@@ -341,12 +358,20 @@ impl SurfaceSortieState {
             && ship.owner_id == self.pilots[player].owner.index()
     }
 
+    fn vehicle_accessible(&self, player: usize) -> bool {
+        let ship = &self.world.ships[self.pilots[player].vehicle.0];
+        self.vehicle_available(player)
+            || (self.pilots[player].recovery.is_some()
+                && !ship.dead
+                && ship.owner_id == self.pilots[player].owner.index())
+    }
+
     fn vehicle_settled(&self, player: usize) -> bool {
         self.pilots[player].landing.phase == LandingPhase::Landed
     }
 
     fn try_transfer(&mut self, player: usize) -> TransferResult {
-        if !self.vehicle_available(player) {
+        if !self.vehicle_accessible(player) {
             return TransferResult::VehicleUnavailable;
         }
         if !self.vehicle_settled(player) {
@@ -505,7 +530,9 @@ impl Scenario for SurfaceSortieScenario {
                 state.pilots[player].controls_armed = input == SurfaceSortieAction::default();
             } else {
                 *effective = input;
-                if input.interact_held && !state.pilots[player].interact_was_held {
+                if state.update_scuttle_input(player, input, dt) {
+                    *effective = SurfaceSortieAction::default();
+                } else if input.interact_held && !state.pilots[player].interact_was_held {
                     let result = state.try_transfer(player);
                     state.pilots[player].last_transfer = result;
                     if matches!(result, TransferResult::Exited | TransferResult::Boarded) {
@@ -530,13 +557,17 @@ impl Scenario for SurfaceSortieScenario {
                 pilot.facing = effective.horizontal.signum();
             }
             let ship = &mut state.world.ships[pilot.vehicle.0];
-            ship.set_thrust(if !on_foot && effective.primary_held {
+            ship.set_thrust(if !on_foot && !ship.dead && effective.primary_held {
                 1.0
             } else {
                 0.0
             });
-            ship.set_turn(if on_foot { 0.0 } else { effective.horizontal });
-            ship.set_brake(if !on_foot && effective.brake_held {
+            ship.set_turn(if on_foot || ship.dead {
+                0.0
+            } else {
+                effective.horizontal
+            });
+            ship.set_brake(if !on_foot && !ship.dead && effective.brake_held {
                 1.0
             } else {
                 0.0
@@ -555,6 +586,7 @@ impl Scenario for SurfaceSortieScenario {
             Duration::from_secs_f32(dt),
             &mut state.pilots,
         );
+        state.reconcile_recovery_vehicles();
         for (player, (before, effective)) in samples.into_iter().zip(effective_inputs).enumerate() {
             let Some(before) = before else { continue };
             let pilot = &mut state.pilots[player];
@@ -576,13 +608,14 @@ impl Scenario for SurfaceSortieScenario {
         // Resolve all claimants together, then service each eligible vehicle once.
         state.update_outpost(Duration::from_secs_f32(dt));
         state.update_planet_claims(Duration::from_secs_f32(dt));
+        state.update_recovery(Duration::from_secs_f32(dt));
         result
     }
 
     fn observe(state: &SurfaceSortieState) -> Observation {
         Observation {
             payload: serde_json::to_vec(&SurfaceSessionObservation {
-                version: 9,
+                version: 10,
                 players: (0..state.player_count())
                     .map(|player| state.observation(player))
                     .collect(),

--- a/scenarios/spacewars/src/surface_sortie/claim.rs
+++ b/scenarios/spacewars/src/surface_sortie/claim.rs
@@ -1,0 +1,393 @@
+//! Planet ownership without infrastructure. Flags are visual, surface-local markers.
+
+use super::*;
+
+const FLAG_STAGE_TIME: Duration = Duration::from_secs(3);
+const FLAG_INTERACTION_RANGE: f32 = 3.0;
+const CLAIM_MAX_SPEED: f32 = 1.0;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanetClaimPhase {
+    #[default]
+    Idle,
+    Lowering,
+    Raising,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanetClaimStatus {
+    Aboard,
+    Elsewhere,
+    NeedSupport,
+    NeedBalance,
+    NeedSettle,
+    ApproachFlag,
+    Ready,
+    Lowering,
+    Raising,
+    Contested,
+    Secured,
+}
+
+impl PlanetClaimStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Aboard => "land and disembark to claim",
+            Self::Elsewhere => "stand on this planet to claim",
+            Self::NeedSupport => "stand on the planet's surface",
+            Self::NeedBalance => "recover your balance",
+            Self::NeedSettle | Self::Ready => "stand still to claim",
+            Self::ApproachFlag => "walk to the flag",
+            Self::Lowering => "lowering enemy flag; stay nearby",
+            Self::Raising => "raising your flag; stand still",
+            Self::Contested => "contested; flag progress paused",
+            Self::Secured => "your planet",
+        }
+    }
+}
+
+/// The contact location and normal in the completed terrain body's frame.
+/// Never reproject onto an assumed radius: future noncircular ground can use
+/// the same attachment contract without adding a rigid body for the flag.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct FlagAnchor {
+    position: Vec2,
+    normal: Vec2,
+}
+
+impl FlagAnchor {
+    fn world_position(self, frame: motion::SurfaceFrame) -> Vec2 {
+        frame.position + self.position.rotate_radians(frame.angle)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PlanetFlag {
+    player: PlayerId,
+    anchor: FlagAnchor,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ClaimProgress {
+    player: PlayerId,
+    phase: PlanetClaimPhase,
+    elapsed: Duration,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Claimant {
+    player: PlayerId,
+    planet: Option<usize>,
+    status: PlanetClaimStatus,
+    anchor: Option<FlagAnchor>,
+}
+
+pub(super) struct SurfacePlanetClaim {
+    pub planet: usize,
+    flag: Option<PlanetFlag>,
+    progress: Option<ClaimProgress>,
+    statuses: [PlanetClaimStatus; SPACEWARS_PLAYER_COUNT],
+    captures: u64,
+    neutralizations: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct PlanetFlagObservation {
+    pub player: PlayerId,
+    pub position: Vec2,
+    pub normal: Vec2,
+    pub raised_fraction: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PlanetClaimObservation {
+    pub planet: usize,
+    pub owner: Option<PlayerId>,
+    pub claimant: Option<PlayerId>,
+    pub phase: PlanetClaimPhase,
+    pub progress: f32,
+    pub stage_required_seconds: f32,
+    pub flag_interaction_range: f32,
+    pub status: PlanetClaimStatus,
+    pub flag: Option<PlanetFlagObservation>,
+    pub captures: u64,
+    pub neutralizations: u64,
+}
+
+impl SurfacePlanetClaim {
+    pub(super) fn new(planet: usize) -> Self {
+        Self {
+            planet,
+            flag: None,
+            progress: None,
+            statuses: [PlanetClaimStatus::Aboard; SPACEWARS_PLAYER_COUNT],
+            captures: 0,
+            neutralizations: 0,
+        }
+    }
+
+    pub(super) fn observation(
+        &self,
+        owner: Option<usize>,
+        frame: motion::SurfaceFrame,
+        player: usize,
+    ) -> PlanetClaimObservation {
+        let phase = self.progress.map_or(PlanetClaimPhase::Idle, |p| p.phase);
+        let progress = self.progress.map_or(0.0, |p| {
+            p.elapsed.as_secs_f32() / FLAG_STAGE_TIME.as_secs_f32()
+        });
+        PlanetClaimObservation {
+            planet: self.planet,
+            owner: owner.and_then(PlayerId::from_index),
+            claimant: self.progress.map(|p| p.player),
+            phase,
+            progress,
+            stage_required_seconds: FLAG_STAGE_TIME.as_secs_f32(),
+            flag_interaction_range: FLAG_INTERACTION_RANGE,
+            status: self.statuses[player],
+            flag: self.flag.map(|flag| PlanetFlagObservation {
+                player: flag.player,
+                position: flag.anchor.world_position(frame),
+                normal: flag.anchor.normal.rotate_radians(frame.angle),
+                raised_fraction: match phase {
+                    PlanetClaimPhase::Idle => 1.0,
+                    PlanetClaimPhase::Lowering => 1.0 - progress,
+                    PlanetClaimPhase::Raising => progress,
+                },
+            }),
+            captures: self.captures,
+            neutralizations: self.neutralizations,
+        }
+    }
+
+    fn cancel_progress(&mut self) {
+        if self
+            .progress
+            .take()
+            .is_some_and(|p| p.phase == PlanetClaimPhase::Raising)
+        {
+            self.flag = None;
+        }
+        // An interrupted lowering restores the still-owned flag to full height.
+        // A completed lowering has already removed both the flag and owner.
+    }
+
+    fn update(
+        &mut self,
+        owner: &mut Option<usize>,
+        frame: motion::SurfaceFrame,
+        claimants: &[Claimant],
+        dt: Duration,
+    ) {
+        let mut eligible = [None; SPACEWARS_PLAYER_COUNT];
+        let mut count = 0;
+        for candidate in claimants {
+            let status = if candidate.planet.is_some_and(|planet| planet != self.planet) {
+                PlanetClaimStatus::Elsewhere
+            } else if candidate.status == PlanetClaimStatus::Ready
+                && self.flag.is_some_and(|flag| {
+                    candidate.anchor.is_some_and(|anchor| {
+                        anchor
+                            .world_position(frame)
+                            .distance_to(flag.anchor.world_position(frame))
+                            > FLAG_INTERACTION_RANGE
+                    })
+                })
+            {
+                PlanetClaimStatus::ApproachFlag
+            } else {
+                candidate.status
+            };
+            self.statuses[candidate.player.index()] = if *owner == Some(candidate.player.index()) {
+                PlanetClaimStatus::Secured
+            } else {
+                status
+            };
+            if status == PlanetClaimStatus::Ready {
+                eligible[count] = Some(*candidate);
+                count += 1;
+            }
+        }
+        // Resolve the complete set first; seat iteration cannot win a capture race.
+        if count > 1 {
+            if self
+                .progress
+                .is_some_and(|p| !eligible.iter().flatten().any(|c| c.player == p.player))
+            {
+                self.cancel_progress();
+            }
+            for candidate in eligible.into_iter().flatten() {
+                self.statuses[candidate.player.index()] = PlanetClaimStatus::Contested;
+            }
+            return;
+        }
+        let Some(candidate) = eligible[0] else {
+            self.cancel_progress();
+            return;
+        };
+        if *owner == Some(candidate.player.index()) {
+            self.cancel_progress();
+            return;
+        }
+        if self.progress.is_none_or(|p| p.player != candidate.player) {
+            self.cancel_progress();
+            let phase = if owner.is_some() {
+                PlanetClaimPhase::Lowering
+            } else {
+                self.flag = Some(PlanetFlag {
+                    player: candidate.player,
+                    anchor: candidate
+                        .anchor
+                        .expect("eligible claimant has real support"),
+                });
+                PlanetClaimPhase::Raising
+            };
+            self.progress = Some(ClaimProgress {
+                player: candidate.player,
+                phase,
+                elapsed: Duration::ZERO,
+            });
+        }
+        let progress = self.progress.as_mut().expect("active claim");
+        self.statuses[candidate.player.index()] = match progress.phase {
+            PlanetClaimPhase::Lowering => PlanetClaimStatus::Lowering,
+            PlanetClaimPhase::Raising => PlanetClaimStatus::Raising,
+            PlanetClaimPhase::Idle => unreachable!("idle is not an active claim"),
+        };
+        progress.elapsed = progress.elapsed.saturating_add(dt).min(FLAG_STAGE_TIME);
+        if progress.elapsed < FLAG_STAGE_TIME {
+            return;
+        }
+        match progress.phase {
+            PlanetClaimPhase::Lowering => {
+                *owner = None;
+                self.flag = Some(PlanetFlag {
+                    player: candidate.player,
+                    anchor: candidate
+                        .anchor
+                        .expect("eligible claimant has real support"),
+                });
+                self.neutralizations += 1;
+                // The old flag is gone. Reserve the new flag at height zero;
+                // raising receives no elapsed time from the lowering tick.
+                self.progress = Some(ClaimProgress {
+                    player: candidate.player,
+                    phase: PlanetClaimPhase::Raising,
+                    elapsed: Duration::ZERO,
+                });
+                self.statuses[candidate.player.index()] = PlanetClaimStatus::Raising;
+            }
+            PlanetClaimPhase::Raising => {
+                *owner = Some(candidate.player.index());
+                self.captures += 1;
+                self.statuses[candidate.player.index()] = PlanetClaimStatus::Secured;
+                self.progress = None;
+            }
+            PlanetClaimPhase::Idle => unreachable!("idle is not an active claim"),
+        }
+        // Ownership changes and both seat views must agree in this same observation.
+        for other in claimants.iter().filter(|c| c.player != candidate.player) {
+            if self.statuses[other.player.index()] == PlanetClaimStatus::Secured {
+                self.statuses[other.player.index()] = other.status;
+            }
+        }
+    }
+}
+
+impl SurfaceSortieState {
+    fn claim_candidate(&self, player: usize) -> Claimant {
+        let mut candidate = Claimant {
+            player: self.pilots[player].owner,
+            planet: None,
+            status: PlanetClaimStatus::Aboard,
+            anchor: None,
+        };
+        let Some(snapshot) = self.spaceling_snapshot(player) else {
+            return candidate;
+        };
+        candidate.status = PlanetClaimStatus::NeedSupport;
+        let Some((support, planet)) = snapshot.support.and_then(|support| {
+            physics::planet_surface_support_index(support.collider)
+                .filter(|&index| index < self.world.planets.len())
+                .map(|planet| (support, planet))
+        }) else {
+            return candidate;
+        };
+        candidate.planet = Some(planet);
+        if snapshot.balance != SpacelingBalance::Balanced {
+            candidate.status = PlanetClaimStatus::NeedBalance;
+            return candidate;
+        }
+        let offset = support.position - snapshot.motion.position;
+        let relative = snapshot.motion.linear_velocity
+            + Vec2::new(-offset.y, offset.x) * snapshot.motion.angular_velocity
+            - support.velocity;
+        if relative.length() > CLAIM_MAX_SPEED {
+            candidate.status = PlanetClaimStatus::NeedSettle;
+            return candidate;
+        }
+        let frame = motion::SurfaceFrame::read(&self.world.physics, planet);
+        candidate.anchor = Some(FlagAnchor {
+            position: (support.position - frame.position).rotate_radians(-frame.angle),
+            normal: support.normal.rotate_radians(-frame.angle),
+        });
+        candidate.status = PlanetClaimStatus::Ready;
+        candidate
+    }
+
+    pub(super) fn update_planet_claims(&mut self, dt: Duration) {
+        if self.claims.is_empty() {
+            return;
+        }
+        // Sample each pilot once from the completed step, not once per planet.
+        let candidates: [_; SPACEWARS_PLAYER_COUNT] = std::array::from_fn(|player| {
+            if player < self.player_count() {
+                self.claim_candidate(player)
+            } else {
+                Claimant {
+                    player: PlayerId::from_index(player).expect("bounded player seat"),
+                    planet: None,
+                    status: PlanetClaimStatus::Aboard,
+                    anchor: None,
+                }
+            }
+        });
+        let count = self.player_count();
+        for claim in &mut self.claims {
+            let frame = motion::SurfaceFrame::read(&self.world.physics, claim.planet);
+            claim.update(
+                &mut self.world.planets[claim.planet].owner_id,
+                frame,
+                &candidates[..count],
+                dt,
+            );
+        }
+    }
+
+    pub(super) fn claim_observation(
+        &self,
+        planet: usize,
+        player: usize,
+    ) -> Option<PlanetClaimObservation> {
+        let claim = self.claims.get(planet)?;
+        Some(claim.observation(
+            self.world.planets[planet].owner_id,
+            motion::SurfaceFrame::read(&self.world.physics, planet),
+            player,
+        ))
+    }
+
+    pub(super) fn enable_planet_claims(&mut self) {
+        self.claims = (0..self.world.planets.len())
+            .map(SurfacePlanetClaim::new)
+            .collect();
+        for pilot in &mut self.pilots {
+            pilot.travel_enabled = true;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/scenarios/spacewars/src/surface_sortie/claim/tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/claim/tests.rs
@@ -1,0 +1,586 @@
+use super::*;
+use engine_rapier::world::{
+    BodyId as PhysicsBodyId, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec,
+};
+
+const P1: PlayerId = PlayerId::PLAYER_1;
+const P2: PlayerId = PlayerId::PLAYER_2;
+const NEUTRAL: SurfaceSortieAction = SurfaceSortieAction {
+    horizontal: 0.0,
+    primary_held: false,
+    interact_held: false,
+    brake_held: false,
+};
+const INTERACT: SurfaceSortieAction = SurfaceSortieAction {
+    interact_held: true,
+    ..NEUTRAL
+};
+
+fn frame() -> motion::SurfaceFrame {
+    motion::SurfaceFrame {
+        position: Vec2::new(40.0, -20.0),
+        angle: 0.4,
+        linear_velocity: Vec2::new(3.0, 2.0),
+        angular_velocity: 0.05,
+    }
+}
+
+fn standing(player: PlayerId, x: f32) -> Claimant {
+    Claimant {
+        player,
+        planet: Some(0),
+        status: PlanetClaimStatus::Ready,
+        anchor: Some(FlagAnchor {
+            position: Vec2::new(x, 10.0),
+            normal: Vec2::Y,
+        }),
+    }
+}
+
+#[test]
+fn claim_requires_full_raise_then_nearby_lowering_before_a_fresh_raise() {
+    let mut claim = SurfacePlanetClaim::new(0);
+    let mut owner = None;
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P1, 7.0)],
+        Duration::from_secs(2),
+    );
+    assert_eq!(owner, None);
+    let partial = claim.observation(owner, frame(), 0);
+    assert_eq!(partial.phase, PlanetClaimPhase::Raising);
+    assert!((partial.flag.unwrap().raised_fraction - 2.0 / 3.0).abs() < 1e-6);
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P1, 7.0)],
+        Duration::from_secs(1),
+    );
+    assert_eq!(owner, Some(0));
+    let original = claim.observation(owner, frame(), 0).flag.unwrap();
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 20.0)],
+        Duration::from_secs(20),
+    );
+    assert_eq!(owner, Some(0));
+    assert_eq!(
+        claim.observation(owner, frame(), 1).status,
+        PlanetClaimStatus::ApproachFlag
+    );
+    assert_eq!(claim.observation(owner, frame(), 1).flag.unwrap(), original);
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 8.0)],
+        Duration::from_secs(1),
+    );
+    assert_eq!(owner, Some(0));
+    let lowering = claim.observation(owner, frame(), 1);
+    assert_eq!(lowering.phase, PlanetClaimPhase::Lowering);
+    assert!((lowering.flag.unwrap().raised_fraction - 2.0 / 3.0).abs() < 1e-6);
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 8.0)],
+        Duration::from_secs(2),
+    );
+    assert_eq!(owner, None);
+    let lowered = claim.observation(owner, frame(), 1);
+    assert_eq!(lowered.phase, PlanetClaimPhase::Raising);
+    assert_eq!(lowered.progress, 0.0);
+    assert_eq!(lowered.flag.unwrap().player, P2);
+    assert_eq!(lowered.flag.unwrap().raised_fraction, 0.0);
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 8.0)],
+        Duration::from_secs(2),
+    );
+    assert_eq!(owner, None, "lowering time must not count toward raising");
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 8.0)],
+        Duration::from_secs(1),
+    );
+    assert_eq!(owner, Some(1));
+    assert_eq!(claim.captures, 2);
+    assert_eq!(claim.neutralizations, 1);
+    assert_eq!(
+        claim
+            .observation(owner, frame(), 1)
+            .flag
+            .unwrap()
+            .raised_fraction,
+        1.0
+    );
+}
+
+#[test]
+fn interruptions_reset_only_the_unfinished_stage_and_never_borrow_another_claim() {
+    let mut claim = SurfacePlanetClaim::new(0);
+    let mut owner = None;
+    claim.update(&mut owner, frame(), &[standing(P1, 0.0)], FLAG_STAGE_TIME);
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 1.0)],
+        Duration::from_secs(2),
+    );
+    let mut airborne = standing(P2, 1.0);
+    airborne.planet = None;
+    airborne.anchor = None;
+    airborne.status = PlanetClaimStatus::NeedSupport;
+    claim.update(&mut owner, frame(), &[airborne], Duration::from_secs(10));
+    assert_eq!(owner, Some(0));
+    let reset = claim.observation(owner, frame(), 1);
+    assert_eq!(reset.phase, PlanetClaimPhase::Idle);
+    assert_eq!(reset.status, PlanetClaimStatus::NeedSupport);
+    assert_eq!(reset.flag.unwrap().raised_fraction, 1.0);
+    claim.update(&mut owner, frame(), &[standing(P2, 1.0)], FLAG_STAGE_TIME);
+    assert_eq!(owner, None);
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 1.0)],
+        Duration::from_secs(2),
+    );
+    claim.update(&mut owner, frame(), &[airborne], Duration::from_secs(1));
+    assert_eq!(
+        owner, None,
+        "completed neutralization survives an interrupted raise"
+    );
+    assert!(claim.flag.is_none());
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P1, -9.0)],
+        Duration::from_secs(1),
+    );
+    assert_eq!(owner, None);
+    assert_eq!(claim.observation(owner, frame(), 0).progress, 1.0 / 3.0);
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P1, -9.0)],
+        Duration::from_secs(2),
+    );
+    assert_eq!(owner, Some(0));
+    assert_eq!(claim.captures, 2);
+}
+
+#[test]
+fn contests_are_local_to_existing_flags_and_independent_of_seat_order() {
+    let mut a = SurfacePlanetClaim::new(0);
+    let mut b = SurfacePlanetClaim::new(0);
+    let mut owner_a = None;
+    let mut owner_b = None;
+    for (claim, owner) in [(&mut a, &mut owner_a), (&mut b, &mut owner_b)] {
+        claim.update(owner, frame(), &[standing(P1, 0.0)], FLAG_STAGE_TIME);
+        claim.update(owner, frame(), &[standing(P2, 1.0)], Duration::from_secs(1));
+    }
+    a.update(
+        &mut owner_a,
+        frame(),
+        &[standing(P1, -1.0), standing(P2, 1.0)],
+        Duration::from_secs(20),
+    );
+    b.update(
+        &mut owner_b,
+        frame(),
+        &[standing(P2, 1.0), standing(P1, -1.0)],
+        Duration::from_secs(20),
+    );
+    for player in 0..2 {
+        assert_eq!(
+            a.observation(owner_a, frame(), player),
+            b.observation(owner_b, frame(), player)
+        );
+        assert_eq!(
+            a.observation(owner_a, frame(), player).status,
+            PlanetClaimStatus::Contested
+        );
+    }
+    assert_eq!(a.observation(owner_a, frame(), 1).progress, 1.0 / 3.0);
+    a.update(
+        &mut owner_a,
+        frame(),
+        &[standing(P1, 20.0), standing(P2, 1.0)],
+        Duration::from_secs(2),
+    );
+    assert_eq!(
+        owner_a, None,
+        "a distant defender cannot contest the old flag"
+    );
+    a.update(
+        &mut owner_a,
+        frame(),
+        &[standing(P1, 20.0), standing(P2, 1.0)],
+        FLAG_STAGE_TIME,
+    );
+    assert_eq!(
+        owner_a,
+        Some(1),
+        "a distant opponent cannot contest the new flag either"
+    );
+}
+
+#[test]
+fn simultaneous_neutral_claimants_do_not_win_by_iteration_order() {
+    let mut claim = SurfacePlanetClaim::new(0);
+    let mut owner = None;
+    claim.update(
+        &mut owner,
+        frame(),
+        &[standing(P2, 10.0), standing(P1, -10.0)],
+        Duration::from_secs(20),
+    );
+    assert_eq!(owner, None);
+    assert!(claim.flag.is_none());
+    assert_eq!(claim.statuses, [PlanetClaimStatus::Contested; 2]);
+    claim.update(&mut owner, frame(), &[standing(P1, -10.0)], FLAG_STAGE_TIME);
+    assert_eq!(owner, Some(0));
+}
+
+#[test]
+fn flags_keep_the_exact_contact_anchor_as_the_planet_rotates_and_translates() {
+    let mut claim = SurfacePlanetClaim::new(0);
+    let mut owner = None;
+    let candidate = standing(P1, 17.0);
+    claim.update(&mut owner, frame(), &[candidate], FLAG_STAGE_TIME);
+    let moved = motion::SurfaceFrame {
+        position: Vec2::new(-100.0, 300.0),
+        angle: 1.9,
+        ..frame()
+    };
+    let flag = claim.observation(owner, moved, 0).flag.unwrap();
+    let anchor = candidate.anchor.unwrap();
+    assert_eq!(
+        flag.position,
+        moved.position + anchor.position.rotate_radians(moved.angle)
+    );
+    assert_eq!(flag.normal, anchor.normal.rotate_radians(moved.angle));
+    assert_eq!(owner, Some(0));
+}
+
+#[test]
+fn nearby_support_on_another_planet_cannot_lower_a_flag() {
+    let mut claim = SurfacePlanetClaim::new(0);
+    let mut owner = None;
+    claim.update(&mut owner, frame(), &[standing(P1, 0.0)], FLAG_STAGE_TIME);
+    let mut foreign = standing(P2, 0.0);
+    foreign.planet = Some(1);
+    claim.update(&mut owner, frame(), &[foreign], Duration::from_secs(30));
+    assert_eq!(owner, Some(0));
+    assert_eq!(claim.statuses[1], PlanetClaimStatus::Elsewhere);
+    assert!(claim.progress.is_none());
+    // Verify both sides of the declared range using the same completed frame.
+    claim.update(&mut owner, frame(), &[standing(P2, 3.01)], FLAG_STAGE_TIME);
+    assert_eq!(owner, Some(0));
+    assert_eq!(claim.statuses[1], PlanetClaimStatus::ApproachFlag);
+    claim.update(&mut owner, frame(), &[standing(P2, 2.99)], FLAG_STAGE_TIME);
+    assert_eq!(owner, None);
+    assert_eq!(claim.neutralizations, 1);
+}
+
+fn step(state: &mut SurfaceSortieState, inputs: [SurfaceSortieAction; 2]) {
+    SurfaceSortieScenario::step(
+        state,
+        &[inputs[0].encode(P1), inputs[1].encode(P2)],
+        Duration::from_secs_f64(1.0 / 60.0),
+    );
+}
+
+fn idle(state: &mut SurfaceSortieState, ticks: usize) {
+    for _ in 0..ticks {
+        step(state, [NEUTRAL; 2]);
+    }
+}
+
+fn fixture(preset: SurfaceMotionPreset, bearing: f32, players: usize) -> SurfaceSortieState {
+    let world = SurfaceSortieScenario::init(preset, 7).world;
+    let up = Vec2::Y.rotate_radians(bearing);
+    let mut state = SurfaceSortieScenario::on_surface(world, preset, 0, up, None);
+    state.enable_planet_claims();
+    state.world.ships[0].life = state.world.ships[0].life_max;
+    if players == 2 {
+        let planet = state.world.planets[0];
+        let up = -up;
+        let center = planet.position + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + 5.5);
+        let ship = &mut state.world.ships[1];
+        ship.position = center - SHIP_PIVOT;
+        ship.rotation_radians = rotation_for_direction(up);
+        ship.direction = up;
+        ship.velocity = preset.initial_velocity(&planet)
+            + Vec2::new(-(center - planet.position).y, (center - planet.position).x)
+                * planet.wrapper_omega;
+        ship.life = ship.life_max;
+        state.pilots.push(SurfacePilot::new(P2, 0, true));
+        state
+            .world
+            .physics
+            .enable_surface_sortie(&[0, 1], &state.world.ships);
+    }
+    idle(&mut state, 120);
+    state
+}
+
+#[test]
+fn landing_disembarking_and_waiting_claims_without_a_terminal_on_moving_planets() {
+    for preset in [
+        SurfaceMotionPreset::Stationary,
+        SurfaceMotionPreset::Translating,
+        SurfaceMotionPreset::Orbit,
+    ] {
+        for bearing in 0..4 {
+            let mut state = fixture(preset, bearing as f32 * std::f32::consts::FRAC_PI_2, 1);
+            let initial = state.observation(0);
+            assert!(
+                state.vehicle_settled(0),
+                "{preset:?}/{bearing}: {initial:?}"
+            );
+            assert!(initial.outpost.is_none());
+            assert!(state.outposts.is_empty());
+            assert_eq!(
+                state.world.planets[0].owner_id, None,
+                "landing alone cannot claim"
+            );
+            let colliders = state.world.physics.world.collider_count();
+            step(&mut state, [INTERACT, NEUTRAL]);
+            assert_eq!(state.location(0), PilotLocation::OnFoot);
+            let mut anchor = None;
+            for _ in 0..360 {
+                idle(&mut state, 1);
+                let claim = state.claim_observation(0, 0).unwrap();
+                if anchor.is_none() && claim.phase == PlanetClaimPhase::Raising {
+                    let frame = motion::SurfaceFrame::read(&state.world.physics, 0);
+                    let support = state.spaceling_snapshot(0).unwrap().support.unwrap();
+                    assert!(claim.flag.unwrap().position.distance_to(support.position) < 0.02);
+                    anchor = Some(state.claims[0].flag.unwrap().anchor);
+                    assert!((claim.flag.unwrap().position - frame.position).length() > 1.0);
+                }
+                if claim.owner == Some(P1) {
+                    break;
+                }
+            }
+            assert_eq!(
+                state.world.planets[0].owner_id,
+                Some(0),
+                "{preset:?}/{bearing}: {:?}",
+                state.observation(0)
+            );
+            assert_eq!(state.claims[0].flag.unwrap().anchor, anchor.unwrap());
+            assert_eq!(state.claims[0].captures, 1);
+            assert_eq!(
+                state.world.physics.world.body_count(),
+                initial.physical_bodies + 1
+            );
+            assert_eq!(state.world.physics.world.collider_count(), colliders + 1);
+            assert_eq!(
+                state.observation(0).ship_health,
+                initial.ship_health,
+                "claiming is not repair"
+            );
+            step(&mut state, [INTERACT, NEUTRAL]);
+            assert_eq!(state.location(0), PilotLocation::Aboard(VehicleId(0)));
+            idle(&mut state, 60);
+            assert_eq!(
+                state.world.physics.world.body_count(),
+                initial.physical_bodies
+            );
+            assert_eq!(state.world.physics.world.collider_count(), colliders);
+            assert_eq!(state.claims[0].flag.unwrap().anchor, anchor.unwrap());
+            assert_eq!(state.world.planets[0].owner_id, Some(0));
+        }
+    }
+}
+
+#[test]
+fn another_landing_cannot_lower_the_flag_until_the_pilot_reaches_it() {
+    let mut state = fixture(SurfaceMotionPreset::Orbit, 0.0, 2);
+    assert!(state.vehicle_settled(0) && state.vehicle_settled(1));
+    step(&mut state, [INTERACT, NEUTRAL]);
+    idle(&mut state, 240);
+    assert_eq!(state.world.planets[0].owner_id, Some(0));
+    step(&mut state, [INTERACT, NEUTRAL]);
+    idle(&mut state, 1);
+    step(&mut state, [NEUTRAL, INTERACT]);
+    idle(&mut state, 240);
+    let old_flag = state.claim_observation(0, 1).unwrap().flag.unwrap();
+    assert_eq!(state.world.planets[0].owner_id, Some(0));
+    assert_eq!(
+        state.claim_observation(0, 1).unwrap().status,
+        PlanetClaimStatus::ApproachFlag
+    );
+    assert_eq!(old_flag.raised_fraction, 1.0);
+    // Arrange arrival near the existing flag, then let real Rapier contact,
+    // balance and relative speed gates drive every stage of the takeover.
+    let planet = state.world.planets[0];
+    let frame = motion::SurfaceFrame::read(&state.world.physics, 0);
+    let up = old_flag
+        .normal
+        .rotate_radians(-2.0 / (planet.radius * BODY_BOUNDS_RADIUS_SCALE));
+    let position = frame.position
+        + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE
+            + SurfaceSortieState::spec().half_height()
+            + 0.1);
+    let body = state.pilots[1].body.as_ref().unwrap().body();
+    state
+        .world
+        .physics
+        .world
+        .set_pose(body, position, rotation_for_direction(up), true);
+    state.world.physics.world.set_velocity(
+        body,
+        motion::point_velocity(frame, position),
+        frame.angular_velocity,
+        true,
+    );
+    let mut saw_lowering = false;
+    let mut saw_neutral = false;
+    for _ in 0..480 {
+        idle(&mut state, 1);
+        let claim = state.claim_observation(0, 1).unwrap();
+        match claim.phase {
+            PlanetClaimPhase::Lowering => {
+                saw_lowering = true;
+                assert_eq!(claim.owner, Some(P1));
+                assert_eq!(claim.flag.unwrap().player, P1);
+            }
+            PlanetClaimPhase::Raising => {
+                saw_neutral = true;
+                assert!(saw_lowering);
+                assert_eq!(claim.owner, None);
+                assert_eq!(claim.flag.unwrap().player, P2);
+            }
+            PlanetClaimPhase::Idle => {}
+        }
+        if claim.owner == Some(P2) {
+            break;
+        }
+    }
+    assert!(saw_lowering && saw_neutral);
+    assert_eq!(
+        state.world.planets[0].owner_id,
+        Some(1),
+        "{:?}",
+        state.observation(1)
+    );
+    assert_eq!(state.claims[0].captures, 2);
+    assert_eq!(state.claims[0].neutralizations, 1);
+}
+
+#[test]
+fn walking_jumping_and_knockdown_interrupt_a_physically_started_claim() {
+    for interruption in 0..3 {
+        let mut state = fixture(SurfaceMotionPreset::Stationary, 0.0, 1);
+        step(&mut state, [INTERACT, NEUTRAL]);
+        idle(&mut state, 80);
+        let partial = state.claim_observation(0, 0).unwrap();
+        assert_eq!(partial.phase, PlanetClaimPhase::Raising);
+        assert!(partial.progress > 0.2 && partial.progress < 1.0);
+        match interruption {
+            0 => {
+                for _ in 0..20 {
+                    step(
+                        &mut state,
+                        [
+                            SurfaceSortieAction {
+                                horizontal: 1.0,
+                                ..NEUTRAL
+                            },
+                            NEUTRAL,
+                        ],
+                    );
+                }
+                assert_eq!(
+                    state.claim_candidate(0).status,
+                    PlanetClaimStatus::NeedSettle
+                );
+            }
+            1 => {
+                step(
+                    &mut state,
+                    [
+                        SurfaceSortieAction {
+                            primary_held: true,
+                            ..NEUTRAL
+                        },
+                        NEUTRAL,
+                    ],
+                );
+                assert!(!state.spaceling_snapshot(0).unwrap().grounded());
+            }
+            _ => {
+                let snapshot = state.spaceling_snapshot(0).unwrap();
+                let body = state.pilots[0].body.as_ref().unwrap().body();
+                state.world.physics.world.set_velocity(
+                    body,
+                    snapshot.motion.linear_velocity,
+                    10.0,
+                    true,
+                );
+                idle(&mut state, 1);
+                assert_eq!(
+                    state.spaceling_snapshot(0).unwrap().balance,
+                    SpacelingBalance::KnockedDown
+                );
+            }
+        }
+        let claim = state.claim_observation(0, 0).unwrap();
+        assert_eq!(claim.owner, None);
+        assert_eq!(claim.phase, PlanetClaimPhase::Idle);
+        assert_eq!(claim.progress, 0.0);
+        assert!(claim.flag.is_none());
+    }
+}
+
+#[test]
+fn standing_on_an_unrelated_platform_is_not_planetary_support() {
+    let mut state = fixture(SurfaceMotionPreset::Stationary, 0.0, 1);
+    state.world.planets[0].wrapper_omega = 0.0;
+    let up = state.access_up(0);
+    let hatch = state.access_position(0);
+    let platform = PhysicsId::new(45_123);
+    assert!(state.world.physics.world.insert_body(
+        PhysicsBodyId::new(platform, BodyRole::PRIMARY),
+        BodySpec {
+            kind: engine_rapier::world::BodyKind::Fixed,
+            position: hatch + up * 0.5,
+            angle: rotation_for_direction(up),
+            ..BodySpec::default()
+        },
+        &[ColliderSpec::cuboid(
+            ColliderId::new(platform, ColliderRole::PRIMARY, 0),
+            0.7,
+            0.2
+        )],
+    ));
+    state.pilots[0].body = SpacelingAssembly::insert(
+        &mut state.world.physics.world,
+        pilot_physics_id(P1),
+        hatch + up * 1.65,
+        rotation_for_direction(up),
+        SurfaceSortieState::spec(),
+    );
+    idle(&mut state, 240);
+    let snapshot = state.spaceling_snapshot(0).unwrap();
+    assert!(snapshot.grounded());
+    assert_eq!(snapshot.balance, SpacelingBalance::Balanced);
+    assert_eq!(
+        state.claim_candidate(0).status,
+        PlanetClaimStatus::NeedSupport
+    );
+    assert_eq!(state.world.planets[0].owner_id, None);
+    assert!(state.claims[0].flag.is_none());
+    state.world.physics.world.remove_entity(platform);
+    idle(&mut state, 300);
+    assert_eq!(
+        state.world.planets[0].owner_id,
+        Some(0),
+        "real planetary support enables claiming"
+    );
+}

--- a/scenarios/spacewars/src/surface_sortie/compatibility.rs
+++ b/scenarios/spacewars/src/surface_sortie/compatibility.rs
@@ -46,6 +46,13 @@ impl GeneratedSurfaceCase {
     }
 
     pub fn init(self) -> Result<SurfaceSortieState, &'static str> {
+        self.init_with_outpost(true)
+    }
+
+    pub(super) fn init_with_outpost(
+        self,
+        outpost: bool,
+    ) -> Result<SurfaceSortieState, &'static str> {
         if self.bearing > 3 {
             return Err("bearing must be 0, 1, 2, or 3");
         }
@@ -67,7 +74,7 @@ impl GeneratedSurfaceCase {
             self.profile.preset(),
             self.planet,
             up,
-            terminal_angle,
+            outpost.then_some(terminal_angle),
         );
         state.generated_case = Some(self);
         Ok(state)
@@ -131,7 +138,7 @@ pub struct SurfaceEnvironment {
 
 impl SurfaceEnvironment {
     pub(super) fn read(state: &SurfaceSortieState) -> Self {
-        let planet = &state.world.planets[state.pilot.planet];
+        let planet = &state.world.planets[state.pilots[0].planet];
         let center = state.world.ships[0].position + SHIP_PIVOT;
         let gravity_point = state.world.ships[0].position;
         let up = (center - planet.position).normalized();
@@ -142,7 +149,7 @@ impl SurfaceEnvironment {
             gravity += source_acceleration(sun.position, sun.mass, gravity_point);
         }
         for (index, source) in state.world.planets.iter().enumerate() {
-            if index != state.pilot.planet {
+            if index != state.pilots[0].planet {
                 external += source_acceleration(source.position, source.mass, planet.position);
             }
             gravity += source_acceleration(source.position, source.mass, gravity_point);
@@ -235,13 +242,13 @@ pub struct PilotProbeObservation {
 
 impl PilotProbeObservation {
     fn read(state: &SurfaceSortieState) -> Option<Self> {
-        state.spaceling_snapshot().map(|snapshot| Self {
+        state.spaceling_snapshot(0).map(|snapshot| Self {
             grounded: snapshot.grounded(),
             balanced: snapshot.balance == SpacelingBalance::Balanced,
             relative_speed: snapshot.relative_speed,
             knockdowns: snapshot.knockdowns,
             last_disturbance_velocity: snapshot.last_knockdown.map(|event| event.velocity_change),
-            gravity_acceleration: state.pilot.gravity,
+            gravity_acceleration: state.pilots[0].gravity,
         })
     }
 }
@@ -257,7 +264,7 @@ pub struct CompatibilityReport {
 fn step(state: &mut SurfaceSortieState, action: SurfaceSortieAction) {
     SurfaceSortieScenario::step(
         state,
-        &[action.encode()],
+        &[action.encode(PlayerId::PLAYER_1)],
         Duration::from_secs_f64(1.0 / 60.0),
     );
 }
@@ -265,10 +272,10 @@ fn step(state: &mut SurfaceSortieState, action: SurfaceSortieAction) {
 fn settle(state: &mut SurfaceSortieState) -> bool {
     for _ in 0..600 {
         step(state, SurfaceSortieAction::default());
-        if state.vehicle_settled() {
+        if state.vehicle_settled(0) {
             return true;
         }
-        if !state.vehicle_available() {
+        if !state.vehicle_available(0) {
             return false;
         }
     }
@@ -276,19 +283,19 @@ fn settle(state: &mut SurfaceSortieState) -> bool {
 }
 
 fn local_pilot_angle(state: &SurfaceSortieState) -> f32 {
-    let frame = state.planet_motion();
-    let offset = state.spaceling_snapshot().unwrap().motion.position - frame.position;
+    let frame = state.planet_motion(0);
+    let offset = state.spaceling_snapshot(0).unwrap().motion.position - frame.position;
     offset.y.atan2(offset.x) - frame.angle
 }
 
 fn pilot_altitude(state: &SurfaceSortieState) -> f32 {
     state
-        .spaceling_snapshot()
+        .spaceling_snapshot(0)
         .unwrap()
         .motion
         .position
-        .distance_to(state.planet_motion().position)
-        - state.world.planets[state.pilot.planet].radius * BODY_BOUNDS_RADIUS_SCALE
+        .distance_to(state.planet_motion(0).position)
+        - state.world.planets[state.pilots[0].planet].radius * BODY_BOUNDS_RADIUS_SCALE
 }
 
 pub(super) fn run_probe(mut state: SurfaceSortieState, kind: ProbeKind) -> ProbeResult {
@@ -304,7 +311,7 @@ pub(super) fn run_probe(mut state: SurfaceSortieState, kind: ProbeKind) -> Probe
         final_pilot: None,
     };
     if kind == ProbeKind::Landing {
-        let planet = state.world.planets[state.pilot.planet];
+        let planet = state.world.planets[state.pilots[0].planet];
         let ship = &mut state.world.ships[0];
         let up = (ship.position + SHIP_PIVOT - planet.position).normalized();
         let center = ship.position + SHIP_PIVOT + up * 18.0;
@@ -316,8 +323,8 @@ pub(super) fn run_probe(mut state: SurfaceSortieState, kind: ProbeKind) -> Probe
         ship.omega = planet.wrapper_omega;
     } else {
         let landed = settle(&mut state);
-        result.setup_metrics = state.motion_metrics;
-        result.final_landing = state.landing;
+        result.setup_metrics = state.pilots[0].motion_metrics;
+        result.final_landing = state.pilots[0].landing;
         if !landed {
             return result;
         }
@@ -329,33 +336,33 @@ pub(super) fn run_probe(mut state: SurfaceSortieState, kind: ProbeKind) -> Probe
                     ..SurfaceSortieAction::default()
                 },
             );
-            result.final_landing = state.landing;
-            result.setup_metrics = state.motion_metrics;
-            if state.location() != PilotLocation::OnFoot {
+            result.final_landing = state.pilots[0].landing;
+            result.setup_metrics = state.pilots[0].motion_metrics;
+            if state.location(0) != PilotLocation::OnFoot {
                 result.reason = "transfer_prerequisite";
                 return result;
             }
             for _ in 0..120 {
                 step(&mut state, SurfaceSortieAction::default());
             }
-            result.setup_metrics = state.motion_metrics;
-            result.final_landing = state.landing;
+            result.setup_metrics = state.pilots[0].motion_metrics;
+            result.final_landing = state.pilots[0].landing;
             result.final_pilot = PilotProbeObservation::read(&state);
-            let snapshot = state.spaceling_snapshot().unwrap();
+            let snapshot = state.spaceling_snapshot(0).unwrap();
             if !snapshot.grounded() || snapshot.balance != SpacelingBalance::Balanced {
                 result.reason = "balanced_support_prerequisite";
                 return result;
             }
         }
     }
-    state.motion_metrics = SurfaceMotionMetrics::default();
-    state.idle_anchor = None;
+    state.pilots[0].motion_metrics = SurfaceMotionMetrics::default();
+    state.pilots[0].idle_anchor = None;
     let initial_angle = state
-        .spaceling_snapshot()
+        .spaceling_snapshot(0)
         .map(|_| local_pilot_angle(&state));
-    let initial_height = state.spaceling_snapshot().map(|_| pilot_altitude(&state));
+    let initial_height = state.spaceling_snapshot(0).map(|_| pilot_altitude(&state));
     let initial_jumps = state
-        .spaceling_snapshot()
+        .spaceling_snapshot(0)
         .map_or(0, |snapshot| snapshot.jumps);
     let mut arc = 0.0;
     let mut previous_angle = initial_angle;
@@ -382,7 +389,7 @@ pub(super) fn run_probe(mut state: SurfaceSortieState, kind: ProbeKind) -> Probe
                     .rem_euclid(std::f32::consts::TAU)
                     - std::f32::consts::PI;
                 arc -= delta
-                    * state.world.planets[state.pilot.planet].radius
+                    * state.world.planets[state.pilots[0].planet].radius
                     * BODY_BOUNDS_RADIUS_SCALE;
                 previous_angle = Some(angle);
                 distance = arc;
@@ -390,23 +397,23 @@ pub(super) fn run_probe(mut state: SurfaceSortieState, kind: ProbeKind) -> Probe
             ProbeKind::Jump => {
                 distance = distance.max(pilot_altitude(&state) - initial_height.unwrap())
             }
-            ProbeKind::Takeoff => distance = distance.max(state.landing.altitude),
+            ProbeKind::Takeoff => distance = distance.max(state.pilots[0].landing.altitude),
             _ => {}
         }
-        if kind == ProbeKind::Landing && state.vehicle_settled() {
+        if kind == ProbeKind::Landing && state.vehicle_settled(0) {
             break;
         }
-        if matches!(kind, ProbeKind::Landing | ProbeKind::Takeoff) && !state.vehicle_available() {
+        if matches!(kind, ProbeKind::Landing | ProbeKind::Takeoff) && !state.vehicle_available(0) {
             break;
         }
     }
-    result.metrics = state.motion_metrics;
-    result.final_landing = state.landing;
+    result.metrics = state.pilots[0].motion_metrics;
+    result.final_landing = state.pilots[0].landing;
     result.final_pilot = PilotProbeObservation::read(&state);
     result.distance =
         matches!(kind, ProbeKind::Walk | ProbeKind::Jump | ProbeKind::Takeoff).then_some(distance);
     let passed = match kind {
-        ProbeKind::Landing => state.vehicle_settled() && result.metrics.ship_damage == 0.0,
+        ProbeKind::Landing => state.vehicle_settled(0) && result.metrics.ship_damage == 0.0,
         ProbeKind::Idle => {
             result.metrics.supported_ticks == result.ticks
                 && result.metrics.knockdowns == 0
@@ -419,12 +426,12 @@ pub(super) fn run_probe(mut state: SurfaceSortieState, kind: ProbeKind) -> Probe
         }
         ProbeKind::Jump => {
             distance > 0.5
-                && state.spaceling_snapshot().unwrap().jumps == initial_jumps + 1
-                && state.spaceling_snapshot().unwrap().grounded()
+                && state.spaceling_snapshot(0).unwrap().jumps == initial_jumps + 1
+                && state.spaceling_snapshot(0).unwrap().grounded()
                 && result.metrics.knockdowns == 0
         }
         ProbeKind::Takeoff => {
-            distance > 10.0 && state.vehicle_available() && state.landing.altitude > 10.0
+            distance > 10.0 && state.vehicle_available(0) && state.pilots[0].landing.altitude > 10.0
         }
     };
     result.outcome = if passed {

--- a/scenarios/spacewars/src/surface_sortie/landing.rs
+++ b/scenarios/spacewars/src/surface_sortie/landing.rs
@@ -78,12 +78,13 @@ impl LandingTelemetry {
             .clamp(-1.0, 1.0)
             .acos()
             .to_degrees();
-        let altitude = physics::LANDING_FEET
+        let (feet, foot_radius) = physics.landing_geometry(index);
+        let altitude = feet
             .into_iter()
             .map(|foot| {
                 (motion.position + foot.rotate_radians(motion.angle)).distance_to(surface.position)
                     - planet.radius * BODY_BOUNDS_RADIUS_SCALE
-                    - physics::LANDING_FOOT_RADIUS
+                    - foot_radius
             })
             .fold(f32::INFINITY, f32::min);
         let near =
@@ -115,8 +116,7 @@ impl LandingTelemetry {
         dt: f32,
     ) {
         let mut next = Self::measure(physics, index, planet_index, planet);
-        let settled = ship.form == ShipForm::Ship
-            && !ship.dead
+        let settled = !ship.dead
             && ship.thrust == 0.0
             && next.supported_feet == 2
             && next.angle_degrees < LANDED_ANGLE
@@ -158,7 +158,7 @@ impl SurfacePilot {
         planets: &[PlanetState],
         dt: f32,
     ) {
-        if ship.form != ShipForm::Ship || ship.dead {
+        if ship.dead || (ship.form == ShipForm::EscapePod && self.recovery.is_none()) {
             return;
         }
         self.select_approach_planet(physics, planets);

--- a/scenarios/spacewars/src/surface_sortie/motion.rs
+++ b/scenarios/spacewars/src/surface_sortie/motion.rs
@@ -113,8 +113,8 @@ impl SurfaceFrame {
 }
 
 impl SurfaceSortieState {
-    pub(super) fn planet_motion(&self) -> SurfaceFrame {
-        SurfaceFrame::read(&self.world.physics, self.motion_planet_index())
+    pub(super) fn planet_motion(&self, player: usize) -> SurfaceFrame {
+        SurfaceFrame::read(&self.world.physics, self.motion_planet_index(player))
     }
 
     pub fn motion_preset(&self) -> SurfaceMotionPreset {
@@ -170,23 +170,23 @@ pub(super) struct StepSample {
 }
 
 impl StepSample {
-    pub(super) fn read(state: &SurfaceSortieState) -> Self {
+    pub(super) fn read(state: &SurfaceSortieState, player: usize) -> Self {
         Self {
-            planet: state.motion_planet_index(),
-            snapshot: state.spaceling_snapshot(),
-            landing: state.landing,
-            ship_health: state.world.ships[state.pilot.vehicle.0].life,
-            ship_available: state.vehicle_available(),
+            planet: state.motion_planet_index(player),
+            snapshot: state.spaceling_snapshot(player),
+            landing: state.pilots[player].landing,
+            ship_health: state.world.ships[state.pilots[player].vehicle.0].life,
+            ship_available: state.vehicle_available(player),
         }
     }
 }
 
 impl SurfaceSortieState {
-    pub(super) fn motion_observation(&self) -> SurfaceMotionObservation {
-        let frame = self.planet_motion();
-        let snapshot = self.spaceling_snapshot();
-        let body = self.pilot.body.as_ref().map_or_else(
-            || self.world.physics.ship_body(self.pilot.vehicle.0),
+    pub(super) fn motion_observation(&self, player: usize) -> SurfaceMotionObservation {
+        let frame = self.planet_motion(player);
+        let snapshot = self.spaceling_snapshot(player);
+        let body = self.pilots[player].body.as_ref().map_or_else(
+            || self.world.physics.ship_body(self.pilots[player].vehicle.0),
             |pilot| pilot.body(),
         );
         let actor = self
@@ -196,7 +196,7 @@ impl SurfaceSortieState {
             .motion(body)
             .expect("active sortie body");
         let surface_velocity = point_velocity(frame, actor.position);
-        let planet_index = self.motion_planet_index();
+        let planet_index = self.motion_planet_index(player);
         let planet = &self.world.planets[planet_index];
         let (scripted_acceleration, mut external_gravity_at_center) =
             self.world.sun.map_or((Vec2::ZERO, Vec2::ZERO), |sun| {
@@ -257,18 +257,24 @@ impl SurfaceSortieState {
         }
     }
 
-    pub(super) fn record_motion_step(&mut self, before: StepSample, input: SurfaceSortieAction) {
-        if before.planet != self.motion_planet_index() {
-            self.idle_anchor = None;
+    pub(super) fn record_motion_step(
+        &mut self,
+        player: usize,
+        before: StepSample,
+        input: SurfaceSortieAction,
+    ) {
+        if before.planet != self.motion_planet_index(player) {
+            self.pilots[player].idle_anchor = None;
         }
-        let after = self.spaceling_snapshot();
-        let available = self.vehicle_available();
-        let ship = &self.world.ships[self.pilot.vehicle.0];
-        let frame = self.planet_motion();
-        let metrics = &mut self.motion_metrics;
+        let after = self.spaceling_snapshot(player);
+        let available = self.vehicle_available(player);
+        let ship = &self.world.ships[self.pilots[player].vehicle.0];
+        let frame = self.planet_motion(player);
+        let pilot = &mut self.pilots[player];
+        let metrics = &mut pilot.motion_metrics;
         metrics.on_foot_ticks += u64::from(after.is_some());
         metrics.supported_ticks += u64::from(after.is_some_and(SpacelingSnapshot::grounded));
-        metrics.ship_landed_ticks += u64::from(self.landing.phase == LandingPhase::Landed);
+        metrics.ship_landed_ticks += u64::from(pilot.landing.phase == LandingPhase::Landed);
         if let (Some(before), Some(after)) = (before.snapshot, after) {
             let jumps = after.jumps.saturating_sub(before.jumps);
             metrics.jumps += jumps;
@@ -278,16 +284,16 @@ impl SurfaceSortieState {
         }
         metrics.ship_support_losses += u64::from(
             before.landing.supported_feet > 0
-                && self.landing.supported_feet == 0
+                && pilot.landing.supported_feet == 0
                 && ship.thrust == 0.0,
         );
         metrics.landings += u64::from(
             before.landing.phase != LandingPhase::Landed
-                && self.landing.phase == LandingPhase::Landed,
+                && pilot.landing.phase == LandingPhase::Landed,
         );
         metrics.departures += u64::from(
             before.landing.phase == LandingPhase::Landed
-                && self.landing.phase != LandingPhase::Landed
+                && pilot.landing.phase != LandingPhase::Landed
                 && ship.thrust > 0.0,
         );
         // Called before service healing. A destroyed/transformed ship loses
@@ -299,7 +305,7 @@ impl SurfaceSortieState {
         let idle = if let Some(snapshot) = after {
             snapshot.grounded() && snapshot.balance == SpacelingBalance::Balanced
         } else {
-            self.landing.phase == LandingPhase::Landed
+            pilot.landing.phase == LandingPhase::Landed
         } && input.horizontal == 0.0
             && !input.primary_held
             && !input.interact_held
@@ -310,15 +316,15 @@ impl SurfaceSortieState {
             });
             let local = (position - frame.position).rotate_radians(-frame.angle);
             let on_foot = after.is_some();
-            let anchor = self
+            let anchor = pilot
                 .idle_anchor
                 .filter(|(foot, _)| *foot == on_foot)
                 .map_or(local, |(_, anchor)| anchor);
-            self.idle_anchor = Some((on_foot, anchor));
+            pilot.idle_anchor = Some((on_foot, anchor));
             metrics.idle_drift = local.distance_to(anchor);
             metrics.max_idle_drift = metrics.max_idle_drift.max(metrics.idle_drift);
         } else {
-            self.idle_anchor = None;
+            pilot.idle_anchor = None;
             metrics.idle_drift = 0.0;
         }
     }

--- a/scenarios/spacewars/src/surface_sortie/motion.rs
+++ b/scenarios/spacewars/src/surface_sortie/motion.rs
@@ -311,9 +311,10 @@ impl SurfaceSortieState {
             && !input.interact_held
             && !input.brake_held;
         if idle {
-            let position = after.map_or(ship.position + SHIP_PIVOT, |snapshot| {
-                snapshot.motion.position
-            });
+            let position = after
+                .map_or(ship.position + physics::ship_pivot(ship.form), |snapshot| {
+                    snapshot.motion.position
+                });
             let local = (position - frame.position).rotate_radians(-frame.angle);
             let on_foot = after.is_some();
             let anchor = pilot

--- a/scenarios/spacewars/src/surface_sortie/outpost.rs
+++ b/scenarios/spacewars/src/surface_sortie/outpost.rs
@@ -20,6 +20,7 @@ pub enum CaptureStatus {
     NeedBalance,
     NeedSettle,
     Capturing,
+    Contested,
     Secured,
 }
 
@@ -32,6 +33,7 @@ impl CaptureStatus {
             Self::NeedBalance => "recover your balance",
             Self::NeedSettle => "stand still to capture",
             Self::Capturing => "capturing; stay beside the terminal",
+            Self::Contested => "contested; capture paused",
             Self::Secured => "secured",
         }
     }
@@ -70,9 +72,9 @@ pub(super) struct SurfaceOutpost {
     pub owner: Option<PlayerId>,
     capture_elapsed: Duration,
     capturing_player: Option<PlayerId>,
-    capture_status: CaptureStatus,
+    capture_status: [CaptureStatus; SPACEWARS_PLAYER_COUNT],
     captures: u64,
-    repair_status: RepairStatus,
+    repair_status: [RepairStatus; SPACEWARS_PLAYER_COUNT],
     repaired_health: f32,
 }
 
@@ -103,9 +105,9 @@ impl SurfaceOutpost {
             owner: None,
             capture_elapsed: Duration::ZERO,
             capturing_player: None,
-            capture_status: CaptureStatus::Aboard,
+            capture_status: [CaptureStatus::Aboard; SPACEWARS_PLAYER_COUNT],
             captures: 0,
-            repair_status: RepairStatus::NeedsCapture,
+            repair_status: [RepairStatus::NeedsCapture; SPACEWARS_PLAYER_COUNT],
             repaired_health: 0.0,
         }
     }
@@ -118,7 +120,7 @@ impl SurfaceOutpost {
         planet.position + self.up(planet) * (planet.radius * BODY_BOUNDS_RADIUS_SCALE)
     }
 
-    pub(super) fn observation(&self, planet: &PlanetState) -> OutpostObservation {
+    pub(super) fn observation(&self, planet: &PlanetState, player: usize) -> OutpostObservation {
         OutpostObservation {
             id: self.id,
             planet: self.planet,
@@ -126,33 +128,55 @@ impl SurfaceOutpost {
             surface_normal: self.up(planet),
             owner: self.owner,
             capturing_player: self.capturing_player,
-            capture_status: self.capture_status,
+            capture_status: self.capture_status[player],
             capture_progress: self.capture_elapsed.as_secs_f32() / CAPTURE_TIME.as_secs_f32(),
             capture_required_seconds: CAPTURE_TIME.as_secs_f32(),
             capture_range: CAPTURE_RANGE,
             captures: self.captures,
-            repair_status: self.repair_status,
+            repair_status: self.repair_status[player],
             repair_range: REPAIR_RANGE,
             repaired_health: self.repaired_health,
         }
     }
 
-    pub(super) fn update_capture(
-        &mut self,
-        claimant: PlayerId,
-        status: CaptureStatus,
-        dt: Duration,
-    ) {
-        if self.owner == Some(claimant) {
-            self.capture_status = CaptureStatus::Secured;
-            self.capturing_player = None;
-            self.capture_elapsed = CAPTURE_TIME;
+    /// Evaluate the complete set before changing ownership; iteration order cannot win a race.
+    pub(super) fn update_capture(&mut self, statuses: &[(PlayerId, CaptureStatus)], dt: Duration) {
+        let mut eligible = [None; SPACEWARS_PLAYER_COUNT];
+        let mut count = 0;
+        for &(player, status) in statuses {
+            self.capture_status[player.index()] = if self.owner == Some(player) {
+                CaptureStatus::Secured
+            } else {
+                status
+            };
+            if status == CaptureStatus::Capturing {
+                eligible[count] = Some(player);
+                count += 1;
+            }
+        }
+        if count > 1 {
+            for player in eligible.into_iter().flatten() {
+                self.capture_status[player.index()] = CaptureStatus::Contested;
+            }
+            // Preserve an active claim only while that claimant still qualifies.
+            if !eligible.contains(&self.capturing_player) {
+                self.capturing_player = None;
+                self.capture_elapsed = Duration::ZERO;
+            }
             return;
         }
-        self.capture_status = status;
-        if status != CaptureStatus::Capturing {
-            self.capture_elapsed = Duration::ZERO;
+        let Some(claimant) = eligible[0] else {
             self.capturing_player = None;
+            self.capture_elapsed = if self.owner.is_some() {
+                CAPTURE_TIME
+            } else {
+                Duration::ZERO
+            };
+            return;
+        };
+        if self.owner == Some(claimant) {
+            self.capturing_player = None;
+            self.capture_elapsed = CAPTURE_TIME;
             return;
         }
         if self.capturing_player != Some(claimant) {
@@ -163,7 +187,15 @@ impl SurfaceOutpost {
         if self.capture_elapsed == CAPTURE_TIME {
             self.owner = Some(claimant);
             self.capturing_player = None;
-            self.capture_status = CaptureStatus::Secured;
+            // Refresh both views immediately: the previous owner must not
+            // report "secured" for one extra tick after ownership changes.
+            for &(player, status) in statuses {
+                self.capture_status[player.index()] = if player == claimant {
+                    CaptureStatus::Secured
+                } else {
+                    status
+                };
+            }
             self.captures += 1;
         }
     }
@@ -175,7 +207,7 @@ impl SurfaceOutpost {
         distance: f32,
         dt: Duration,
     ) {
-        self.repair_status = if self.owner.is_none() {
+        self.repair_status[ship.owner_id] = if self.owner.is_none() {
             RepairStatus::NeedsCapture
         } else if ship.dead || ship.life <= 0.0 || ship.form != ShipForm::Ship {
             RepairStatus::VehicleUnavailable
@@ -202,8 +234,8 @@ impl SurfaceOutpost {
 }
 
 impl SurfaceSortieState {
-    fn capture_status(&self, outpost: &SurfaceOutpost) -> CaptureStatus {
-        let Some(snapshot) = self.spaceling_snapshot() else {
+    fn capture_status(&self, player: usize, outpost: &SurfaceOutpost) -> CaptureStatus {
+        let Some(snapshot) = self.spaceling_snapshot(player) else {
             return CaptureStatus::Aboard;
         };
         let planet = &self.world.planets[outpost.planet];
@@ -235,20 +267,33 @@ impl SurfaceSortieState {
     }
 
     pub(super) fn update_outpost(&mut self, dt: Duration) {
+        let player_count = self.player_count();
         for index in 0..self.outposts.len() {
-            let status = self.capture_status(&self.outposts[index]);
-            let landed =
-                self.vehicle_settled() && self.landing.planet == Some(self.outposts[index].planet);
-            let post = &mut self.outposts[index];
-            post.update_capture(self.pilot.owner, status, dt);
-            let position = post.position(&self.world.planets[post.planet]);
-            let ship = &mut self.world.ships[self.pilot.vehicle.0];
-            post.repair_ship(
-                ship,
-                landed,
-                (ship.position + SHIP_PIVOT).distance_to(position),
-                dt,
-            );
+            let statuses: [_; SPACEWARS_PLAYER_COUNT] = std::array::from_fn(|player| {
+                let owner = PlayerId::from_index(player).expect("bounded player index");
+                (
+                    owner,
+                    if player < self.player_count() {
+                        self.capture_status(player, &self.outposts[index])
+                    } else {
+                        CaptureStatus::Aboard
+                    },
+                )
+            });
+            self.outposts[index].update_capture(&statuses[..player_count], dt);
+            for player in 0..self.player_count() {
+                let landed = self.vehicle_settled(player)
+                    && self.pilots[player].landing.planet == Some(self.outposts[index].planet);
+                let post = &mut self.outposts[index];
+                let position = post.position(&self.world.planets[post.planet]);
+                let ship = &mut self.world.ships[self.pilots[player].vehicle.0];
+                post.repair_ship(
+                    ship,
+                    landed,
+                    (ship.position + SHIP_PIVOT).distance_to(position),
+                    dt,
+                );
+            }
         }
     }
 }

--- a/scenarios/spacewars/src/surface_sortie/recovery.rs
+++ b/scenarios/spacewars/src/surface_sortie/recovery.rs
@@ -1,0 +1,370 @@
+//! Expedition-only vehicle loss and replacement. No actor duplication, old
+//! docking services, invincibility changes, or additional physics steps.
+
+use super::*;
+use engine_rapier::world::RayCastOptions;
+
+const SCUTTLE_TIME: Duration = Duration::from_secs(3);
+const REBUILD_TIME: Duration = Duration::from_secs(8);
+const PLACEMENT_RETRY: Duration = Duration::from_millis(500);
+const REBUILD_MAX_SPEED: f32 = 1.0;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceRecoveryStatus {
+    #[default]
+    ShipAvailable,
+    Scuttling,
+    LandPod,
+    NeedSupport,
+    NeedBalance,
+    NeedSettle,
+    NeedOwnedPlanet,
+    Rebuilding,
+    ClearanceBlocked,
+}
+
+impl SurfaceRecoveryStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ShipAvailable => "ship available",
+            Self::Scuttling => "release to cancel scuttle",
+            Self::LandPod => "land pod, then B to exit",
+            Self::NeedSupport => "stand on a planet to rebuild",
+            Self::NeedBalance => "recover your balance to rebuild",
+            Self::NeedSettle => "stand still to rebuild",
+            Self::NeedOwnedPlanet => "claim this planet to rebuild",
+            Self::Rebuilding => "rebuilding; stand still",
+            Self::ClearanceBlocked => "build space blocked; move along surface",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SurfaceRecoveryObservation {
+    pub status: SurfaceRecoveryStatus,
+    pub planet: Option<usize>,
+    pub rebuild_progress: f32,
+    pub rebuild_required_seconds: f32,
+    pub scuttle_progress: f32,
+    pub scuttle_required_seconds: f32,
+    pub ships_lost: u64,
+    pub pod_ejections: u64,
+    pub rebuilds: u64,
+    pub rebuild_interruptions: u64,
+    pub blocked_attempts: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct SurfaceRecovery {
+    status: SurfaceRecoveryStatus,
+    planet: Option<usize>,
+    elapsed: Duration,
+    retry: Duration,
+    scuttle: Duration,
+    ships_lost: u64,
+    pod_ejections: u64,
+    rebuilds: u64,
+    rebuild_interruptions: u64,
+    blocked_attempts: u64,
+}
+
+impl SurfaceRecovery {
+    pub(super) fn observation(&self) -> SurfaceRecoveryObservation {
+        SurfaceRecoveryObservation {
+            status: if self.scuttle.is_zero() {
+                self.status
+            } else {
+                SurfaceRecoveryStatus::Scuttling
+            },
+            planet: self.planet,
+            rebuild_progress: self.elapsed.as_secs_f32() / REBUILD_TIME.as_secs_f32(),
+            rebuild_required_seconds: REBUILD_TIME.as_secs_f32(),
+            scuttle_progress: self.scuttle.as_secs_f32() / SCUTTLE_TIME.as_secs_f32(),
+            scuttle_required_seconds: SCUTTLE_TIME.as_secs_f32(),
+            ships_lost: self.ships_lost,
+            pod_ejections: self.pod_ejections,
+            rebuilds: self.rebuilds,
+            rebuild_interruptions: self.rebuild_interruptions,
+            blocked_attempts: self.blocked_attempts,
+        }
+    }
+
+    fn reset_rebuild(&mut self) {
+        self.rebuild_interruptions += u64::from(!self.elapsed.is_zero());
+        self.planet = None;
+        self.elapsed = Duration::ZERO;
+        self.retry = Duration::ZERO;
+    }
+}
+
+impl SurfacePilot {
+    pub(crate) fn recovery_enabled(&self) -> bool {
+        self.recovery.is_some()
+    }
+
+    pub(crate) fn vehicle_destroyed(&mut self, ship: &mut ShipState) {
+        let recovery = self.recovery.as_mut().expect("Expedition recovery");
+        recovery.ships_lost += 1;
+        recovery.scuttle = Duration::ZERO;
+        recovery.reset_rebuild();
+        self.controls_armed = false;
+        self.control = SpacelingControl::default();
+        self.landing = LandingTelemetry::default();
+        if self.body.is_none() {
+            // Keep the completed body's origin, COM velocity and physical spin;
+            // the legacy mesh pivots/control omega scales differ between forms.
+            let origin = ship.position + physics::ship_pivot(ship.form);
+            let spin = physics::physical_angular_velocity(ship);
+            ship.change_to_escape_pod();
+            ship.position = origin - physics::ship_pivot(ship.form);
+            ship.omega = physics::control_angular_velocity(ship, spin);
+            recovery.pod_ejections += 1;
+            recovery.status = SurfaceRecoveryStatus::LandPod;
+        } else {
+            // The already external creature is the survivor. Keep the vehicle
+            // slot dead, with one breakup, and remove its physical assembly.
+            ship.life = 0.0;
+            recovery.status = SurfaceRecoveryStatus::NeedSupport;
+        }
+        ship.set_thrust(0.0);
+        ship.set_turn(0.0);
+        ship.set_brake(0.0);
+        ship.set_laser(false);
+        ship.set_cannon(false);
+        ship.laser_beam = None;
+        ship.exhaust_trails.clear();
+    }
+}
+
+impl SurfaceSortieState {
+    pub(super) fn enable_recovery(&mut self) {
+        self.world.physics.enable_surface_recovery();
+        for pilot in &mut self.pilots {
+            pilot.recovery = Some(SurfaceRecovery::default());
+        }
+    }
+
+    pub(super) fn reconcile_recovery_vehicles(&mut self) {
+        for pilot in &self.pilots {
+            let index = pilot.vehicle.0;
+            let ship = &self.world.ships[index];
+            if pilot.recovery.is_some() && self.world.physics.surface_vehicle_changed(index, ship) {
+                let changed = self.world.physics.reconcile_surface_vehicle(index, ship);
+                self.world.last_step_metrics.added += changed.added;
+                self.world.last_step_metrics.removed += changed.removed;
+            }
+        }
+    }
+
+    /// Deliberate lab drill, using the existing minimal gamepad controls.
+    /// The chord consumes thrust/jump/transfer while held, and must be released
+    /// after destruction before any input can drive the surviving pod/pilot.
+    pub(super) fn update_scuttle_input(
+        &mut self,
+        player: usize,
+        input: SurfaceSortieAction,
+        dt: Duration,
+    ) -> bool {
+        let available = self.vehicle_available(player);
+        let Some(recovery) = self.pilots[player].recovery.as_mut() else {
+            return false;
+        };
+        let chord = available
+            && input.primary_held
+            && input.interact_held
+            && input.brake_held
+            && input.horizontal.abs() < 0.01;
+        if !chord {
+            recovery.scuttle = Duration::ZERO;
+            return false;
+        }
+        recovery.scuttle = recovery.scuttle.saturating_add(dt).min(SCUTTLE_TIME);
+        if recovery.scuttle == SCUTTLE_TIME {
+            let ship = &mut self.world.ships[self.pilots[player].vehicle.0];
+            ship.translate_life_with_impulse(-ship.life_max, Vec2::ZERO);
+        }
+        true
+    }
+
+    fn rebuild_candidate(
+        &self,
+        player: usize,
+    ) -> Result<(usize, Vec2, Vec2), SurfaceRecoveryStatus> {
+        let snapshot = self
+            .spaceling_snapshot(player)
+            .ok_or(SurfaceRecoveryStatus::LandPod)?;
+        let support = snapshot.support.ok_or(SurfaceRecoveryStatus::NeedSupport)?;
+        let planet = physics::planet_surface_support_index(support.collider)
+            .filter(|&index| index < self.world.planets.len())
+            .ok_or(SurfaceRecoveryStatus::NeedSupport)?;
+        if snapshot.balance != SpacelingBalance::Balanced {
+            return Err(SurfaceRecoveryStatus::NeedBalance);
+        }
+        let velocity = self
+            .world
+            .physics
+            .world
+            .velocity_at_point(
+                self.pilots[player].body.as_ref().unwrap().body(),
+                support.position,
+            )
+            .unwrap();
+        if (velocity - support.velocity).length() > REBUILD_MAX_SPEED {
+            return Err(SurfaceRecoveryStatus::NeedSettle);
+        }
+        if self.world.planets[planet].owner_id != Some(self.pilots[player].owner.index()) {
+            return Err(SurfaceRecoveryStatus::NeedOwnedPlanet);
+        }
+        Ok((planet, support.position, support.normal))
+    }
+
+    pub(super) fn update_recovery(&mut self, dt: Duration) {
+        for player in 0..self.player_count() {
+            if self.pilots[player].recovery.is_none() {
+                continue;
+            }
+            let candidate = if self.vehicle_available(player) {
+                Err(SurfaceRecoveryStatus::ShipAvailable)
+            } else {
+                self.rebuild_candidate(player)
+            };
+            let recovery = self.pilots[player].recovery.as_mut().unwrap();
+            let (planet, point, normal) = match candidate {
+                Ok(candidate) => candidate,
+                Err(status) => {
+                    recovery.reset_rebuild();
+                    recovery.status = status;
+                    continue;
+                }
+            };
+            recovery.status = SurfaceRecoveryStatus::Rebuilding;
+            if recovery.planet != Some(planet) {
+                recovery.reset_rebuild();
+                recovery.planet = Some(planet);
+                // Ownership/support must exist for a fresh full build interval.
+                continue;
+            }
+            recovery.elapsed = recovery.elapsed.saturating_add(dt).min(REBUILD_TIME);
+            if recovery.elapsed < REBUILD_TIME {
+                continue;
+            }
+            recovery.retry = recovery.retry.saturating_sub(dt);
+            if !recovery.retry.is_zero() {
+                recovery.status = SurfaceRecoveryStatus::ClearanceBlocked;
+                continue;
+            }
+            if !self.try_rebuild_vehicle(player, planet, point, normal) {
+                let recovery = self.pilots[player].recovery.as_mut().unwrap();
+                recovery.status = SurfaceRecoveryStatus::ClearanceBlocked;
+                recovery.blocked_attempts += 1;
+                recovery.retry = PLACEMENT_RETRY;
+            }
+        }
+    }
+
+    fn try_rebuild_vehicle(&mut self, player: usize, planet: usize, point: Vec2, up: Vec2) -> bool {
+        let owner = self.pilots[player].owner;
+        let index = self.pilots[player].vehicle.0;
+        let mut replacement = ShipState::new(
+            owner.index(),
+            Vec2::ZERO,
+            self.world.players[owner.index()].color,
+            self.world.players[owner.index()].health_percent,
+            1.0 / 60.0,
+        );
+        let radius = physics::SpacewarsPhysics::surface_vehicle_clearance_radius(&replacement);
+        let right = Vec2::new(up.y, -up.x);
+        // Ground and normal come from local terrain rays, not a radius projection.
+        // Bounded attempts keep construction local and make blocked sites visible.
+        // Prefer the side that puts the ship's hatch toward the waiting pilot;
+        // a parked pod may rule out the closest spot on that side.
+        for offset in [-8.0, -14.0, 8.0, 14.0] {
+            let Some(hit) = self.world.physics.world.cast_ray(
+                point + right * offset + up * 12.0,
+                -up,
+                RayCastOptions {
+                    max_distance: 24.0,
+                    collision_groups: physics::spaceling_collision_groups(),
+                    ..RayCastOptions::default()
+                },
+            ) else {
+                continue;
+            };
+            if !physics::is_planet_surface_support(hit.collider, planet) || hit.normal.dot(up) < 0.8
+            {
+                continue;
+            }
+            let center = hit.point + hit.normal * (radius + 0.6);
+            if !self
+                .world
+                .physics
+                .surface_vehicle_space_is_clear(&replacement, center, radius)
+            {
+                continue;
+            }
+            // Newly rebuilt vehicles or same-tick transfers are not in the last
+            // step's spatial index yet. Check the bounded seat list as well.
+            if self.pilots.iter().any(|pilot| {
+                pilot.snapshot(&self.world.physics).is_some_and(|s| {
+                    s.motion.position.distance_to(center) < radius + Self::spec().half_height()
+                }) || self
+                    .world
+                    .physics
+                    .world
+                    .motion(self.world.physics.ship_body(pilot.vehicle.0))
+                    .is_some_and(|motion| {
+                        motion.position.distance_to(center)
+                            < radius
+                                + physics::SpacewarsPhysics::surface_vehicle_clearance_radius(
+                                    &self.world.ships[pilot.vehicle.0],
+                                )
+                    })
+            }) {
+                continue;
+            }
+            let frame = motion::SurfaceFrame::read(&self.world.physics, planet);
+            replacement.position = center - SHIP_PIVOT;
+            replacement.rotation_radians = rotation_for_direction(hit.normal);
+            replacement.direction = hit.normal;
+            replacement.velocity = motion::point_velocity(frame, center);
+            replacement.omega =
+                physics::control_angular_velocity(&replacement, frame.angular_velocity);
+            self.world.ships[index] = replacement;
+            self.reconcile_recovery_vehicles();
+            // Rapier stores COM velocity, while the surface frame is evaluated
+            // at the assembly origin. Account for the off-center hull mass.
+            let body = self.world.physics.ship_body(index);
+            let origin_velocity = self
+                .world
+                .physics
+                .world
+                .velocity_at_point(body, center)
+                .unwrap();
+            self.world.physics.world.apply_velocity_delta(
+                body,
+                motion::point_velocity(frame, center) - origin_velocity,
+                true,
+            );
+            self.world.ships[index].velocity = self
+                .world
+                .physics
+                .world
+                .motion(body)
+                .unwrap()
+                .linear_velocity;
+            let pilot = &mut self.pilots[player];
+            pilot.planet = planet;
+            pilot.landing = LandingTelemetry::default();
+            pilot.controls_armed = false;
+            let recovery = pilot.recovery.as_mut().unwrap();
+            recovery.planet = None;
+            recovery.elapsed = Duration::ZERO;
+            recovery.retry = Duration::ZERO;
+            recovery.rebuilds += 1;
+            recovery.status = SurfaceRecoveryStatus::ShipAvailable;
+            return true;
+        }
+        false
+    }
+}

--- a/scenarios/spacewars/src/surface_sortie/render.rs
+++ b/scenarios/spacewars/src/surface_sortie/render.rs
@@ -6,10 +6,10 @@ const CYAN: RenderColor = RenderColor::rgb(0.25, 0.93, 0.8);
 const ORANGE: RenderColor = RenderColor::rgb(1.0, 0.58, 0.23);
 const AMBER: RenderColor = RenderColor::rgb(1.0, 0.82, 0.25);
 
-fn camera(state: &SurfaceSortieState) -> Camera2 {
-    let snapshot = state.spaceling_snapshot();
-    let ship = &state.world.ships[state.pilot.vehicle.0];
-    let parked = state.vehicle_settled();
+fn camera(state: &SurfaceSortieState, player: usize) -> Camera2 {
+    let snapshot = state.spaceling_snapshot(player);
+    let ship = &state.world.ships[state.pilots[player].vehicle.0];
+    let parked = state.vehicle_settled(player);
     let (center, height) = if let Some(snapshot) = snapshot {
         let pilot = snapshot.motion.position;
         let ship_center = ship.position + SHIP_PIVOT;
@@ -25,7 +25,7 @@ fn camera(state: &SurfaceSortieState) -> Camera2 {
         }
     } else if parked {
         (
-            (ship.position + state.access_position()) * 0.5 + state.access_up() * 2.0,
+            (ship.position + state.access_position(player)) * 0.5 + state.access_up(player) * 2.0,
             44.0,
         )
     } else {
@@ -34,12 +34,12 @@ fn camera(state: &SurfaceSortieState) -> Camera2 {
     Camera2::new(render_point(center), height)
 }
 
-pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
-    let observation = state.observation();
-    let snapshot = state.spaceling_snapshot();
-    let ship = &state.world.ships[state.pilot.vehicle.0];
-    let parked = state.vehicle_settled();
-    let camera = camera(state);
+pub(super) fn frame(state: &SurfaceSortieState, player: usize) -> RenderFrame {
+    let observation = state.observation(player);
+    let snapshot = state.spaceling_snapshot(player);
+    let ship = &state.world.ships[state.pilots[player].vehicle.0];
+    let parked = state.vehicle_settled(player);
+    let camera = camera(state, player);
     let center = Vec2::new(camera.center.x, camera.center.y);
     let height = camera.height;
     let mut frame = RenderFrame::new(camera);
@@ -61,6 +61,20 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
             radius,
             RenderColor::rgb(0.09, 0.16, 0.23),
         );
+        if let Some(owner) = planet.owner_id {
+            frame.push_primitive(
+                -17,
+                RenderPrimitive::Circle(RenderCircle {
+                    center: render_point(planet.position),
+                    radius,
+                    fill: None,
+                    stroke: Some(Stroke::new(
+                        render_color(state.world.players[owner].color),
+                        1.5,
+                    )),
+                }),
+            );
+        }
         for index in 0..72 {
             let up = Vec2::from_radians(
                 planet.wrapper_angle + index as f32 * std::f32::consts::TAU / 72.0,
@@ -78,56 +92,21 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     for post in &observation.outposts {
         draw_outpost(&mut frame, state, post);
     }
+    for flag in observation
+        .planet_claims
+        .iter()
+        .filter_map(|claim| claim.flag.as_ref())
+    {
+        draw_planet_flag(&mut frame, state, flag);
+    }
+    for player in 0..state.player_count() {
+        draw_actor(&mut frame, state, player);
+    }
+    if state.player_count() > 1 || observation.planet_claim.is_some() {
+        draw_player_hud(&mut frame, state, player, center, height);
+        return frame;
+    }
     let access = observation.access_position;
-    if parked {
-        circle(
-            &mut frame,
-            -1,
-            access + state.access_up() * 0.12,
-            0.38,
-            CYAN,
-        );
-    }
-    render_ship(&mut frame, ship);
-    if ship.form == ShipForm::Ship {
-        for foot in physics::LANDING_FEET {
-            let position = ship.position + SHIP_PIVOT + foot.rotate_radians(ship.rotation_radians);
-            line(
-                &mut frame,
-                1,
-                position,
-                position + Vec2::Y.rotate_radians(ship.rotation_radians) * 1.3,
-                LIGHT,
-                2.0,
-            );
-            circle(
-                &mut frame,
-                1,
-                position,
-                physics::LANDING_FOOT_RADIUS,
-                if parked { CYAN } else { LIGHT },
-            );
-        }
-    }
-    render_exhaust(&mut frame, ship);
-    if let Some(snapshot) = snapshot {
-        draw_spaceling(
-            &mut frame,
-            snapshot,
-            state.pilot.facing,
-            state.pilot.gait_phase,
-        );
-        if let Some(support) = snapshot.support {
-            line(
-                &mut frame,
-                6,
-                support.position,
-                support.position + support.normal,
-                CYAN,
-                2.0,
-            );
-        }
-    }
     // Keep diagnostics legible when the parked ship crosses the HUD as the
     // planet rotates. The scene remains visible through the shallow strips.
     for (bottom, top) in [(0.27, 0.48), (-0.49, -0.255)] {
@@ -152,7 +131,7 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
                 if state.travel_enabled() {
                     return format!(
                         "SURFACE EXPEDITION / V1  |  seed {}  |  approach planet {}",
-                        case.seed, state.pilot.planet
+                        case.seed, state.pilots[player].planet
                     );
                 }
                 format!(
@@ -189,12 +168,12 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
         LIGHT,
         13.0,
     );
-    let message = if !state.vehicle_available() {
+    let message = if !state.vehicle_available(player) {
         TransferResult::VehicleUnavailable.label()
-    } else if !state.controls_armed {
+    } else if !state.pilots[player].controls_armed {
         "Release all controls to activate the new control context"
     } else {
-        state.last_transfer.label()
+        state.pilots[player].last_transfer.label()
     };
     text(
         &mut frame,
@@ -203,7 +182,10 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
         CYAN,
         16.0,
     );
-    let post = &observation.outpost;
+    let post = observation
+        .outpost
+        .as_ref()
+        .expect("pinned outpost fixture");
     let ownership = post.owner.map_or_else(
         || "NEUTRAL".to_owned(),
         |owner| format!("P{}", owner.index() + 1),
@@ -280,7 +262,11 @@ pub(super) fn frame(state: &SurfaceSortieState) -> RenderFrame {
     frame
 }
 
-pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> RenderFrame {
+pub(super) fn minimap(
+    state: &SurfaceSortieState,
+    player: usize,
+    viewport_aspect: f32,
+) -> RenderFrame {
     let radius = state.world.config.universe_radius as f32;
     let mut map = RenderFrame::new(Camera2::new(
         render_point(Vec2::splat(radius)),
@@ -307,7 +293,7 @@ pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> Rende
             -18,
             RenderPrimitive::Circle(RenderCircle {
                 center: render_point(sun.position),
-                radius: state.world.planets[state.pilot.planet].orbit_radius,
+                radius: state.world.planets[state.pilots[player].planet].orbit_radius,
                 fill: None,
                 stroke: Some(Stroke::new(RenderColor::rgba(0.55, 0.6, 0.7, 0.45), 1.0)),
             }),
@@ -319,7 +305,35 @@ pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> Rende
             -10,
             planet.position,
             planet.radius * BODY_BOUNDS_RADIUS_SCALE,
-            CYAN,
+            planet
+                .owner_id
+                .map_or(CYAN, |owner| render_color(state.world.players[owner].color)),
+        );
+    }
+    for claim in &state.claims {
+        let observation = state
+            .claim_observation(claim.planet, player)
+            .expect("indexed claim");
+        let Some(flag) = observation.flag else {
+            continue;
+        };
+        let half = (radius * 0.025).max(12.0);
+        let marker = flag.position + flag.normal * (half * 2.0).max(35.0);
+        let color = render_color(state.world.players[flag.player.index()].color);
+        line(&mut map, 1, flag.position, marker, color, 1.0);
+        map.push_primitive(
+            2,
+            RenderPrimitive::Polygon(RenderPolygon {
+                points: [
+                    Vec2::new(-half, -half),
+                    Vec2::new(-half, half),
+                    Vec2::new(half, 0.0),
+                ]
+                .map(|point| render_point(marker + point))
+                .to_vec(),
+                fill: Some(Fill::new(color)),
+                stroke: Some(Stroke::new(LIGHT, 1.0)),
+            }),
         );
     }
     for outpost in &state.outposts {
@@ -354,7 +368,7 @@ pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> Rende
         );
     }
     // The footprint follows the actual full-window camera, including resizes.
-    let camera = camera(state);
+    let camera = camera(state, player);
     let aspect = if viewport_aspect.is_finite() && viewport_aspect > 0.0 {
         viewport_aspect
     } else {
@@ -377,42 +391,44 @@ pub(super) fn minimap(state: &SurfaceSortieState, viewport_aspect: f32) -> Rende
             stroke: Some(Stroke::new(LIGHT, 1.0)),
         }),
     );
-    let ship = &state.world.ships[state.pilot.vehicle.0];
-    map.push_primitive(
-        2,
-        RenderPrimitive::Polygon(RenderPolygon {
-            points: [
-                Vec2::new(0.0, 20.0),
-                Vec2::new(-12.0, -12.0),
-                Vec2::new(0.0, -5.0),
-                Vec2::new(12.0, -12.0),
-            ]
-            .map(|offset| {
-                render_point(
-                    ship.position + SHIP_PIVOT + offset.rotate_radians(ship.rotation_radians),
-                )
-            })
-            .to_vec(),
-            fill: Some(Fill::new(RenderColor::rgb(1.0, 0.22, 0.22))),
-            stroke: Some(Stroke::new(LIGHT, 1.0)),
-        }),
-    );
-    if let Some(snapshot) = state.spaceling_snapshot() {
+    for player in 0..state.player_count() {
+        let ship = &state.world.ships[state.pilots[player].vehicle.0];
         map.push_primitive(
-            3,
+            2,
             RenderPrimitive::Polygon(RenderPolygon {
                 points: [
-                    Vec2::new(0.0, 12.0),
-                    Vec2::new(-10.0, 0.0),
-                    Vec2::new(0.0, -12.0),
-                    Vec2::new(10.0, 0.0),
+                    Vec2::new(0.0, 20.0),
+                    Vec2::new(-12.0, -12.0),
+                    Vec2::new(0.0, -5.0),
+                    Vec2::new(12.0, -12.0),
                 ]
-                .map(|offset| render_point(snapshot.motion.position + offset))
+                .map(|offset| {
+                    render_point(
+                        ship.position + SHIP_PIVOT + offset.rotate_radians(ship.rotation_radians),
+                    )
+                })
                 .to_vec(),
-                fill: Some(Fill::new(ORANGE)),
+                fill: Some(Fill::new(render_color(state.world.players[player].color))),
                 stroke: Some(Stroke::new(LIGHT, 1.0)),
             }),
         );
+        if let Some(snapshot) = state.spaceling_snapshot(player) {
+            map.push_primitive(
+                3,
+                RenderPrimitive::Polygon(RenderPolygon {
+                    points: [
+                        Vec2::new(0.0, 12.0),
+                        Vec2::new(-10.0, 0.0),
+                        Vec2::new(0.0, -12.0),
+                        Vec2::new(10.0, 0.0),
+                    ]
+                    .map(|offset| render_point(snapshot.motion.position + offset))
+                    .to_vec(),
+                    fill: Some(Fill::new(pilot_color(state, player))),
+                    stroke: Some(Stroke::new(LIGHT, 1.0)),
+                }),
+            );
+        }
     }
     map
 }
@@ -421,6 +437,30 @@ fn outpost_color(state: &SurfaceSortieState, owner: Option<PlayerId>) -> RenderC
     owner.map_or(AMBER, |owner| {
         render_color(state.world.players[owner.index()].color)
     })
+}
+
+fn draw_planet_flag(
+    frame: &mut RenderFrame,
+    state: &SurfaceSortieState,
+    flag: &PlanetFlagObservation,
+) {
+    let up = flag.normal;
+    let right = Vec2::new(up.y, -up.x);
+    let local = |x, y| flag.position + right * x + up * y;
+    line(frame, 0, local(0.0, 0.0), local(0.0, 3.6), LIGHT, 1.5);
+    let top = 0.9 + flag.raised_fraction * 2.7;
+    frame.push_primitive(
+        1,
+        RenderPrimitive::Polygon(RenderPolygon {
+            points: [(0.0, top), (1.8, top - 0.45), (0.0, top - 0.9)]
+                .map(|(x, y)| render_point(local(x, y)))
+                .to_vec(),
+            fill: Some(Fill::new(render_color(
+                state.world.players[flag.player.index()].color,
+            ))),
+            stroke: Some(Stroke::new(LIGHT, 1.0)),
+        }),
+    );
 }
 
 fn draw_outpost(
@@ -534,11 +574,17 @@ fn draw_outpost(
     );
 }
 
-fn draw_spaceling(frame: &mut RenderFrame, snapshot: SpacelingSnapshot, facing: f32, phase: f32) {
+fn draw_spaceling(
+    frame: &mut RenderFrame,
+    snapshot: SpacelingSnapshot,
+    facing: f32,
+    phase: f32,
+    color: RenderColor,
+) {
     let center = snapshot.motion.position;
     let local = |x, y| center + Vec2::new(x, y).rotate_radians(snapshot.motion.angle);
     let suit = match snapshot.balance {
-        SpacelingBalance::Balanced => ORANGE,
+        SpacelingBalance::Balanced => color,
         SpacelingBalance::KnockedDown => RenderColor::rgb(1.0, 0.25, 0.25),
         SpacelingBalance::Recovering => RenderColor::rgb(1.0, 0.85, 0.3),
     };
@@ -638,4 +684,207 @@ fn text(
     text.color = color;
     text.size = size;
     frame.push_primitive(20, RenderPrimitive::Text(text));
+}
+
+fn pilot_color(state: &SurfaceSortieState, player: usize) -> RenderColor {
+    if state.player_count() == 1 {
+        ORANGE
+    } else {
+        render_color(state.world.players[player].color)
+    }
+}
+
+fn draw_actor(frame: &mut RenderFrame, state: &SurfaceSortieState, player: usize) {
+    let access = state.access_position(player);
+    let ship = &state.world.ships[state.pilots[player].vehicle.0];
+    let snapshot = state.spaceling_snapshot(player);
+    let parked = state.vehicle_settled(player);
+    if parked {
+        circle(
+            frame,
+            -1,
+            access + state.access_up(player) * 0.12,
+            0.38,
+            CYAN,
+        );
+    }
+    render_ship(frame, ship);
+    if ship.form == ShipForm::Ship {
+        for foot in physics::LANDING_FEET {
+            let position = ship.position + SHIP_PIVOT + foot.rotate_radians(ship.rotation_radians);
+            line(
+                frame,
+                1,
+                position,
+                position + Vec2::Y.rotate_radians(ship.rotation_radians) * 1.3,
+                LIGHT,
+                2.0,
+            );
+            circle(
+                frame,
+                1,
+                position,
+                physics::LANDING_FOOT_RADIUS,
+                if parked { CYAN } else { LIGHT },
+            );
+        }
+    }
+    render_exhaust(frame, ship);
+    if let Some(snapshot) = snapshot {
+        draw_spaceling(
+            frame,
+            snapshot,
+            state.pilots[player].facing,
+            state.pilots[player].gait_phase,
+            pilot_color(state, player),
+        );
+        if let Some(support) = snapshot.support {
+            line(
+                frame,
+                6,
+                support.position,
+                support.position + support.normal,
+                CYAN,
+                2.0,
+            );
+        }
+    }
+}
+
+fn draw_player_hud(
+    frame: &mut RenderFrame,
+    state: &SurfaceSortieState,
+    player: usize,
+    center: Vec2,
+    height: f32,
+) {
+    let observation = state.observation(player);
+    let ship = &state.world.ships[state.pilots[player].vehicle.0];
+    let color = pilot_color(state, player);
+    for (bottom, top) in [(0.29, 0.49), (-0.49, -0.25)] {
+        frame.push_primitive(
+            15,
+            RenderPrimitive::Polygon(RenderPolygon {
+                points: [(-4.0, bottom), (4.0, bottom), (4.0, top), (-4.0, top)]
+                    .map(|(x, y)| render_point(center + Vec2::new(x, y) * height))
+                    .to_vec(),
+                fill: Some(Fill::new(RenderColor::rgba(0.025, 0.03, 0.055, 0.85))),
+                stroke: None,
+            }),
+        );
+    }
+    let mode = if observation.location == PilotLocation::OnFoot {
+        "ON FOOT"
+    } else {
+        "ABOARD"
+    };
+    let (objective, progress, detail) = if let Some(claim) = &observation.planet_claim {
+        let owner = claim.owner.map_or("Neutral".to_owned(), |owner| {
+            format!("P{}", owner.index() + 1)
+        });
+        let phase = match claim.phase {
+            PlanetClaimPhase::Idle => String::new(),
+            PlanetClaimPhase::Lowering => format!(" / lowering {:.0}%", claim.progress * 100.0),
+            PlanetClaimPhase::Raising => format!(" / raising {:.0}%", claim.progress * 100.0),
+        };
+        (
+            format!("Planet {}: {owner}{phase}", claim.planet),
+            claim.status.label().to_owned(),
+            claim.flag.map_or_else(
+                || {
+                    format!(
+                        "Stand still 3s / feet {}/2",
+                        observation.landing.supported_feet
+                    )
+                },
+                |flag| {
+                    format!(
+                        "Flag {:.1}u / feet {}/2",
+                        observation.position.distance_to(flag.position),
+                        observation.landing.supported_feet
+                    )
+                },
+            ),
+        )
+    } else {
+        let post = observation.outpost.as_ref().expect("outpost fixture");
+        (
+            format!(
+                "Site {}: {} / {:.0}%",
+                post.id.0,
+                post.owner.map_or("Neutral".to_owned(), |owner| format!(
+                    "P{}",
+                    owner.index() + 1
+                )),
+                post.capture_progress * 100.0
+            ),
+            post.capture_status.label().to_owned(),
+            format!(
+                "{} / feet {}/2",
+                post.repair_status.label(),
+                observation.landing.supported_feet
+            ),
+        )
+    };
+    let lines = [
+        (
+            0.445,
+            format!(
+                "P{}  {mode}  /  planet {}",
+                player + 1,
+                observation.motion.planet
+            ),
+            color,
+        ),
+        (
+            0.385,
+            format!(
+                "Ship {:.0}%  /  {}",
+                ship.life / ship.life_max * 100.0,
+                observation.landing.phase.label()
+            ),
+            LIGHT,
+        ),
+        (0.325, "A: thrust/jump  B: board/exit".to_owned(), LIGHT),
+        (
+            -0.29,
+            if !observation.ship_available {
+                "Vehicle lost; restart".to_owned()
+            } else if !observation.controls_armed {
+                "Release controls after transfer".to_owned()
+            } else {
+                match observation.last_transfer {
+                    TransferResult::ExitBlocked => "No clear space beside the hatch",
+                    TransferResult::TooFar => "Return to your own ship's hatch",
+                    TransferResult::MustBeSupported => "Stand still on the ship's planet",
+                    TransferResult::ShipNotSettled => "Land and settle before transfer",
+                    _ if observation.location == PilotLocation::OnFoot => {
+                        if observation.planet_claim.is_some() {
+                            "Claim on foot; B at your hatch"
+                        } else {
+                            "Walk to terminal; B at hatch"
+                        }
+                    }
+                    _ if observation.landing.phase == LandingPhase::Landed => {
+                        "B: exit your landed ship"
+                    }
+                    _ => "Land rear-first; settle to exit",
+                }
+                .to_owned()
+            },
+            CYAN,
+        ),
+        (-0.345, objective, LIGHT),
+        (-0.405, progress, AMBER),
+        (-0.46, detail, color),
+    ];
+    for (y, label, color) in lines {
+        text(
+            frame,
+            center + Vec2::new(0.0, y * height),
+            label,
+            color,
+            13.0,
+        );
+    }
 }

--- a/scenarios/spacewars/src/surface_sortie/render.rs
+++ b/scenarios/spacewars/src/surface_sortie/render.rs
@@ -12,7 +12,7 @@ fn camera(state: &SurfaceSortieState, player: usize) -> Camera2 {
     let parked = state.vehicle_settled(player);
     let (center, height) = if let Some(snapshot) = snapshot {
         let pilot = snapshot.motion.position;
-        let ship_center = ship.position + SHIP_PIVOT;
+        let ship_center = ship.position + physics::ship_pivot(ship.form);
         if parked && pilot.distance_to(ship_center) < 32.0 {
             // North-up framing must work on the sides/underside too. Keep the
             // nearby ship and pilot in the central band between the HUD strips;
@@ -98,6 +98,12 @@ pub(super) fn frame(state: &SurfaceSortieState, player: usize) -> RenderFrame {
         .filter_map(|claim| claim.flag.as_ref())
     {
         draw_planet_flag(&mut frame, state, flag);
+    }
+    if observation.recovery.is_some() {
+        for debris in state.world.debris.iter().filter(|debris| !debris.dead) {
+            render_debris(&mut frame, debris);
+        }
+        render_particles(&mut frame, &state.world);
     }
     for player in 0..state.player_count() {
         draw_actor(&mut frame, state, player);
@@ -393,25 +399,35 @@ pub(super) fn minimap(
     );
     for player in 0..state.player_count() {
         let ship = &state.world.ships[state.pilots[player].vehicle.0];
-        map.push_primitive(
-            2,
-            RenderPrimitive::Polygon(RenderPolygon {
-                points: [
-                    Vec2::new(0.0, 20.0),
-                    Vec2::new(-12.0, -12.0),
-                    Vec2::new(0.0, -5.0),
-                    Vec2::new(12.0, -12.0),
-                ]
-                .map(|offset| {
-                    render_point(
-                        ship.position + SHIP_PIVOT + offset.rotate_radians(ship.rotation_radians),
-                    )
-                })
-                .to_vec(),
-                fill: Some(Fill::new(render_color(state.world.players[player].color))),
-                stroke: Some(Stroke::new(LIGHT, 1.0)),
-            }),
-        );
+        if !ship.dead {
+            map.push_primitive(
+                2,
+                RenderPrimitive::Polygon(RenderPolygon {
+                    points: [
+                        Vec2::new(0.0, 20.0),
+                        Vec2::new(-12.0, -12.0),
+                        Vec2::new(0.0, -5.0),
+                        Vec2::new(12.0, -12.0),
+                    ]
+                    .map(|offset| {
+                        render_point(
+                            ship.position
+                                + physics::ship_pivot(ship.form)
+                                + (offset
+                                    * if ship.form == ShipForm::EscapePod {
+                                        0.7
+                                    } else {
+                                        1.0
+                                    })
+                                .rotate_radians(ship.rotation_radians),
+                        )
+                    })
+                    .to_vec(),
+                    fill: Some(Fill::new(render_color(state.world.players[player].color))),
+                    stroke: Some(Stroke::new(LIGHT, 1.0)),
+                }),
+            );
+        }
         if let Some(snapshot) = state.spaceling_snapshot(player) {
             map.push_primitive(
                 3,
@@ -699,7 +715,7 @@ fn draw_actor(frame: &mut RenderFrame, state: &SurfaceSortieState, player: usize
     let ship = &state.world.ships[state.pilots[player].vehicle.0];
     let snapshot = state.spaceling_snapshot(player);
     let parked = state.vehicle_settled(player);
-    if parked {
+    if parked && !ship.dead {
         circle(
             frame,
             -1,
@@ -708,15 +724,23 @@ fn draw_actor(frame: &mut RenderFrame, state: &SurfaceSortieState, player: usize
             CYAN,
         );
     }
-    render_ship(frame, ship);
-    if ship.form == ShipForm::Ship {
-        for foot in physics::LANDING_FEET {
-            let position = ship.position + SHIP_PIVOT + foot.rotate_radians(ship.rotation_radians);
+    if !ship.dead {
+        render_ship(frame, ship);
+    }
+    if !ship.dead && (ship.form == ShipForm::Ship || state.pilots[player].recovery.is_some()) {
+        let (feet, radius) = physics::surface_landing_geometry(ship.form);
+        for foot in feet {
+            let position = ship.position
+                + physics::ship_pivot(ship.form)
+                + foot.rotate_radians(ship.rotation_radians);
             line(
                 frame,
                 1,
                 position,
-                position + Vec2::Y.rotate_radians(ship.rotation_radians) * 1.3,
+                position
+                    + Vec2::Y.rotate_radians(ship.rotation_radians)
+                        * radius
+                        * (1.3 / physics::LANDING_FOOT_RADIUS),
                 LIGHT,
                 2.0,
             );
@@ -724,12 +748,14 @@ fn draw_actor(frame: &mut RenderFrame, state: &SurfaceSortieState, player: usize
                 frame,
                 1,
                 position,
-                physics::LANDING_FOOT_RADIUS,
+                radius,
                 if parked { CYAN } else { LIGHT },
             );
         }
     }
-    render_exhaust(frame, ship);
+    if !ship.dead {
+        render_exhaust(frame, ship);
+    }
     if let Some(snapshot) = snapshot {
         draw_spaceling(
             frame,
@@ -775,6 +801,8 @@ fn draw_player_hud(
     }
     let mode = if observation.location == PilotLocation::OnFoot {
         "ON FOOT"
+    } else if ship.form == ShipForm::EscapePod {
+        "POD"
     } else {
         "ABOARD"
     };
@@ -826,6 +854,50 @@ fn draw_player_hud(
             ),
         )
     };
+    let recovery = observation.recovery.as_ref();
+    let vehicle_status = if !observation.ship_available && recovery.is_some() {
+        if ship.dead {
+            "Ship lost / pilot alive".to_owned()
+        } else {
+            format!("Escape pod / {}", observation.landing.phase.label())
+        }
+    } else {
+        format!(
+            "Ship {:.0}%  /  {}",
+            ship.life / ship.life_max * 100.0,
+            observation.landing.phase.label()
+        )
+    };
+    let recovery_message = recovery
+        .filter(|r| r.scuttle_progress > 0.0 || !observation.ship_available)
+        .map(|r| {
+            if r.scuttle_progress > 0.0 {
+                format!(
+                    "Scuttle {:.0}% / release to cancel",
+                    r.scuttle_progress * 100.0
+                )
+            } else if r.rebuild_progress > 0.0 {
+                format!(
+                    "Rebuild {:.0}% / {}",
+                    r.rebuild_progress * 100.0,
+                    if r.status == SurfaceRecoveryStatus::ClearanceBlocked {
+                        "space blocked"
+                    } else {
+                        "stand still"
+                    }
+                )
+            } else if r.status == SurfaceRecoveryStatus::LandPod
+                && observation.landing.phase == LandingPhase::Landed
+            {
+                if observation.last_transfer == TransferResult::ExitBlocked {
+                    "No clear space beside the hatch".to_owned()
+                } else {
+                    "B: exit your landed pod".to_owned()
+                }
+            } else {
+                r.status.label().to_owned()
+            }
+        });
     let lines = [
         (
             0.445,
@@ -836,22 +908,16 @@ fn draw_player_hud(
             ),
             color,
         ),
-        (
-            0.385,
-            format!(
-                "Ship {:.0}%  /  {}",
-                ship.life / ship.life_max * 100.0,
-                observation.landing.phase.label()
-            ),
-            LIGHT,
-        ),
+        (0.385, vehicle_status, LIGHT),
         (0.325, "A: thrust/jump  B: board/exit".to_owned(), LIGHT),
         (
             -0.29,
-            if !observation.ship_available {
+            if !observation.controls_armed {
+                "Release controls to continue".to_owned()
+            } else if let Some(message) = recovery_message {
+                message
+            } else if !observation.ship_available {
                 "Vehicle lost; restart".to_owned()
-            } else if !observation.controls_armed {
-                "Release controls after transfer".to_owned()
             } else {
                 match observation.last_transfer {
                     TransferResult::ExitBlocked => "No clear space beside the hatch",

--- a/scenarios/spacewars/src/surface_sortie/tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests.rs
@@ -7,6 +7,7 @@ mod compatibility_tests;
 mod motion_tests;
 mod multiplayer_tests;
 mod outpost_tests;
+mod recovery_tests;
 mod travel_tests;
 
 fn tick(state: &mut SurfaceSortieState, input: SurfaceSortieAction) {

--- a/scenarios/spacewars/src/surface_sortie/tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests.rs
@@ -5,13 +5,14 @@ use engine_rapier::world::{
 
 mod compatibility_tests;
 mod motion_tests;
+mod multiplayer_tests;
 mod outpost_tests;
 mod travel_tests;
 
 fn tick(state: &mut SurfaceSortieState, input: SurfaceSortieAction) {
     SurfaceSortieScenario::step(
         state,
-        &[input.encode()],
+        &[input.encode(PlayerId::PLAYER_1)],
         Duration::from_secs_f64(1.0 / 60.0),
     );
 }
@@ -25,7 +26,7 @@ fn idle(state: &mut SurfaceSortieState, ticks: usize) {
 fn parked() -> SurfaceSortieState {
     let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7);
     idle(&mut state, 120);
-    assert!(state.vehicle_settled(), "{:?}", state.observation());
+    assert!(state.vehicle_settled(0), "{:?}", state.observation(0));
     state
 }
 
@@ -55,7 +56,7 @@ fn approach_in(
     sideways: f32,
 ) -> SurfaceSortieState {
     let mut state = SurfaceSortieScenario::init(preset, 7);
-    state.controls_armed = true;
+    state.pilots[0].controls_armed = true;
     let planet = state.world.planets[0];
     let up = Vec2::from_radians(up_angle);
     let center = planet.position + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + 5.5 + height);
@@ -72,7 +73,7 @@ fn approach_in(
 #[test]
 fn minimap_retains_world_context_and_uses_the_actual_camera_aspect() {
     let mut state = parked();
-    let initial_map = SurfaceSortieScenario::minimap_frame(&state, 16.0 / 9.0);
+    let initial_map = SurfaceSortieScenario::minimap_frame(&state, 0, 16.0 / 9.0);
     // Move far enough that the planet is outside the main camera.
     state.world.ships[0].position += Vec2::new(200.0, 170.0);
     idle(&mut state, 1);
@@ -82,7 +83,7 @@ fn minimap_retains_world_context_and_uses_the_actual_camera_aspect() {
             > camera.height
     );
     for aspect in [16.0 / 9.0, 9.0 / 16.0] {
-        let map = SurfaceSortieScenario::minimap_frame(&state, aspect);
+        let map = SurfaceSortieScenario::minimap_frame(&state, 0, aspect);
         assert_eq!(map.camera, initial_map.camera);
         let layer = map
             .ordered_layers()
@@ -115,7 +116,7 @@ fn gentle_flown_landings_work_around_the_planet_and_access_follows_the_ship() {
             idle(&mut state, 1);
             assert!(!state.world.physics.ship_is_constrained(0));
             assert!(state.world.spaceport_contacts.is_empty());
-            if state.vehicle_settled() {
+            if state.vehicle_settled(0) {
                 landed_at = Some(tick_index);
                 break;
             }
@@ -123,23 +124,23 @@ fn gentle_flown_landings_work_around_the_planet_and_access_follows_the_ship() {
         assert!(
             landed_at.is_some(),
             "bearing {index}: {:?}",
-            state.observation()
+            state.observation(0)
         );
         assert_eq!(state.world.ships[0].life, original_health);
-        assert_eq!(state.landing.supported_feet, 2);
+        assert_eq!(state.pilots[0].landing.supported_feet, 2);
         assert!(
             state
-                .access_position()
+                .access_position(0)
                 .distance_to(state.world.ships[0].position + SHIP_PIVOT)
                 < 12.0
         );
         disembark(&mut state);
         interact(&mut state);
         assert_eq!(
-            state.last_transfer,
+            state.pilots[0].last_transfer,
             TransferResult::Boarded,
             "bearing {index}: {:?}",
-            state.observation()
+            state.observation(0)
         );
     }
 }
@@ -158,16 +159,16 @@ fn thrust_lifts_off_physically_and_released_thrust_returns_to_a_landed_ship() {
                 ..SurfaceSortieAction::default()
             },
         );
-        assert!(!state.vehicle_settled());
+        assert!(!state.vehicle_settled(0));
         assert!(!state.world.physics.ship_is_constrained(0));
         if index == 0 {
             assert!(state.world.ships[0].position.distance_to(before) < 0.05);
         }
     }
     assert!(state.world.ships[0].position.distance_to(start) > 3.0);
-    assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+    assert_eq!(state.try_transfer(0), TransferResult::ShipNotSettled);
     idle(&mut state, 900);
-    assert!(state.vehicle_settled(), "{:?}", state.observation());
+    assert!(state.vehicle_settled(0), "{:?}", state.observation(0));
     assert_eq!(state.world.physics.world.body_count(), bodies);
 }
 
@@ -175,19 +176,19 @@ fn thrust_lifts_off_physically_and_released_thrust_returns_to_a_landed_ship() {
 fn hovering_or_nose_contact_does_not_allow_transfer_and_settling_takes_time() {
     let mut state = approach(std::f32::consts::FRAC_PI_2, 1.0, 0.0, 0.0, 0.0);
     idle(&mut state, 1);
-    assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+    assert_eq!(state.try_transfer(0), TransferResult::ShipNotSettled);
     let mut saw_settling = false;
     for _ in 0..300 {
         idle(&mut state, 1);
-        if state.landing.phase == LandingPhase::Settling {
+        if state.pilots[0].landing.phase == LandingPhase::Settling {
             saw_settling = true;
-            assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+            assert_eq!(state.try_transfer(0), TransferResult::ShipNotSettled);
         }
-        if state.vehicle_settled() {
+        if state.vehicle_settled(0) {
             break;
         }
     }
-    assert!(saw_settling && state.vehicle_settled());
+    assert!(saw_settling && state.vehicle_settled(0));
 
     let mut nose_first = approach(
         std::f32::consts::FRAC_PI_2,
@@ -199,8 +200,8 @@ fn hovering_or_nose_contact_does_not_allow_transfer_and_settling_takes_time() {
     let mut touched_hull = false;
     for _ in 0..60 {
         idle(&mut nose_first, 1);
-        assert!(!nose_first.vehicle_settled());
-        assert_eq!(nose_first.landing.assist_strength, 0.0);
+        assert!(!nose_first.vehicle_settled(0));
+        assert_eq!(nose_first.pilots[0].landing.assist_strength, 0.0);
         touched_hull |= nose_first.world.physics.contacts().iter().any(|contact| {
             matches!(
                 (contact.a, contact.b),
@@ -212,7 +213,7 @@ fn hovering_or_nose_contact_does_not_allow_transfer_and_settling_takes_time() {
         });
     }
     assert!(touched_hull, "test must exercise a physical hull collision");
-    assert_eq!(nose_first.try_transfer(), TransferResult::ShipNotSettled);
+    assert_eq!(nose_first.try_transfer(0), TransferResult::ShipNotSettled);
 }
 
 #[test]
@@ -220,12 +221,12 @@ fn assist_reduces_sideways_drift_but_is_bounded_and_does_not_auto_point_the_ship
     let mut aligned = approach(std::f32::consts::FRAC_PI_2, 8.0, 0.0, 4.0, 8.0);
     idle(&mut aligned, 30);
     assert!(
-        aligned.landing.lateral_speed.abs() < 5.0,
+        aligned.pilots[0].landing.lateral_speed.abs() < 5.0,
         "{:?}",
-        aligned.landing
+        aligned.pilots[0].landing
     );
     assert!(
-        aligned.landing.descent_speed > 0.5,
+        aligned.pilots[0].landing.descent_speed > 0.5,
         "assist must descend, not hover"
     );
     let mut sideways = approach(
@@ -237,7 +238,7 @@ fn assist_reduces_sideways_drift_but_is_bounded_and_does_not_auto_point_the_ship
     );
     let original_angle = sideways.world.ships[0].rotation_radians;
     idle(&mut sideways, 20);
-    assert_eq!(sideways.landing.assist_strength, 0.0);
+    assert_eq!(sideways.pilots[0].landing.assist_strength, 0.0);
     assert!((sideways.world.ships[0].rotation_radians - original_angle).abs() < 0.03);
 
     let mut fast = approach(std::f32::consts::FRAC_PI_2, 8.0, 0.0, 65.0, 0.0);
@@ -246,7 +247,7 @@ fn assist_reduces_sideways_drift_but_is_bounded_and_does_not_auto_point_the_ship
     assert!(
         fast.world.ships[0].life < health || fast.world.ships[0].form != ShipForm::Ship,
         "a hard impact must not be silently converted to a safe landing: {:?}",
-        fast.observation()
+        fast.observation(0)
     );
 }
 
@@ -262,26 +263,26 @@ fn interact(state: &mut SurfaceSortieState) {
 
 fn disembark(state: &mut SurfaceSortieState) {
     interact(state);
-    assert_eq!(state.last_transfer, TransferResult::Exited);
+    assert_eq!(state.pilots[0].last_transfer, TransferResult::Exited);
     idle(state, 120);
     assert!(
-        state.spaceling_snapshot().unwrap().grounded(),
+        state.spaceling_snapshot(0).unwrap().grounded(),
         "{:?}",
-        state.observation()
+        state.observation(0)
     );
 }
 
 #[test]
 fn parked_exit_walk_jump_return_and_reboard_preserves_identity_and_vehicle() {
     let mut state = parked();
-    let original = state.observation();
+    let original = state.observation(0);
     state.world.ships[0].life = 70.0;
     disembark(&mut state);
     assert_eq!(
-        state.observation().physical_bodies,
+        state.observation(0).physical_bodies,
         original.physical_bodies + 1
     );
-    let start_position = state.observation().position;
+    let start_position = state.observation(0).position;
     for _ in 0..40 {
         tick(
             &mut state,
@@ -291,7 +292,7 @@ fn parked_exit_walk_jump_return_and_reboard_preserves_identity_and_vehicle() {
             },
         );
     }
-    assert!(state.observation().position.distance_to(start_position) > 1.0);
+    assert!(state.observation(0).position.distance_to(start_position) > 1.0);
     tick(
         &mut state,
         SurfaceSortieAction {
@@ -299,12 +300,12 @@ fn parked_exit_walk_jump_return_and_reboard_preserves_identity_and_vehicle() {
             ..SurfaceSortieAction::default()
         },
     );
-    assert_eq!(state.spaceling_snapshot().unwrap().jumps, 1);
+    assert_eq!(state.spaceling_snapshot(0).unwrap().jumps, 1);
     idle(&mut state, 120);
     // Walk back toward the real access point; no test pose teleport is used.
     for _ in 0..600 {
-        let position = state.observation().position;
-        let offset = state.access_position() - position;
+        let position = state.observation(0).position;
+        let offset = state.access_position(0) - position;
         if offset.length() < 1.3 {
             break;
         }
@@ -319,15 +320,15 @@ fn parked_exit_walk_jump_return_and_reboard_preserves_identity_and_vehicle() {
         );
     }
     idle(&mut state, 60);
-    assert!(state.vehicle_settled());
+    assert!(state.vehicle_settled(0));
     interact(&mut state);
     assert_eq!(
-        state.last_transfer,
+        state.pilots[0].last_transfer,
         TransferResult::Boarded,
         "{:?}",
-        state.observation()
+        state.observation(0)
     );
-    let after = state.observation();
+    let after = state.observation(0);
     assert_eq!(after.spaceling, original.spaceling);
     assert_eq!(after.owner, original.owner);
     assert_eq!(after.vehicle, original.vehicle);
@@ -342,19 +343,19 @@ fn parked_exit_walk_jump_return_and_reboard_preserves_identity_and_vehicle() {
 fn spawn_inherits_rotating_surface_velocity_without_transporting_airborne_body() {
     let mut state = parked();
     let planet = state.world.planets[0];
-    assert_eq!(state.try_transfer(), TransferResult::Exited);
-    let snapshot = state.spaceling_snapshot().unwrap();
+    assert_eq!(state.try_transfer(0), TransferResult::Exited);
+    let snapshot = state.spaceling_snapshot(0).unwrap();
     assert_eq!(
         snapshot.motion.linear_velocity,
-        motion::point_velocity(state.planet_motion(), snapshot.motion.position)
+        motion::point_velocity(state.planet_motion(0), snapshot.motion.position)
     );
     assert_eq!(
         snapshot.motion.angular_velocity,
-        state.planet_motion().angular_velocity
+        state.planet_motion(0).angular_velocity
     );
     assert_eq!(snapshot.contacts, 0);
     // In flight, changing the terrain angle must not teleport the actor.
-    let body = state.pilot.body.as_ref().unwrap().body();
+    let body = state.pilots[0].body.as_ref().unwrap().body();
     let position = planet.position + Vec2::Y * 100.0;
     state
         .world
@@ -368,35 +369,35 @@ fn spawn_inherits_rotating_surface_velocity_without_transporting_airborne_body()
         .set_velocity(body, Vec2::new(2.0, 0.0), 0.0, true);
     state.world.planets[0].wrapper_angle += 0.7;
     idle(&mut state, 1);
-    assert!(state.observation().position.distance_to(position) < 0.1);
+    assert!(state.observation(0).position.distance_to(position) < 0.1);
     let expected_velocity = Vec2::new(2.0, -GRAVITY * planet.mass / 100.0_f32.powi(2));
-    assert!((state.observation().velocity - expected_velocity).length() < 1.0e-4);
+    assert!((state.observation(0).velocity - expected_velocity).length() < 1.0e-4);
 }
 
 #[test]
 fn repeated_sorties_stay_supported_around_the_rotating_planet_without_body_leaks() {
     let mut state = parked();
-    let bodies = state.observation().physical_bodies;
+    let bodies = state.observation(0).physical_bodies;
     for _ in 0..12 {
         disembark(&mut state);
         idle(&mut state, 1200);
-        let snapshot = state.spaceling_snapshot().unwrap();
+        let snapshot = state.spaceling_snapshot(0).unwrap();
         assert!(snapshot.grounded());
         assert_eq!(snapshot.knockdowns, 0);
         assert!(
             snapshot
                 .motion
                 .position
-                .distance_to(state.access_position())
+                .distance_to(state.access_position(0))
                 < 1.5
         );
-        assert_eq!(state.observation().physical_bodies, bodies + 1);
+        assert_eq!(state.observation(0).physical_bodies, bodies + 1);
         interact(&mut state);
-        assert_eq!(state.last_transfer, TransferResult::Boarded);
-        assert_eq!(state.observation().physical_bodies, bodies);
+        assert_eq!(state.pilots[0].last_transfer, TransferResult::Boarded);
+        assert_eq!(state.observation(0).physical_bodies, bodies);
         idle(&mut state, 60);
     }
-    assert_eq!(state.transfers, 24);
+    assert_eq!(state.pilots[0].transfers, 24);
     assert_eq!(state.world.planets[0].owner_id, None);
 }
 
@@ -412,16 +413,16 @@ fn held_inputs_cannot_leak_across_either_transfer() {
     for _ in 0..180 {
         tick(&mut state, held);
     }
-    assert_eq!(state.transfers, 1);
-    assert!(!state.controls_armed);
-    assert_eq!(state.spaceling_snapshot().unwrap().jumps, 0);
+    assert_eq!(state.pilots[0].transfers, 1);
+    assert!(!state.pilots[0].controls_armed);
+    assert_eq!(state.spaceling_snapshot(0).unwrap().jumps, 0);
     assert_eq!(state.world.ships[0].thrust, 0.0);
     idle(&mut state, 120);
     for _ in 0..120 {
         tick(&mut state, held);
     }
-    assert_eq!(state.transfers, 2, "{:?}", state.observation());
-    assert!(matches!(state.location(), PilotLocation::Aboard(_)));
+    assert_eq!(state.pilots[0].transfers, 2, "{:?}", state.observation(0));
+    assert!(matches!(state.location(0), PilotLocation::Aboard(_)));
     assert_eq!(state.world.ships[0].thrust, 0.0);
     assert_eq!(state.world.ships[0].turn, 0.0);
     assert!(!state.world.ships[0].laser_firing);
@@ -441,10 +442,10 @@ fn unsafe_exit_blocked_capsule_remote_or_airborne_boarding_and_lost_vehicle_are_
     let mut state = parked();
     state.world.ships[0].velocity += Vec2::Y * 20.0;
     idle(&mut state, 1);
-    assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+    assert_eq!(state.try_transfer(0), TransferResult::ShipNotSettled);
     let mut state = parked();
     let obstacle = PhysicsId::new(45_000);
-    let center = state.access_position() + state.access_up() * 1.0;
+    let center = state.access_position(0) + state.access_up(0) * 1.0;
     let collider = ColliderSpec::ball(ColliderId::new(obstacle, ColliderRole::PRIMARY, 0), 1.3);
     assert!(state.world.physics.world.insert_body(
         PhysicsBodyId::new(obstacle, BodyRole::PRIMARY),
@@ -456,8 +457,8 @@ fn unsafe_exit_blocked_capsule_remote_or_airborne_boarding_and_lost_vehicle_are_
         &[collider]
     ));
     idle(&mut state, 1); // Publish the obstacle in the broad-phase index.
-    assert_eq!(state.try_transfer(), TransferResult::ExitBlocked);
-    assert!(state.pilot.body.is_none());
+    assert_eq!(state.try_transfer(0), TransferResult::ExitBlocked);
+    assert!(state.pilots[0].body.is_none());
     state.world.physics.world.remove_entity(obstacle);
     idle(&mut state, 1);
     disembark(&mut state);
@@ -468,7 +469,7 @@ fn unsafe_exit_blocked_capsule_remote_or_airborne_boarding_and_lost_vehicle_are_
             ..SurfaceSortieAction::default()
         },
     );
-    assert_eq!(state.try_transfer(), TransferResult::MustBeSupported);
+    assert_eq!(state.try_transfer(0), TransferResult::MustBeSupported);
     idle(&mut state, 120);
     for _ in 0..120 {
         tick(
@@ -480,10 +481,10 @@ fn unsafe_exit_blocked_capsule_remote_or_airborne_boarding_and_lost_vehicle_are_
         );
     }
     idle(&mut state, 60);
-    assert_eq!(state.try_transfer(), TransferResult::TooFar);
+    assert_eq!(state.try_transfer(0), TransferResult::TooFar);
     state.world.ships[0].change_to_escape_pod();
-    assert_eq!(state.try_transfer(), TransferResult::VehicleUnavailable);
-    assert!(state.pilot.body.is_some());
+    assert_eq!(state.try_transfer(0), TransferResult::VehicleUnavailable);
+    assert!(state.pilots[0].body.is_some());
 }
 
 #[test]
@@ -509,7 +510,7 @@ fn restart_actions_and_observations_are_reproducible_and_malformed_actions_are_r
         );
     }
     for payload in [vec![], vec![0; 6], vec![0, 0, 0, 0, 2, 0, 0]] {
-        assert!(SurfaceSortieAction::decode(&Action::scenario(CONTROL_V1, payload)).is_none());
+        assert!(SurfaceSortieAction::decode(&Action::scenario(CONTROL_V2, payload)).is_none());
     }
     assert!(
         SurfaceSortieAction::decode(
@@ -517,7 +518,7 @@ fn restart_actions_and_observations_are_reproducible_and_malformed_actions_are_r
                 horizontal: f32::NAN,
                 ..SurfaceSortieAction::default()
             }
-            .encode()
+            .encode(PlayerId::PLAYER_1)
         )
         .is_none()
     );

--- a/scenarios/spacewars/src/surface_sortie/tests/compatibility_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/compatibility_tests.rs
@@ -86,17 +86,17 @@ fn surface_v1_extended_idle_support() {
             .with_profile(GeneratedSurfaceProfile::SurfaceV1);
         let mut state = case.init().unwrap();
         idle(&mut state, 120);
-        assert!(state.vehicle_settled(), "{case:?}");
+        assert!(state.vehicle_settled(0), "{case:?}");
         disembark(&mut state);
         let bodies = state.world.physics.world.body_count();
-        state.motion_metrics = SurfaceMotionMetrics::default();
-        state.idle_anchor = None;
+        state.pilots[0].motion_metrics = SurfaceMotionMetrics::default();
+        state.pilots[0].idle_anchor = None;
         let mut unsupported_streak = 0;
         let mut longest_gap = 0;
         let mut max_hatch_distance = 0.0_f32;
         for _ in 0..12000 {
             idle(&mut state, 1);
-            let snapshot = state.spaceling_snapshot().unwrap();
+            let snapshot = state.spaceling_snapshot(0).unwrap();
             unsupported_streak = if snapshot.grounded() {
                 0
             } else {
@@ -107,18 +107,18 @@ fn surface_v1_extended_idle_support() {
                 snapshot
                     .motion
                     .position
-                    .distance_to(state.access_position()),
+                    .distance_to(state.access_position(0)),
             );
         }
-        let metrics = state.motion_metrics;
+        let metrics = state.pilots[0].motion_metrics;
         eprintln!(
             "extended {case:?}: {metrics:?}, longest_gap={longest_gap}, max_hatch={max_hatch_distance}, hatch={}",
             state
-                .spaceling_snapshot()
+                .spaceling_snapshot(0)
                 .unwrap()
                 .motion
                 .position
-                .distance_to(state.access_position())
+                .distance_to(state.access_position(0))
         );
         assert_eq!(state.world.physics.world.body_count(), bodies);
         assert_eq!(metrics.knockdowns, 0);
@@ -210,7 +210,7 @@ fn controlled(radius: f32, gravity: f32, spin: f32) -> SurfaceSortieState {
         SurfaceMotionPreset::Stationary,
         0,
         Vec2::Y,
-        -20.4 / radius,
+        Some(-20.4 / radius),
     )
 }
 
@@ -289,9 +289,9 @@ fn generated_fixture_preserves_all_world_sources_and_the_selected_planet_identit
     assert_eq!(state.world.planets, planets);
     assert_eq!(state.world.sun, sun);
     assert_eq!(GeneratedSurfaceCase::planet_count(case.seed), planets.len());
-    assert_eq!(state.pilot.planet, case.planet);
+    assert_eq!(state.pilots[0].planet, case.planet);
     assert_eq!(state.outposts[0].planet, case.planet);
-    assert_eq!(state.observation().generated_case, Some(case));
+    assert_eq!(state.observation(0).generated_case, Some(case));
     assert_eq!(state.world.physics.world.body_count(), planets.len() + 3);
     let bodies = state.world.physics.world.body_count();
     idle(&mut state, 1);
@@ -311,7 +311,7 @@ fn generated_fixture_preserves_all_world_sources_and_the_selected_planet_identit
     }
     assert_eq!(state.world.physics.world.body_count(), bodies);
     assert_eq!(
-        state.planet_motion().position,
+        state.planet_motion(0).position,
         state.world.planets[case.planet].position
     );
     assert!(!state.world.physics.ship_is_constrained(0));
@@ -374,15 +374,16 @@ fn generated_field_report_matches_the_shared_solver_and_support_is_planet_specif
     let environment = compatibility::SurfaceEnvironment::read(&state);
     idle(&mut state, 1);
     assert!(
-        (state.pilot.ship_gravity_delta * 60.0 - environment.gravity_at_ship_spawn).length() < 0.01
+        (state.pilots[0].ship_gravity_delta * 60.0 - environment.gravity_at_ship_spawn).length()
+            < 0.01
     );
     for _ in 0..600 {
-        if state.vehicle_settled() {
+        if state.vehicle_settled(0) {
             break;
         }
         idle(&mut state, 1);
     }
-    assert!(state.vehicle_settled());
+    assert!(state.vehicle_settled(0));
     let planet = state.world.planets[2];
     let up = (state.world.ships[0].position + SHIP_PIVOT - planet.position).normalized();
     assert_eq!(state.world.physics.landing_feet_supported(0, 2, up), 2);

--- a/scenarios/spacewars/src/surface_sortie/tests/motion_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/motion_tests.rs
@@ -320,7 +320,7 @@ fn orbital_motion_metrics_and_rendering_replay_and_restart_deterministically() {
             SurfaceSortieScenario::observe(&SurfaceSortieScenario::init(preset, 123)).payload,
             initial
         );
-        assert_eq!(a.observation(0).version, 9);
+        assert_eq!(a.observation(0).version, 10);
         assert!(a.pilots[0].motion_metrics.on_foot_ticks > 0);
         assert_eq!(a.pilots[0].motion_metrics.jumps, 1);
         assert_eq!(a.pilots[0].motion_metrics.ship_damage, 0.0);

--- a/scenarios/spacewars/src/surface_sortie/tests/motion_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/motion_tests.rs
@@ -14,31 +14,31 @@ fn orbital_support_handles_opposite_and_faster_orbit_and_spin() {
         state.world.ships[0].omega = spin;
         idle(&mut state, 120);
         assert!(
-            state.vehicle_settled(),
+            state.vehicle_settled(0),
             "{orbit}/{spin}: {:?}",
-            state.observation()
+            state.observation(0)
         );
         disembark(&mut state);
         let mut supported = 0;
         for _ in 0..3600 {
             idle(&mut state, 1);
-            supported += usize::from(state.spaceling_snapshot().unwrap().grounded());
+            supported += usize::from(state.spaceling_snapshot(0).unwrap().grounded());
         }
         assert!(
             supported > 3500,
             "{orbit}/{spin}: {:?}",
-            state.observation()
+            state.observation(0)
         );
-        assert_eq!(state.motion_metrics.ship_damage, 0.0);
-        assert_eq!(state.motion_metrics.knockdowns, 0);
+        assert_eq!(state.pilots[0].motion_metrics.ship_damage, 0.0);
+        assert_eq!(state.pilots[0].motion_metrics.knockdowns, 0);
         assert!(
-            state.motion_metrics.max_idle_drift < 1.0,
+            state.pilots[0].motion_metrics.max_idle_drift < 1.0,
             "{orbit}/{spin}: {:?}",
-            state.motion_metrics
+            state.pilots[0].motion_metrics
         );
         eprintln!(
             "rates orbit={orbit} spin={spin}: {}",
-            serde_json::to_string(&state.motion_metrics).unwrap()
+            serde_json::to_string(&state.pilots[0].motion_metrics).unwrap()
         );
     }
 }
@@ -54,8 +54,8 @@ fn single_pilot_fixture_does_not_simulate_the_unused_ship_slot() {
         state.world.ships[1].position = state.world.ships[0].position;
         idle(&mut state, 120);
         assert_eq!(state.world.physics.world.motion(inactive), None);
-        assert!(state.vehicle_settled());
-        assert_eq!(state.motion_metrics.ship_damage, 0.0);
+        assert!(state.vehicle_settled(0));
+        assert_eq!(state.pilots[0].motion_metrics.ship_damage, 0.0);
         assert!(
             !state
                 .world
@@ -70,9 +70,9 @@ fn single_pilot_fixture_does_not_simulate_the_unused_ship_slot() {
 fn motion_metrics_preserve_damage_through_repair_and_reset_only_current_idle_drift() {
     let mut state = parked();
     idle(&mut state, 120);
-    let maximum = state.motion_metrics.max_idle_drift;
-    assert!(state.motion_metrics.idle_drift > 0.0);
-    assert!(state.idle_anchor.is_some());
+    let maximum = state.pilots[0].motion_metrics.max_idle_drift;
+    assert!(state.pilots[0].motion_metrics.idle_drift > 0.0);
+    assert!(state.pilots[0].idle_anchor.is_some());
     tick(
         &mut state,
         SurfaceSortieAction {
@@ -80,30 +80,30 @@ fn motion_metrics_preserve_damage_through_repair_and_reset_only_current_idle_dri
             ..SurfaceSortieAction::default()
         },
     );
-    assert_eq!(state.motion_metrics.idle_drift, 0.0);
-    assert_eq!(state.idle_anchor, None);
-    assert_eq!(state.motion_metrics.max_idle_drift, maximum);
+    assert_eq!(state.pilots[0].motion_metrics.idle_drift, 0.0);
+    assert_eq!(state.pilots[0].idle_anchor, None);
+    assert_eq!(state.pilots[0].motion_metrics.max_idle_drift, maximum);
     idle(&mut state, 1);
-    assert!(state.idle_anchor.is_some());
-    assert_eq!(state.motion_metrics.idle_drift, 0.0);
+    assert!(state.pilots[0].idle_anchor.is_some());
+    assert_eq!(state.pilots[0].motion_metrics.idle_drift, 0.0);
 
     // Isolate the counter's before/after contract from impact tuning. Recording
     // happens before the repair service; even immediate healing cannot mask it.
-    let before = motion::StepSample::read(&state);
+    let before = motion::StepSample::read(&state, 0);
     state.world.ships[0].life -= 10.0;
-    state.record_motion_step(before, SurfaceSortieAction::default());
-    assert_eq!(state.motion_metrics.ship_damage, 10.0);
-    state.outposts[0].owner = Some(state.pilot.owner);
+    state.record_motion_step(0, before, SurfaceSortieAction::default());
+    assert_eq!(state.pilots[0].motion_metrics.ship_damage, 10.0);
+    state.outposts[0].owner = Some(state.pilots[0].owner);
     let health = state.world.ships[0].life;
     idle(&mut state, 120);
     assert!(state.world.ships[0].life > health);
-    assert_eq!(state.motion_metrics.ship_damage, 10.0);
+    assert_eq!(state.pilots[0].motion_metrics.ship_damage, 10.0);
 
-    let before = motion::StepSample::read(&state);
+    let before = motion::StepSample::read(&state, 0);
     let remaining = state.world.ships[0].life;
     state.world.ships[0].change_to_escape_pod();
-    state.record_motion_step(before, SurfaceSortieAction::default());
-    assert_eq!(state.motion_metrics.ship_damage, 10.0 + remaining);
+    state.record_motion_step(0, before, SurfaceSortieAction::default());
+    assert_eq!(state.pilots[0].motion_metrics.ship_damage, 10.0 + remaining);
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn first_completed_surface_frame_has_the_presets_origin_velocity() {
         let mut state = SurfaceSortieScenario::init(preset, 7);
         let origin = state.world.planets[0].position;
         idle(&mut state, 1);
-        let motion = state.motion_observation();
+        let motion = state.motion_observation(0);
         let expected = (state.world.planets[0].position - origin) * 60.0;
         assert!(
             (motion.planet_velocity - expected).length() < 0.01,
@@ -138,19 +138,19 @@ fn orbital_approaches_land_from_eight_bearings_without_damage() {
         );
         for _ in 0..900 {
             idle(&mut state, 1);
-            if state.vehicle_settled() {
+            if state.vehicle_settled(0) {
                 break;
             }
         }
         assert!(
-            state.vehicle_settled(),
+            state.vehicle_settled(0),
             "bearing={bearing} {:?}",
-            state.observation()
+            state.observation(0)
         );
-        assert_eq!(state.motion_metrics.ship_damage, 0.0);
+        assert_eq!(state.pilots[0].motion_metrics.ship_damage, 0.0);
         disembark(&mut state);
         interact(&mut state);
-        assert_eq!(state.last_transfer, TransferResult::Boarded);
+        assert_eq!(state.pilots[0].last_transfer, TransferResult::Boarded);
     }
 }
 
@@ -163,7 +163,7 @@ pub(super) fn free_flight_without_transport(init: impl Fn() -> SurfaceSortieStat
     let mut state = init();
     idle(&mut state, 120);
     disembark(&mut state);
-    let snapshot = state.spaceling_snapshot().unwrap();
+    let snapshot = state.spaceling_snapshot(0).unwrap();
     let velocity = snapshot.motion.linear_velocity;
     tick(
         &mut state,
@@ -172,12 +172,12 @@ pub(super) fn free_flight_without_transport(init: impl Fn() -> SurfaceSortieStat
             ..SurfaceSortieAction::default()
         },
     );
-    assert_eq!(state.motion_metrics.jumps, 1);
+    assert_eq!(state.pilots[0].motion_metrics.jumps, 1);
     assert_eq!(
-        state.motion_metrics.pilot_support_losses, 0,
+        state.pilots[0].motion_metrics.pilot_support_losses, 0,
         "a jump isn't unexpected support loss"
     );
-    let after = state.spaceling_snapshot().unwrap();
+    let after = state.spaceling_snapshot(0).unwrap();
     let right = Vec2::new(snapshot.up.y, -snapshot.up.x);
     assert!(
         (after.motion.linear_velocity - velocity).dot(right).abs() < 0.2,
@@ -188,18 +188,18 @@ pub(super) fn free_flight_without_transport(init: impl Fn() -> SurfaceSortieStat
     // the shared gravity field. Moving terrain must not carry a jumping actor.
     idle(&mut state, 2);
     for _ in 0..12 {
-        let before = state.spaceling_snapshot().unwrap();
+        let before = state.spaceling_snapshot(0).unwrap();
         assert!(!before.grounded());
         idle(&mut state, 1);
-        let after = state.spaceling_snapshot().unwrap();
-        let expected = before.motion.linear_velocity + state.pilot.gravity / 60.0;
+        let after = state.spaceling_snapshot(0).unwrap();
+        let expected = before.motion.linear_velocity + state.pilots[0].gravity / 60.0;
         assert!(
             (after.motion.linear_velocity - expected).length() < 1.0e-4,
             "no air transport: {after:?}"
         );
     }
     idle(&mut state, 180);
-    assert!(state.spaceling_snapshot().unwrap().grounded());
+    assert!(state.spaceling_snapshot(0).unwrap().grounded());
 
     // A fresh, reproducible fixture exercises takeoff through player controls.
     let mut state = init();
@@ -216,7 +216,7 @@ pub(super) fn free_flight_without_transport(init: impl Fn() -> SurfaceSortieStat
         (state.world.ships[0].velocity - before).length() < 1.0,
         "no hidden launch impulse"
     );
-    assert_eq!(state.motion_metrics.departures, 1);
+    assert_eq!(state.pilots[0].motion_metrics.departures, 1);
     assert!(!state.world.physics.ship_is_constrained(0));
     for _ in 0..100 {
         tick(
@@ -227,11 +227,11 @@ pub(super) fn free_flight_without_transport(init: impl Fn() -> SurfaceSortieStat
             },
         );
     }
-    assert!(state.landing.altitude > 25.0);
+    assert!(state.pilots[0].landing.altitude > 25.0);
     for _ in 0..10 {
         let velocity = state.world.ships[0].velocity;
         idle(&mut state, 1);
-        let expected = velocity + state.pilot.ship_gravity_delta;
+        let expected = velocity + state.pilots[0].ship_gravity_delta;
         assert!(
             (state.world.ships[0].velocity - expected).length() < 1.0e-4,
             "ship coasts independently outside assist range"
@@ -248,7 +248,7 @@ fn excessive_support_acceleration_causes_separation_and_stops_capture_and_repair
     idle(&mut state, 40);
     assert!(
         state.outposts[0]
-            .observation(&state.world.planets[0])
+            .observation(&state.world.planets[0], 0)
             .capture_progress
             > 0.0
     );
@@ -256,29 +256,29 @@ fn excessive_support_acceleration_causes_separation_and_stops_capture_and_repair
     // magnetic attachment to make this unsafe scripted trajectory "pass".
     state.world.planets[0].orbit_omega = 0.8;
     idle(&mut state, 30);
-    assert!(!state.spaceling_snapshot().unwrap().grounded());
-    assert!(!state.vehicle_settled());
+    assert!(!state.spaceling_snapshot(0).unwrap().grounded());
+    assert!(!state.vehicle_settled(0));
     assert_eq!(
         state.outposts[0]
-            .observation(&state.world.planets[0])
+            .observation(&state.world.planets[0], 0)
             .capture_progress,
         0.0
     );
-    assert!(state.motion_metrics.pilot_support_losses > 0);
-    state.outposts[0].owner = Some(state.pilot.owner);
+    assert!(state.pilots[0].motion_metrics.pilot_support_losses > 0);
+    state.outposts[0].owner = Some(state.pilots[0].owner);
     let healed = state.outposts[0]
-        .observation(&state.world.planets[0])
+        .observation(&state.world.planets[0], 0)
         .repaired_health;
     idle(&mut state, 30);
     assert_ne!(
         state.outposts[0]
-            .observation(&state.world.planets[0])
+            .observation(&state.world.planets[0], 0)
             .repair_status,
         RepairStatus::Repairing
     );
     assert_eq!(
         state.outposts[0]
-            .observation(&state.world.planets[0])
+            .observation(&state.world.planets[0], 0)
             .repaired_health,
         healed
     );
@@ -307,12 +307,12 @@ fn orbital_motion_metrics_and_rendering_replay_and_restart_deterministically() {
             };
             tick(&mut a, input);
             tick(&mut b, input);
-            assert_eq!(a.observation(), b.observation());
+            assert_eq!(a.observation(0), b.observation(0));
         }
         let before = SurfaceSortieScenario::observe(&a).payload;
         for _ in 0..3 {
             SurfaceSortieScenario::render_frame(&a);
-            SurfaceSortieScenario::minimap_frame(&a, 9.0 / 16.0);
+            SurfaceSortieScenario::minimap_frame(&a, 0, 9.0 / 16.0);
             SurfaceSortieScenario::step(&mut a, &[], Duration::ZERO);
         }
         assert_eq!(SurfaceSortieScenario::observe(&a).payload, before);
@@ -320,10 +320,10 @@ fn orbital_motion_metrics_and_rendering_replay_and_restart_deterministically() {
             SurfaceSortieScenario::observe(&SurfaceSortieScenario::init(preset, 123)).payload,
             initial
         );
-        assert_eq!(a.observation().version, 7);
-        assert!(a.motion_metrics.on_foot_ticks > 0);
-        assert_eq!(a.motion_metrics.jumps, 1);
-        assert_eq!(a.motion_metrics.ship_damage, 0.0);
+        assert_eq!(a.observation(0).version, 9);
+        assert!(a.pilots[0].motion_metrics.on_foot_ticks > 0);
+        assert_eq!(a.pilots[0].motion_metrics.jumps, 1);
+        assert_eq!(a.pilots[0].motion_metrics.ship_damage, 0.0);
     }
 }
 
@@ -332,7 +332,7 @@ fn orbital_frame_has_matched_external_gravity_without_a_follow_force() {
     let mut state = SurfaceSortieScenario::init(SurfaceMotionPreset::Orbit, 7);
     idle(&mut state, 1);
     for _ in 0..120 {
-        let observation = state.motion_observation();
+        let observation = state.motion_observation(0);
         assert!(
             (observation.scripted_acceleration - observation.external_gravity_at_center).length()
                 < 1.0e-5
@@ -343,7 +343,7 @@ fn orbital_frame_has_matched_external_gravity_without_a_follow_force() {
     // Ordinary worlds do not necessarily have this agreement. The diagnostic
     // exposes the difference; it does not silently subtract or add a force.
     state.world.sun.as_mut().unwrap().mass *= 10.0;
-    let observation = state.motion_observation();
+    let observation = state.motion_observation(0);
     assert!(
         (observation.scripted_acceleration - observation.external_gravity_at_center).length() > 8.0
     );
@@ -386,7 +386,7 @@ fn orbiting_and_translating_sorties_stay_supported_without_actor_transport() {
     ] {
         let mut state = SurfaceSortieScenario::init(preset, 7);
         idle(&mut state, 120);
-        assert!(state.vehicle_settled(), "{:?}", state.observation());
+        assert!(state.vehicle_settled(0), "{:?}", state.observation(0));
         disembark(&mut state);
         let bodies = state.world.physics.world.body_count();
         let colliders = state.world.physics.world.collider_count();
@@ -397,16 +397,16 @@ fn orbiting_and_translating_sorties_stay_supported_without_actor_transport() {
         let started = Instant::now();
         for _ in 0..ticks {
             idle(&mut state, 1);
-            let snapshot = state.spaceling_snapshot().unwrap();
+            let snapshot = state.spaceling_snapshot(0).unwrap();
             supported += usize::from(snapshot.grounded());
             assert_eq!(state.world.physics.world.body_count(), bodies);
             assert_eq!(state.world.physics.world.collider_count(), colliders);
-            landed += usize::from(state.vehicle_settled());
+            landed += usize::from(state.vehicle_settled(0));
             max_hatch_distance = max_hatch_distance.max(
                 snapshot
                     .motion
                     .position
-                    .distance_to(state.access_position()),
+                    .distance_to(state.access_position(0)),
             );
         }
         eprintln!(
@@ -415,20 +415,20 @@ fn orbiting_and_translating_sorties_stay_supported_without_actor_transport() {
             state.world.physics.world.body_count(),
             ticks as f64 / started.elapsed().as_secs_f64(),
         );
-        assert!(supported > ticks * 98 / 100, "{:?}", state.observation());
-        assert!(landed > ticks * 98 / 100, "{:?}", state.observation());
+        assert!(supported > ticks * 98 / 100, "{:?}", state.observation(0));
+        assert!(landed > ticks * 98 / 100, "{:?}", state.observation(0));
         assert!(max_hatch_distance < BOARDING_RANGE);
-        assert_eq!(state.spaceling_snapshot().unwrap().knockdowns, 0);
+        assert_eq!(state.spaceling_snapshot(0).unwrap().knockdowns, 0);
         assert_eq!(state.world.ships[0].life, health);
         assert_eq!(state.world.physics.world.body_count(), bodies);
-        assert_eq!(state.motion_metrics.ship_damage, 0.0);
-        assert_eq!(state.motion_metrics.pilot_support_losses, 0);
+        assert_eq!(state.pilots[0].motion_metrics.ship_damage, 0.0);
+        assert_eq!(state.pilots[0].motion_metrics.pilot_support_losses, 0);
         eprintln!(
             "metrics: {}",
-            serde_json::to_string(&state.motion_metrics).unwrap()
+            serde_json::to_string(&state.pilots[0].motion_metrics).unwrap()
         );
         interact(&mut state);
-        assert_eq!(state.last_transfer, TransferResult::Boarded);
+        assert_eq!(state.pilots[0].last_transfer, TransferResult::Boarded);
     }
 }
 
@@ -443,7 +443,7 @@ fn physical_spin_matches_prescribed_motion_during_landing() {
     );
     for _ in 0..900 {
         idle(&mut state, 1);
-        let surface = state.planet_motion();
+        let surface = state.planet_motion(0);
         assert!(
             (surface.angular_velocity - state.world.planets[0].wrapper_omega).abs() < 0.001,
             "tick {}: prescribed spin {}, completed motion {surface:?}",
@@ -457,10 +457,10 @@ fn physical_spin_matches_prescribed_motion_during_landing() {
 fn frame_velocity_matches_motion_of_the_surface_not_its_offset_center_of_mass() {
     let state = parked();
     let planet = state.world.planets[0];
-    let frame = state.planet_motion();
+    let frame = state.planet_motion(0);
     for point in [
         planet.position,
-        state.access_position(),
+        state.access_position(0),
         state.outposts[0].position(&planet),
     ] {
         let actual = state

--- a/scenarios/spacewars/src/surface_sortie/tests/multiplayer_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/multiplayer_tests.rs
@@ -317,7 +317,7 @@ fn generated_two_player_sessions_replay_and_inactive_or_invalid_seats_are_ignore
         SurfaceSortieScenario::observe(&SurfaceSortieScenario::init_expedition(0, 2)).payload
     );
     let observation: serde_json::Value = serde_json::from_slice(&initial).unwrap();
-    assert_eq!(observation["version"], 9);
+    assert_eq!(observation["version"], 10);
     assert_eq!(observation["players"].as_array().unwrap().len(), 2);
     let mut solo = solo;
     step_pair(

--- a/scenarios/spacewars/src/surface_sortie/tests/multiplayer_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/multiplayer_tests.rs
@@ -1,0 +1,364 @@
+use super::*;
+
+const NEUTRAL: SurfaceSortieAction = SurfaceSortieAction {
+    horizontal: 0.0,
+    primary_held: false,
+    interact_held: false,
+    brake_held: false,
+};
+const INTERACT: SurfaceSortieAction = SurfaceSortieAction {
+    interact_held: true,
+    ..NEUTRAL
+};
+
+fn step_pair(state: &mut SurfaceSortieState, inputs: [SurfaceSortieAction; 2]) {
+    SurfaceSortieScenario::step(
+        state,
+        &[
+            inputs[0].encode(PlayerId::PLAYER_1),
+            inputs[1].encode(PlayerId::PLAYER_2),
+        ],
+        Duration::from_secs_f64(1.0 / 60.0),
+    );
+}
+
+fn idle_pair(state: &mut SurfaceSortieState, ticks: usize) {
+    for _ in 0..ticks {
+        step_pair(state, [NEUTRAL; 2]);
+    }
+}
+
+/// Setup only: place two independent vehicles on the same controlled planet.
+fn two_on_planet(preset: SurfaceMotionPreset, separation: f32) -> SurfaceSortieState {
+    let mut state = SurfaceSortieScenario::init(preset, 7);
+    let planet = state.world.planets[0];
+    let up = Vec2::Y.rotate_radians(separation);
+    let center = planet.position + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + 5.5);
+    let ship = &mut state.world.ships[1];
+    ship.position = center - SHIP_PIVOT;
+    ship.rotation_radians = rotation_for_direction(up);
+    ship.direction = up;
+    ship.velocity = preset.initial_velocity(&planet)
+        + Vec2::new(-(center - planet.position).y, (center - planet.position).x)
+            * planet.wrapper_omega;
+    ship.life = ship.life_max * 0.75;
+    state
+        .pilots
+        .push(SurfacePilot::new(PlayerId::PLAYER_2, 0, false));
+    state
+        .world
+        .physics
+        .enable_surface_sortie(&[0, 1], &state.world.ships);
+    idle_pair(&mut state, 120);
+    for player in 0..2 {
+        assert!(
+            state.vehicle_settled(player),
+            "{:?}",
+            state.observation(player)
+        );
+    }
+    state
+}
+
+#[test]
+fn two_pilots_land_exit_and_reboard_on_the_same_moving_planet_without_body_leaks() {
+    for preset in [SurfaceMotionPreset::Stationary, SurfaceMotionPreset::Orbit] {
+        let mut state = two_on_planet(preset, std::f32::consts::PI);
+        let base_bodies = state.world.physics.world.body_count();
+        let health = [state.world.ships[0].life, state.world.ships[1].life];
+        for cycle in 0..6 {
+            step_pair(&mut state, [INTERACT; 2]);
+            assert_eq!(state.world.physics.world.body_count(), base_bodies + 2);
+            for player in 0..2 {
+                assert_eq!(state.pilots[player].last_transfer, TransferResult::Exited);
+                assert_eq!(state.location(player), PilotLocation::OnFoot);
+                assert_eq!(state.pilots[player].id, SpacelingId(player as u64 + 1));
+            }
+            let bodies = state
+                .pilots
+                .iter()
+                .map(|p| p.body.as_ref().unwrap().body())
+                .collect::<Vec<_>>();
+            assert_ne!(bodies[0], bodies[1]);
+            idle_pair(&mut state, 30);
+            let targets = state
+                .world
+                .gravity_participants
+                .iter()
+                .filter_map(|p| {
+                    let (tag, payload) = split_gravity_id(p.id);
+                    (tag == GRAVITY_SURFACE_PILOT_TAG).then_some(payload)
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(targets, vec![0, 1]);
+            for player in 0..2 {
+                assert!(state.spaceling_snapshot(player).unwrap().grounded());
+            }
+            step_pair(&mut state, [INTERACT; 2]);
+            assert_eq!(state.world.physics.world.body_count(), base_bodies);
+            for (player, initial_health) in health.iter().enumerate() {
+                assert_eq!(state.pilots[player].last_transfer, TransferResult::Boarded);
+                assert_eq!(
+                    state.location(player),
+                    PilotLocation::Aboard(VehicleId(player))
+                );
+                assert_eq!(state.pilots[player].transfers, (cycle + 1) * 2);
+                assert_eq!(state.world.ships[player].life, *initial_health);
+            }
+            idle_pair(&mut state, 30);
+        }
+    }
+}
+
+#[test]
+fn one_seats_transfer_neutral_gate_does_not_cancel_or_arm_the_other_seat() {
+    let mut state = two_on_planet(SurfaceMotionPreset::Stationary, std::f32::consts::PI);
+    let flying = SurfaceSortieAction {
+        horizontal: -1.0,
+        primary_held: true,
+        ..NEUTRAL
+    };
+    for _ in 0..8 {
+        step_pair(&mut state, [INTERACT, flying]);
+        assert_eq!(state.location(0), PilotLocation::OnFoot);
+        assert_eq!(state.pilots[0].transfers, 1);
+        assert!(!state.pilots[0].controls_armed);
+        assert_eq!(state.world.ships[0].thrust, 0.0);
+        assert_eq!(state.world.ships[0].turn, 0.0);
+        assert_eq!(state.world.ships[1].thrust, 1.0);
+        assert_eq!(state.world.ships[1].turn, -1.0);
+        assert!(state.pilots[1].controls_armed);
+    }
+    step_pair(&mut state, [NEUTRAL; 2]);
+    assert!(state.pilots[0].controls_armed);
+    assert_eq!(state.world.ships[1].thrust, 0.0);
+}
+
+#[test]
+fn capture_is_order_independent_and_contested_time_does_not_count() {
+    let mut a = outpost::SurfaceOutpost::new(OutpostId(1), 0, 0.0);
+    let mut b = outpost::SurfaceOutpost::new(OutpostId(1), 0, 0.0);
+    let p1 = (PlayerId::PLAYER_1, CaptureStatus::Capturing);
+    let p2 = (PlayerId::PLAYER_2, CaptureStatus::Capturing);
+    for post in [&mut a, &mut b] {
+        post.update_capture(&[p1], Duration::from_secs(1));
+    }
+    a.update_capture(&[p1, p2], Duration::from_secs(20));
+    b.update_capture(&[p2, p1], Duration::from_secs(20));
+    let planet = SurfaceSortieScenario::init(SurfaceMotionPreset::Stationary, 0)
+        .world
+        .planets[0];
+    for player in 0..2 {
+        assert_eq!(
+            a.observation(&planet, player),
+            b.observation(&planet, player)
+        );
+        assert_eq!(
+            a.observation(&planet, player).capture_status,
+            CaptureStatus::Contested
+        );
+    }
+    assert_eq!(a.owner, None);
+    assert!((a.observation(&planet, 0).capture_progress - 1.0 / 3.0).abs() < 1e-6);
+    a.update_capture(&[p1], Duration::from_secs(2));
+    assert_eq!(a.owner, Some(PlayerId::PLAYER_1));
+    a.update_capture(&[p1, p2], Duration::from_secs(20));
+    assert_eq!(a.owner, Some(PlayerId::PLAYER_1));
+    let p1_away = (PlayerId::PLAYER_1, CaptureStatus::Aboard);
+    a.update_capture(&[p1_away, p2], Duration::from_secs(2));
+    assert_eq!(a.owner, Some(PlayerId::PLAYER_1));
+    a.update_capture(&[p1_away, p2], Duration::from_secs(1));
+    assert_eq!(a.owner, Some(PlayerId::PLAYER_2));
+    assert_eq!(
+        a.observation(&planet, 0).capture_status,
+        CaptureStatus::Aboard
+    );
+    assert_eq!(
+        a.observation(&planet, 1).capture_status,
+        CaptureStatus::Secured
+    );
+}
+
+fn place_pilot_near_terminal(state: &mut SurfaceSortieState, player: usize, side: f32) {
+    let planet = state.world.planets[0];
+    let radius = planet.radius * BODY_BOUNDS_RADIUS_SCALE;
+    let up = state.outposts[0]
+        .up(&planet)
+        .rotate_radians(side * 2.0 / radius);
+    let position =
+        planet.position + up * (radius + SurfaceSortieState::spec().half_height() + 0.04);
+    let frame = motion::SurfaceFrame::read(&state.world.physics, 0);
+    let body = state.pilots[player].body.as_ref().unwrap().body();
+    state
+        .world
+        .physics
+        .world
+        .set_pose(body, position, rotation_for_direction(up), true);
+    state.world.physics.world.set_velocity(
+        body,
+        motion::point_velocity(frame, position),
+        frame.angular_velocity,
+        true,
+    );
+}
+
+#[test]
+fn physical_claimants_contest_and_friendly_repair_is_vehicle_specific_on_one_planet() {
+    let mut state = two_on_planet(SurfaceMotionPreset::Stationary, -0.68);
+    let health = [state.world.ships[0].life, state.world.ships[1].life];
+    step_pair(&mut state, [INTERACT; 2]);
+    place_pilot_near_terminal(&mut state, 0, 1.0);
+    place_pilot_near_terminal(&mut state, 1, -1.0);
+    idle_pair(&mut state, 220);
+    assert_eq!(state.outposts[0].owner, None);
+    for player in 0..2 {
+        assert_eq!(
+            state
+                .observation(player)
+                .outpost
+                .as_ref()
+                .unwrap()
+                .capture_status,
+            CaptureStatus::Contested,
+            "{:?}",
+            state.observation(player)
+        );
+    }
+    // This fixture moves one claimant away, then lets actual contacts decide eligibility.
+    let body = state.pilots[1].body.as_ref().unwrap().body();
+    let position = state.spaceling_snapshot(1).unwrap().motion.position + Vec2::Y * 30.0;
+    state
+        .world
+        .physics
+        .world
+        .set_pose(body, position, 0.0, true);
+    state
+        .world
+        .physics
+        .world
+        .set_velocity(body, Vec2::Y * 50.0, 0.0, true);
+    idle_pair(&mut state, 240);
+    assert_eq!(state.outposts[0].owner, Some(PlayerId::PLAYER_1));
+    assert!(state.world.ships[0].life > health[0]);
+    assert_eq!(state.world.ships[1].life, health[1]);
+    assert_eq!(
+        state.observation(1).outpost.as_ref().unwrap().repair_status,
+        RepairStatus::NotFriendly
+    );
+    assert!(
+        state
+            .world
+            .planets
+            .iter()
+            .all(|planet| planet.owner_id.is_none())
+    );
+}
+
+#[test]
+fn a_pilot_cannot_board_another_players_hatch_or_control_their_ship() {
+    let mut state = two_on_planet(SurfaceMotionPreset::Stationary, std::f32::consts::PI);
+    step_pair(&mut state, [INTERACT; 2]);
+    let position =
+        state.access_position(1) + state.access_up(1) * SurfaceSortieState::spec().half_height();
+    let body = state.pilots[0].body.as_ref().unwrap().body();
+    state.world.physics.world.set_pose(
+        body,
+        position,
+        rotation_for_direction(state.access_up(1)),
+        true,
+    );
+    assert_eq!(state.try_transfer(0), TransferResult::TooFar);
+    assert_eq!(state.location(0), PilotLocation::OnFoot);
+    assert_eq!(state.location(1), PilotLocation::OnFoot);
+    assert_eq!(state.pilots[0].vehicle, VehicleId(0));
+}
+
+#[test]
+fn generated_two_player_sessions_replay_and_inactive_or_invalid_seats_are_ignored() {
+    let mut a = SurfaceSortieScenario::init_expedition(0, 2);
+    let mut b = SurfaceSortieScenario::init_expedition(0, 2);
+    let solo = SurfaceSortieScenario::init_expedition(0, 1);
+    assert_eq!(
+        a.world.physics.world.body_count(),
+        solo.world.physics.world.body_count() + 1
+    );
+    assert_eq!(a.outposts.len(), solo.outposts.len());
+    assert!(a.outposts.is_empty());
+    assert_eq!(a.claims.len(), solo.claims.len());
+    let initial = SurfaceSortieScenario::observe(&a).payload;
+    for tick in 0..360 {
+        let inputs = [
+            SurfaceSortieAction {
+                interact_held: tick == 90,
+                ..NEUTRAL
+            },
+            SurfaceSortieAction {
+                primary_held: (120..150).contains(&tick),
+                ..NEUTRAL
+            },
+        ];
+        step_pair(&mut a, inputs);
+        // Different seats commute even when their packets arrive in reversed order.
+        SurfaceSortieScenario::step(
+            &mut b,
+            &[
+                inputs[1].encode(PlayerId::PLAYER_2),
+                inputs[0].encode(PlayerId::PLAYER_1),
+            ],
+            Duration::from_secs_f64(1.0 / 60.0),
+        );
+        assert_eq!(
+            SurfaceSortieScenario::observe(&a).payload,
+            SurfaceSortieScenario::observe(&b).payload
+        );
+    }
+    assert_eq!(
+        initial,
+        SurfaceSortieScenario::observe(&SurfaceSortieScenario::init_expedition(0, 2)).payload
+    );
+    let observation: serde_json::Value = serde_json::from_slice(&initial).unwrap();
+    assert_eq!(observation["version"], 9);
+    assert_eq!(observation["players"].as_array().unwrap().len(), 2);
+    let mut solo = solo;
+    step_pair(
+        &mut solo,
+        [
+            NEUTRAL,
+            SurfaceSortieAction {
+                primary_held: true,
+                ..NEUTRAL
+            },
+        ],
+    );
+    assert_eq!(solo.world.ships[0].thrust, 0.0);
+    assert_eq!(solo.player_count(), 1);
+    for player in [2, 255] {
+        let payload = vec![0, 0, 0, 0, 1, 0, 0, player];
+        assert!(SurfaceSortieAction::decode(&Action::scenario(CONTROL_V2, payload)).is_none());
+    }
+    for player in [PlayerId::PLAYER_1, PlayerId::PLAYER_2] {
+        assert_eq!(
+            SurfaceSortieAction::decode(&INTERACT.encode(player)),
+            Some((player, INTERACT))
+        );
+    }
+}
+
+#[test]
+fn another_spaceling_blocks_an_occupied_exit_without_duplicate_bodies() {
+    let mut state = two_on_planet(SurfaceMotionPreset::Stationary, std::f32::consts::PI);
+    step_pair(&mut state, [INTERACT, NEUTRAL]);
+    let up = state.access_up(1);
+    let position =
+        state.access_position(1) + up * (SurfaceSortieState::spec().half_height() + 0.12);
+    let body = state.pilots[0].body.as_ref().unwrap().body();
+    state
+        .world
+        .physics
+        .world
+        .set_pose(body, position, rotation_for_direction(up), true);
+    let count = state.world.physics.world.body_count();
+    assert_eq!(state.try_transfer(1), TransferResult::ExitBlocked);
+    assert_eq!(state.world.physics.world.body_count(), count);
+    assert_eq!(state.location(1), PilotLocation::Aboard(VehicleId(1)));
+}

--- a/scenarios/spacewars/src/surface_sortie/tests/outpost_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/outpost_tests.rs
@@ -5,13 +5,13 @@ pub(super) fn walk_to(
     target: impl Fn(&SurfaceSortieState) -> Vec2,
 ) {
     for _ in 0..600 {
-        let snapshot = state.spaceling_snapshot().unwrap();
+        let snapshot = state.spaceling_snapshot(0).unwrap();
         let delta = target(state) - snapshot.motion.position;
         if delta.length() < 0.3 {
             idle(state, 12);
             return;
         }
-        let up = (snapshot.motion.position - state.world.planets[state.pilot.planet].position)
+        let up = (snapshot.motion.position - state.world.planets[state.pilots[0].planet].position)
             .normalized();
         tick(
             state,
@@ -21,7 +21,7 @@ pub(super) fn walk_to(
             },
         );
     }
-    panic!("could not walk to target: {:?}", state.observation());
+    panic!("could not walk to target: {:?}", state.observation(0));
 }
 
 pub(super) fn terminal_approach(state: &SurfaceSortieState) -> Vec2 {
@@ -38,10 +38,15 @@ fn at_terminal() -> SurfaceSortieState {
     disembark(&mut state);
     walk_to(&mut state, terminal_approach);
     assert_eq!(
-        state.observation().outpost.capture_status,
+        state
+            .observation(0)
+            .outpost
+            .as_ref()
+            .unwrap()
+            .capture_status,
         CaptureStatus::Capturing,
         "{:?}",
-        state.observation()
+        state.observation(0)
     );
     state
 }
@@ -49,11 +54,11 @@ fn at_terminal() -> SurfaceSortieState {
 fn capture(state: &mut SurfaceSortieState) {
     for _ in 0..200 {
         idle(state, 1);
-        if state.outposts[0].owner == Some(state.pilot.owner) {
+        if state.outposts[0].owner == Some(state.pilots[0].owner) {
             return;
         }
     }
-    panic!("capture did not complete: {:?}", state.observation());
+    panic!("capture did not complete: {:?}", state.observation(0));
 }
 
 #[test]
@@ -61,13 +66,13 @@ fn outpost_capture_and_repair_replay_identically_and_do_not_advance_without_step
     let mut a = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7);
     let mut b = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7);
     for frame in 0..650 {
-        let observation = a.observation();
+        let observation = a.observation(0);
         let input = SurfaceSortieAction {
             interact_held: frame == 60,
             horizontal: if frame > 120
                 && observation
                     .position
-                    .distance_to(observation.outpost.position)
+                    .distance_to(observation.outpost.as_ref().unwrap().position)
                     > 2.35
             {
                 1.0
@@ -78,22 +83,22 @@ fn outpost_capture_and_repair_replay_identically_and_do_not_advance_without_step
         };
         tick(&mut a, input);
         tick(&mut b, input);
-        assert_eq!(a.observation(), b.observation(), "tick {frame}");
+        assert_eq!(a.observation(0), b.observation(0), "tick {frame}");
     }
-    assert_eq!(a.outposts[0].owner, Some(a.pilot.owner));
-    assert!(a.observation().outpost.repaired_health > 0.0);
-    let before = a.observation();
+    assert_eq!(a.outposts[0].owner, Some(a.pilots[0].owner));
+    assert!(a.observation(0).outpost.as_ref().unwrap().repaired_health > 0.0);
+    let before = a.observation(0);
     for _ in 0..10 {
         let _ = SurfaceSortieScenario::render_frame(&a);
-        let _ = SurfaceSortieScenario::minimap_frame(&a, 16.0 / 9.0);
+        let _ = SurfaceSortieScenario::minimap_frame(&a, 0, 16.0 / 9.0);
         let _ = SurfaceSortieScenario::observe(&a);
         SurfaceSortieScenario::step(&mut a, &[], Duration::ZERO);
     }
-    assert_eq!(a.observation(), before);
-    let fresh = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7).observation();
-    assert_eq!(fresh.outpost.owner, None);
-    assert_eq!(fresh.outpost.capture_progress, 0.0);
-    assert_eq!(fresh.outpost.repaired_health, 0.0);
+    assert_eq!(a.observation(0), before);
+    let fresh = SurfaceSortieScenario::init(SurfaceMotionPreset::default(), 7).observation(0);
+    assert_eq!(fresh.outpost.as_ref().unwrap().owner, None);
+    assert_eq!(fresh.outpost.as_ref().unwrap().capture_progress, 0.0);
+    assert_eq!(fresh.outpost.as_ref().unwrap().repaired_health, 0.0);
     assert_eq!(fresh.ship_health, 75.0);
 }
 
@@ -112,11 +117,11 @@ pub(super) fn round_trip_state(mut state: SurfaceSortieState) {
     let preset = state.motion_preset();
     idle(&mut state, 120);
     assert!(
-        state.vehicle_settled(),
+        state.vehicle_settled(0),
         "{preset:?}: {:?}",
-        state.observation()
+        state.observation(0)
     );
-    let initial = state.observation();
+    let initial = state.observation(0);
     assert_eq!(initial.ship_health, state.world.ships[0].life_max * 0.75);
     idle(&mut state, 360);
     assert_eq!(
@@ -131,20 +136,20 @@ pub(super) fn round_trip_state(mut state: SurfaceSortieState) {
     );
     walk_to(&mut state, terminal_approach);
     idle(&mut state, 60);
-    let partial = state.observation().outpost;
+    let partial = state.observation(0).outpost.unwrap();
     assert!(partial.capture_progress > 0.2 && partial.capture_progress < 1.0);
     assert_eq!(partial.owner, None);
     assert_eq!(partial.repair_status, RepairStatus::NeedsCapture);
     capture(&mut state);
-    assert!(state.vehicle_settled());
-    assert_eq!(state.observation().outpost.captures, 1);
+    assert!(state.vehicle_settled(0));
+    assert_eq!(state.observation(0).outpost.as_ref().unwrap().captures, 1);
     assert_eq!(
-        state.world.planets[state.pilot.planet].owner_id, None,
+        state.world.planets[state.pilots[0].planet].owner_id, None,
         "outpost ownership is not planet ownership"
     );
     assert!(state.world.spaceport_contacts.is_empty());
     assert_eq!(
-        state.observation().physical_bodies,
+        state.observation(0).physical_bodies,
         initial.physical_bodies + 1
     );
     for _ in 0..360 {
@@ -157,24 +162,37 @@ pub(super) fn round_trip_state(mut state: SurfaceSortieState) {
     }
     assert_eq!(state.world.ships[0].life, state.world.ships[0].life_max);
     let initial_damage = state.world.ships[0].life_max - initial.ship_health;
-    assert!((state.observation().outpost.repaired_health - initial_damage).abs() < 1e-3);
+    assert!(
+        (state
+            .observation(0)
+            .outpost
+            .as_ref()
+            .unwrap()
+            .repaired_health
+            - initial_damage)
+            .abs()
+            < 1e-3
+    );
     assert_eq!(
-        state.observation().outpost.repair_status,
+        state.observation(0).outpost.as_ref().unwrap().repair_status,
         RepairStatus::Ready
     );
     walk_to(&mut state, |s| {
-        s.access_position() + s.access_up() * SurfaceSortieState::spec().half_height()
+        s.access_position(0) + s.access_up(0) * SurfaceSortieState::spec().half_height()
     });
     interact(&mut state);
     assert_eq!(
-        state.last_transfer,
+        state.pilots[0].last_transfer,
         TransferResult::Boarded,
         "{:?}",
-        state.observation()
+        state.observation(0)
     );
-    assert_eq!(state.observation().physical_bodies, initial.physical_bodies);
-    assert_eq!(state.observation().spaceling, initial.spaceling);
-    assert_eq!(state.observation().vehicle, initial.vehicle);
+    assert_eq!(
+        state.observation(0).physical_bodies,
+        initial.physical_bodies
+    );
+    assert_eq!(state.observation(0).spaceling, initial.spaceling);
+    assert_eq!(state.observation(0).vehicle, initial.vehicle);
     idle(&mut state, 1); // Neutral transfer handoff.
     state.world.ships[0].life = 60.0;
     for _ in 0..30 {
@@ -187,12 +205,15 @@ pub(super) fn round_trip_state(mut state: SurfaceSortieState) {
         );
         assert_eq!(state.world.ships[0].life, 60.0, "no repair once taking off");
         assert_eq!(
-            state.observation().outpost.repair_status,
+            state.observation(0).outpost.as_ref().unwrap().repair_status,
             RepairStatus::NeedLanding
         );
     }
-    assert!(state.landing.altitude > 1.0);
-    assert_eq!(state.observation().outpost.owner, Some(initial.owner));
+    assert!(state.pilots[0].landing.altitude > 1.0);
+    assert_eq!(
+        state.observation(0).outpost.as_ref().unwrap().owner,
+        Some(initial.owner)
+    );
 }
 
 #[test]
@@ -200,7 +221,15 @@ fn interrupted_outpost_capture_resets_when_walking_away_jumping_or_knocked_down(
     for interruption in 0..3 {
         let mut state = at_terminal();
         idle(&mut state, 60);
-        assert!(state.observation().outpost.capture_progress > 0.2);
+        assert!(
+            state
+                .observation(0)
+                .outpost
+                .as_ref()
+                .unwrap()
+                .capture_progress
+                > 0.2
+        );
         match interruption {
             0 => {
                 for _ in 0..40 {
@@ -213,7 +242,12 @@ fn interrupted_outpost_capture_resets_when_walking_away_jumping_or_knocked_down(
                     );
                 }
                 assert_eq!(
-                    state.observation().outpost.capture_status,
+                    state
+                        .observation(0)
+                        .outpost
+                        .as_ref()
+                        .unwrap()
+                        .capture_status,
                     CaptureStatus::TooFar
                 );
             }
@@ -225,11 +259,11 @@ fn interrupted_outpost_capture_resets_when_walking_away_jumping_or_knocked_down(
                         ..SurfaceSortieAction::default()
                     },
                 );
-                assert!(!state.spaceling_snapshot().unwrap().grounded());
+                assert!(!state.spaceling_snapshot(0).unwrap().grounded());
             }
             _ => {
-                let snapshot = state.spaceling_snapshot().unwrap();
-                let body = state.pilot.body.as_ref().unwrap().body();
+                let snapshot = state.spaceling_snapshot(0).unwrap();
+                let body = state.pilots[0].body.as_ref().unwrap().body();
                 state.world.physics.world.set_velocity(
                     body,
                     snapshot.motion.linear_velocity,
@@ -238,12 +272,12 @@ fn interrupted_outpost_capture_resets_when_walking_away_jumping_or_knocked_down(
                 );
                 idle(&mut state, 1);
                 assert_eq!(
-                    state.spaceling_snapshot().unwrap().balance,
+                    state.spaceling_snapshot(0).unwrap().balance,
                     SpacelingBalance::KnockedDown
                 );
             }
         }
-        let outpost = state.observation().outpost;
+        let outpost = state.observation(0).outpost.unwrap();
         assert_eq!(outpost.capture_progress, 0.0);
         assert_eq!(outpost.capturing_player, None);
         assert_eq!(outpost.owner, None);
@@ -278,28 +312,33 @@ fn unrelated_physical_support_near_the_terminal_does_not_capture() {
     // Construct a supported actor on an unrelated platform inside the capture
     // radius. This isolates the surface-identity gate from the walk-up test.
     let spec = SurfaceSortieState::spec();
-    state.pilot.body = SpacelingAssembly::insert(
+    state.pilots[0].body = SpacelingAssembly::insert(
         &mut state.world.physics.world,
-        PILOT_PHYSICS_ID,
+        pilot_physics_id(PlayerId::PLAYER_1),
         position + up * 0.75,
         rotation_for_direction(up),
         spec,
     );
-    assert!(state.pilot.body.is_some());
+    assert!(state.pilots[0].body.is_some());
     idle(&mut state, 240);
-    assert!(state.spaceling_snapshot().unwrap().grounded());
+    assert!(state.spaceling_snapshot(0).unwrap().grounded());
     assert_eq!(
-        state.observation().outpost.capture_status,
+        state
+            .observation(0)
+            .outpost
+            .as_ref()
+            .unwrap()
+            .capture_status,
         CaptureStatus::NeedSupport,
         "{:?}",
-        state.observation()
+        state.observation(0)
     );
     assert_eq!(state.outposts[0].owner, None);
     state.world.physics.world.remove_entity(platform);
     idle(&mut state, 300);
     assert_eq!(
         state.outposts[0].owner,
-        Some(state.pilot.owner),
+        Some(state.pilots[0].owner),
         "actual planet support permits capture"
     );
 }
@@ -351,14 +390,14 @@ fn outpost_repair_policy_requires_friendly_landed_in_range_and_live_ship() {
     let mut ship = initial.clone();
     post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
     assert_eq!(
-        post.observation(&state.world.planets[0]).repair_status,
+        post.observation(&state.world.planets[0], 0).repair_status,
         RepairStatus::NeedsCapture
     );
     assert_eq!(ship.life, initial.life);
     post.owner = Some(PlayerId::PLAYER_2);
     post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
     assert_eq!(
-        post.observation(&state.world.planets[0]).repair_status,
+        post.observation(&state.world.planets[0], 0).repair_status,
         RepairStatus::NotFriendly
     );
     post.owner = Some(PlayerId::PLAYER_1);
@@ -368,7 +407,7 @@ fn outpost_repair_policy_requires_friendly_landed_in_range_and_live_ship() {
     ] {
         post.repair_ship(&mut ship, landed, distance, Duration::from_secs(1));
         assert_eq!(
-            post.observation(&state.world.planets[0]).repair_status,
+            post.observation(&state.world.planets[0], 0).repair_status,
             expected
         );
         assert_eq!(ship.life, initial.life);
@@ -383,7 +422,7 @@ fn outpost_repair_policy_requires_friendly_landed_in_range_and_live_ship() {
         let before = ship.life;
         post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
         assert_eq!(
-            post.observation(&state.world.planets[0]).repair_status,
+            post.observation(&state.world.planets[0], 0).repair_status,
             RepairStatus::VehicleUnavailable
         );
         assert_eq!(ship.life, before);
@@ -393,14 +432,14 @@ fn outpost_repair_policy_requires_friendly_landed_in_range_and_live_ship() {
     ship.life = ship.life_max - 0.02;
     post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(1));
     assert_eq!(ship.life, ship.life_max);
-    let repaired = post.observation(&state.world.planets[0]).repaired_health;
+    let repaired = post.observation(&state.world.planets[0], 0).repaired_health;
     post.repair_ship(&mut ship, true, 0.0, Duration::from_secs(10));
     assert_eq!(
-        post.observation(&state.world.planets[0]).repaired_health,
+        post.observation(&state.world.planets[0], 0).repaired_health,
         repaired
     );
     assert_eq!(
-        post.observation(&state.world.planets[0]).repair_status,
+        post.observation(&state.world.planets[0], 0).repair_status,
         RepairStatus::Ready
     );
 }
@@ -410,34 +449,29 @@ fn outpost_capture_uses_elapsed_time_and_never_shares_partial_progress_between_p
     let mut state = parked();
     let post = &mut state.outposts[0];
     post.update_capture(
-        PlayerId::PLAYER_1,
-        CaptureStatus::Capturing,
+        &[(PlayerId::PLAYER_1, CaptureStatus::Capturing)],
         Duration::from_secs(2),
     );
     assert_eq!(post.owner, None);
     post.update_capture(
-        PlayerId::PLAYER_2,
-        CaptureStatus::Capturing,
+        &[(PlayerId::PLAYER_2, CaptureStatus::Capturing)],
         Duration::from_secs(2),
     );
     assert_eq!(post.owner, None);
     post.update_capture(
-        PlayerId::PLAYER_2,
-        CaptureStatus::Capturing,
+        &[(PlayerId::PLAYER_2, CaptureStatus::Capturing)],
         Duration::from_secs(1),
     );
     assert_eq!(post.owner, Some(PlayerId::PLAYER_2));
     post.update_capture(
-        PlayerId::PLAYER_2,
-        CaptureStatus::Capturing,
+        &[(PlayerId::PLAYER_2, CaptureStatus::Capturing)],
         Duration::from_secs(10),
     );
-    assert_eq!(post.observation(&state.world.planets[0]).captures, 1);
+    assert_eq!(post.observation(&state.world.planets[0], 0).captures, 1);
     post.update_capture(
-        PlayerId::PLAYER_1,
-        CaptureStatus::Capturing,
+        &[(PlayerId::PLAYER_1, CaptureStatus::Capturing)],
         Duration::from_secs(3),
     );
     assert_eq!(post.owner, Some(PlayerId::PLAYER_1));
-    assert_eq!(post.observation(&state.world.planets[0]).captures, 2);
+    assert_eq!(post.observation(&state.world.planets[0], 0).captures, 2);
 }

--- a/scenarios/spacewars/src/surface_sortie/tests/recovery_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/recovery_tests.rs
@@ -1,0 +1,701 @@
+use super::*;
+
+fn expedition() -> SurfaceSortieState {
+    let mut state = SurfaceSortieScenario::init_expedition(0, 1);
+    idle(&mut state, 120);
+    assert!(state.vehicle_settled(0));
+    state
+}
+
+#[test]
+fn parked_ship_loss_does_not_create_an_empty_pod() {
+    let mut state = expedition();
+    disembark(&mut state);
+    let identity = state.observation(0).spaceling;
+    state.world.ships[0].translate_life(-state.world.ships[0].life_max);
+    idle(&mut state, 2);
+    assert_eq!(state.location(0), PilotLocation::OnFoot);
+    assert_eq!(state.observation(0).spaceling, identity);
+    assert!(
+        state.world.ships[0].dead,
+        "an empty ship must not produce a live pod"
+    );
+    assert!(
+        state
+            .world
+            .physics
+            .world
+            .motion(state.world.physics.ship_body(0))
+            .is_none()
+    );
+}
+
+#[test]
+fn occupied_ship_loss_keeps_a_flyable_pod_without_an_owned_planet() {
+    let mut state = expedition();
+    for _ in 0..90 {
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                primary_held: true,
+                ..Default::default()
+            },
+        );
+    }
+    assert!(state.pilots[0].landing.altitude > 25.0);
+    state.world.ships[0].translate_life(-state.world.ships[0].life_max);
+    idle(&mut state, 2);
+    assert_eq!(state.world.ships[0].form, ShipForm::EscapePod);
+    assert!(
+        state
+            .world
+            .planets
+            .iter()
+            .all(|planet| planet.owner_id.is_none())
+    );
+    let before = state
+        .world
+        .physics
+        .world
+        .motion(state.world.physics.ship_body(0))
+        .unwrap();
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..Default::default()
+        },
+    );
+    let after = state
+        .world
+        .physics
+        .world
+        .motion(state.world.physics.ship_body(0))
+        .unwrap();
+    let control_delta =
+        after.linear_velocity - before.linear_velocity - state.pilots[0].ship_gravity_delta;
+    assert!(
+        control_delta.dot(Vec2::Y.rotate_radians(before.angle)) > 0.2,
+        "pod did not thrust: {control_delta:?}"
+    );
+}
+
+fn scuttle(state: &mut SurfaceSortieState) {
+    for _ in 0..181 {
+        tick(
+            state,
+            SurfaceSortieAction {
+                primary_held: true,
+                interact_held: true,
+                brake_held: true,
+                ..Default::default()
+            },
+        );
+    }
+    idle(state, 2);
+    assert_eq!(state.observation(0).recovery.unwrap().ships_lost, 1);
+}
+
+#[test]
+fn action_only_pod_landing_claim_rebuild_and_departure() {
+    let mut state = expedition();
+    let identity = state.observation(0).spaceling;
+    scuttle(&mut state);
+    assert_eq!(state.world.ships[0].form, ShipForm::EscapePod);
+    for _ in 0..900 {
+        if state.vehicle_settled(0) {
+            break;
+        }
+        let ship = &state.world.ships[0];
+        let up = (ship.position + physics::ship_pivot(ship.form) - state.planet_motion(0).position)
+            .normalized();
+        let angle = (rotation_for_direction(up) - ship.rotation_radians + std::f32::consts::PI)
+            .rem_euclid(std::f32::consts::TAU)
+            - std::f32::consts::PI;
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                horizontal: (-angle * 2.0).clamp(-1.0, 1.0),
+                ..Default::default()
+            },
+        );
+    }
+    assert!(
+        state.vehicle_settled(0),
+        "pod landing: {:?}",
+        state.observation(0)
+    );
+    disembark(&mut state);
+    for _ in 0..900 {
+        idle(&mut state, 1);
+        if state.vehicle_available(0) {
+            break;
+        }
+    }
+    assert!(
+        state.vehicle_available(0),
+        "rebuild: {:?}",
+        state.observation(0)
+    );
+    assert_eq!(state.observation(0).spaceling, identity);
+    assert_eq!(state.location(0), PilotLocation::OnFoot);
+    assert_eq!(state.observation(0).recovery.unwrap().rebuilds, 1);
+    for _ in 0..600 {
+        if state.vehicle_settled(0) {
+            break;
+        }
+        idle(&mut state, 1);
+    }
+    assert!(
+        state.vehicle_settled(0),
+        "new ship landing: {:?}",
+        state.observation(0)
+    );
+    // Walk to the real hatch; no pose writes after the initial fixture.
+    for _ in 0..600 {
+        let snapshot = state.spaceling_snapshot(0).unwrap();
+        let delta = state.access_position(0) - snapshot.motion.position;
+        let right = Vec2::new(snapshot.up.y, -snapshot.up.x);
+        let distance = delta.dot(right);
+        if distance.abs() < 0.8 {
+            break;
+        }
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                horizontal: distance.signum(),
+                ..Default::default()
+            },
+        );
+    }
+    idle(&mut state, 60);
+    interact(&mut state);
+    assert!(
+        matches!(state.location(0), PilotLocation::Aboard(_)),
+        "boarding: {:?}",
+        state.observation(0)
+    );
+    idle(&mut state, 2);
+    for _ in 0..90 {
+        tick(
+            &mut state,
+            SurfaceSortieAction {
+                primary_held: true,
+                ..Default::default()
+            },
+        );
+    }
+    assert!(
+        state.observation(0).landing.altitude > 25.0,
+        "departure: {:?}",
+        state.observation(0)
+    );
+}
+
+#[test]
+fn pod_loss_preserves_origin_velocity_and_physical_spin_once() {
+    let mut state = expedition();
+    let ship = &mut state.world.ships[0];
+    ship.velocity = Vec2::new(7.0, -3.0);
+    ship.omega = physics::control_angular_velocity(ship, 0.7);
+    let origin = ship.position + SHIP_PIVOT;
+    let angle = ship.rotation_radians;
+    let impulse = Vec2::new(2.0, 1.0);
+    ship.translate_life_with_impulse(-ship.life_max, impulse);
+    handle_ship_deaths_with_surface_pilots(&mut state.world, &mut state.pilots);
+    let ship = &state.world.ships[0];
+    assert!((ship.position + POD_PIVOT - origin).length() < 0.0002);
+    assert_eq!(ship.velocity, Vec2::new(9.0, -2.0));
+    assert_eq!(ship.rotation_radians, angle);
+    assert!((physics::physical_angular_velocity(ship) - 0.7).abs() < 1e-6);
+    assert_eq!(state.world.debris.len(), 5);
+    handle_ship_deaths_with_surface_pilots(&mut state.world, &mut state.pilots);
+    assert_eq!(state.world.debris.len(), 5);
+    assert_eq!(
+        state.pilots[0]
+            .recovery
+            .as_ref()
+            .unwrap()
+            .observation()
+            .ships_lost,
+        1
+    );
+    assert_eq!(state.world.ships[0].velocity, Vec2::new(9.0, -2.0));
+}
+
+#[test]
+fn pods_land_and_transfer_at_multiple_bearings_on_moving_terrain() {
+    for preset in [
+        SurfaceMotionPreset::Stationary,
+        SurfaceMotionPreset::Translating,
+        SurfaceMotionPreset::Orbit,
+    ] {
+        for bearing in 0..4 {
+            let mut state = approach_in(
+                preset,
+                bearing as f32 * std::f32::consts::FRAC_PI_2,
+                12.0,
+                0.0,
+                2.0,
+                0.0,
+            );
+            state.enable_recovery();
+            state.world.ships[0].translate_life(-state.world.ships[0].life_max);
+            idle(&mut state, 1);
+            assert_eq!(state.try_transfer(0), TransferResult::ShipNotSettled);
+            for _ in 0..900 {
+                idle(&mut state, 1);
+                if state.vehicle_settled(0) {
+                    break;
+                }
+            }
+            assert!(
+                state.vehicle_settled(0),
+                "{preset:?} bearing={bearing}: {:?}",
+                state.pilots[0].landing
+            );
+            assert_eq!(state.world.planets[0].owner_id, None);
+            assert_eq!(state.pilots[0].landing.supported_feet, 2);
+            assert!(!state.world.physics.ship_is_constrained(0));
+            disembark(&mut state);
+            interact(&mut state);
+            assert_eq!(
+                state.pilots[0].last_transfer,
+                TransferResult::Boarded,
+                "{preset:?} bearing={bearing}"
+            );
+            assert_eq!(state.world.ships[0].form, ShipForm::EscapePod);
+        }
+    }
+}
+
+fn stranded() -> SurfaceSortieState {
+    let mut state = expedition();
+    disembark(&mut state);
+    scuttle(&mut state);
+    assert!(state.world.ships[0].dead);
+    assert_eq!(state.world.planets[0].owner_id, Some(0));
+    assert_eq!(
+        state.observation(0).recovery.unwrap().status,
+        SurfaceRecoveryStatus::Rebuilding
+    );
+    state
+}
+
+#[test]
+fn parked_loss_and_rebuild_keep_the_external_pilot_and_match_surface_velocity() {
+    let mut state = stranded();
+    let identity = state.observation(0).spaceling;
+    let body = state.pilots[0].body.as_ref().unwrap().body();
+    let before = state.world.physics.world.motion(body).unwrap();
+    state.update_recovery(Duration::from_secs(8));
+    assert!(state.vehicle_available(0));
+    assert_eq!(state.location(0), PilotLocation::OnFoot);
+    assert_eq!(state.observation(0).spaceling, identity);
+    assert_eq!(state.world.physics.world.motion(body), Some(before));
+    assert_eq!(state.observation(0).recovery.unwrap().pod_ejections, 0);
+    assert_eq!(state.observation(0).recovery.unwrap().rebuilds, 1);
+    let ship = &state.world.ships[0];
+    assert_eq!(ship.life, ship.life_max);
+    let center = ship.position + SHIP_PIVOT;
+    let velocity = state
+        .world
+        .physics
+        .world
+        .velocity_at_point(state.world.physics.ship_body(0), center)
+        .unwrap();
+    let frame = state.planet_motion(0);
+    assert!((velocity - motion::point_velocity(frame, center)).length() < 1e-5);
+    assert!((physics::physical_angular_velocity(ship) - frame.angular_velocity).abs() < 1e-5);
+    assert!(
+        !state.vehicle_settled(0),
+        "replacement must land physically before boarding"
+    );
+    assert_eq!(state.try_transfer(0), TransferResult::ShipNotSettled);
+}
+
+#[test]
+fn lost_ownership_and_lost_support_reset_rebuild_without_borrowing_time() {
+    let mut state = stranded();
+    state.update_recovery(Duration::from_secs(4));
+    assert!(state.observation(0).recovery.unwrap().rebuild_progress > 0.49);
+    state.world.planets[0].owner_id = Some(1);
+    state.update_recovery(Duration::from_secs(30));
+    let recovery = state.observation(0).recovery.unwrap();
+    assert_eq!(recovery.status, SurfaceRecoveryStatus::NeedOwnedPlanet);
+    assert_eq!(recovery.rebuild_progress, 0.0);
+    assert_eq!(recovery.rebuild_interruptions, 1);
+    assert!(!state.vehicle_available(0));
+    state.world.planets[0].owner_id = Some(0);
+    state.update_recovery(Duration::from_secs(30));
+    assert_eq!(state.observation(0).recovery.unwrap().rebuild_progress, 0.0);
+    state.update_recovery(Duration::from_secs(4));
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..Default::default()
+        },
+    );
+    assert!(!state.spaceling_snapshot(0).unwrap().grounded());
+    let recovery = state.observation(0).recovery.unwrap();
+    assert_eq!(recovery.status, SurfaceRecoveryStatus::NeedSupport);
+    assert_eq!(recovery.rebuild_progress, 0.0);
+    assert_eq!(recovery.rebuild_interruptions, 2);
+}
+
+#[test]
+fn blocked_build_sites_retry_without_spawning_inside_an_obstacle() {
+    let mut state = stranded();
+    let support = state.spaceling_snapshot(0).unwrap().support.unwrap();
+    let right = Vec2::new(support.normal.y, -support.normal.x);
+    let obstacles: Vec<_> = [-8.0, -14.0, 8.0, 14.0]
+        .into_iter()
+        .enumerate()
+        .map(|(index, offset)| {
+            let id = PhysicsId::new(45_100 + index as u64);
+            assert!(state.world.physics.world.insert_body(
+                PhysicsBodyId::new(id, BodyRole::PRIMARY),
+                BodySpec {
+                    kind: engine_rapier::world::BodyKind::Fixed,
+                    position: support.position + right * offset + support.normal * 8.0,
+                    ..BodySpec::default()
+                },
+                &[ColliderSpec::ball(
+                    ColliderId::new(id, ColliderRole::PRIMARY, 0),
+                    3.0
+                )]
+            ));
+            id
+        })
+        .collect();
+    idle(&mut state, 1);
+    state.update_recovery(Duration::from_secs(8));
+    let recovery = state.observation(0).recovery.unwrap();
+    assert_eq!(recovery.status, SurfaceRecoveryStatus::ClearanceBlocked);
+    assert_eq!(recovery.rebuild_progress, 1.0);
+    assert_eq!(recovery.blocked_attempts, 1);
+    assert!(!state.vehicle_available(0));
+    for _ in 0..20 {
+        state.update_recovery(Duration::from_millis(10));
+    }
+    assert_eq!(state.observation(0).recovery.unwrap().blocked_attempts, 1);
+    state.update_recovery(Duration::from_millis(300));
+    assert_eq!(state.observation(0).recovery.unwrap().blocked_attempts, 2);
+    for id in obstacles {
+        assert!(state.world.physics.world.remove_entity(id));
+    }
+    idle(&mut state, 31);
+    assert!(state.vehicle_available(0));
+    assert_eq!(state.observation(0).recovery.unwrap().rebuilds, 1);
+}
+
+#[test]
+fn loss_drill_cancels_on_release_and_requires_neutral_after_loss() {
+    let mut state = expedition();
+    let held = SurfaceSortieAction {
+        primary_held: true,
+        interact_held: true,
+        brake_held: true,
+        ..Default::default()
+    };
+    for _ in 0..90 {
+        tick(&mut state, held);
+    }
+    let observation = state.observation(0);
+    assert_eq!(observation.transfers, 0);
+    assert_eq!(
+        observation.recovery.unwrap().status,
+        SurfaceRecoveryStatus::Scuttling
+    );
+    assert_eq!(state.world.ships[0].thrust, 0.0);
+    idle(&mut state, 1);
+    assert_eq!(state.observation(0).recovery.unwrap().scuttle_progress, 0.0);
+    for _ in 0..150 {
+        tick(&mut state, held);
+    }
+    assert!(
+        state.vehicle_available(0),
+        "the partial drill cannot resume after release"
+    );
+    for _ in 0..450 {
+        tick(&mut state, held);
+    }
+    assert_eq!(state.world.ships[0].form, ShipForm::EscapePod);
+    assert_eq!(state.observation(0).transfers, 0);
+    assert_eq!(state.observation(0).recovery.unwrap().ships_lost, 1);
+    assert!(!state.observation(0).controls_armed);
+    assert_eq!(state.world.ships[0].thrust, 0.0);
+    idle(&mut state, 1);
+    tick(
+        &mut state,
+        SurfaceSortieAction {
+            primary_held: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(state.world.ships[0].thrust, 1.0);
+}
+
+#[test]
+fn observing_rendering_and_zero_ticks_do_not_advance_recovery() {
+    let mut state = stranded();
+    let before = SurfaceSortieScenario::observe(&state).payload;
+    for _ in 0..10 {
+        SurfaceSortieScenario::render_frame(&state);
+        SurfaceSortieScenario::minimap_frame(&state, 0, 16.0 / 9.0);
+        SurfaceSortieScenario::step(&mut state, &[], Duration::ZERO);
+        assert_eq!(SurfaceSortieScenario::observe(&state).payload, before);
+    }
+    assert!(
+        SurfaceSortieScenario::init(SurfaceMotionPreset::Stationary, 0)
+            .observation(0)
+            .recovery
+            .is_none()
+    );
+    assert!(
+        SurfaceSortieScenario::init(SurfaceMotionPreset::GeneratedSurfaceV1, 0)
+            .observation(0)
+            .recovery
+            .is_none()
+    );
+}
+
+#[test]
+fn two_seat_rebuilds_replay_independently_without_duplicate_actors() {
+    let mut a = SurfaceSortieScenario::init_expedition(0, 2);
+    let mut b = SurfaceSortieScenario::init_expedition(0, 2);
+    let step = |state: &mut SurfaceSortieState, input: SurfaceSortieAction, reverse: bool| {
+        let mut actions = [
+            input.encode(PlayerId::PLAYER_1),
+            input.encode(PlayerId::PLAYER_2),
+        ];
+        if reverse {
+            actions.reverse();
+        }
+        SurfaceSortieScenario::step(state, &actions, Duration::from_secs_f64(1.0 / 60.0));
+    };
+    for (state, reverse) in [(&mut a, false), (&mut b, true)] {
+        for _ in 0..120 {
+            step(state, SurfaceSortieAction::default(), reverse);
+        }
+        step(
+            state,
+            SurfaceSortieAction {
+                interact_held: true,
+                ..Default::default()
+            },
+            reverse,
+        );
+        for _ in 0..240 {
+            step(state, SurfaceSortieAction::default(), reverse);
+        }
+        for player in 0..2 {
+            assert_eq!(state.location(player), PilotLocation::OnFoot);
+            assert_eq!(state.world.planets[player].owner_id, Some(player));
+        }
+        for cycle in 0..3 {
+            for ship in &mut state.world.ships {
+                ship.translate_life(-ship.life_max);
+            }
+            step(state, SurfaceSortieAction::default(), reverse);
+            for player in 0..2 {
+                assert!(
+                    state
+                        .world
+                        .physics
+                        .world
+                        .motion(state.world.physics.ship_body(player))
+                        .is_none()
+                );
+                assert!(state.spaceling_snapshot(player).is_some());
+            }
+            for _ in 0..600 {
+                step(state, SurfaceSortieAction::default(), reverse);
+            }
+            for player in 0..2 {
+                assert!(
+                    state.vehicle_available(player),
+                    "cycle {cycle}: {:?}",
+                    state.observation(player).recovery
+                );
+                assert_eq!(
+                    state.observation(player).recovery.unwrap().rebuilds,
+                    cycle + 1
+                );
+                assert_eq!(state.observation(player).recovery.unwrap().pod_ejections, 0);
+                assert_eq!(state.pilots[player].id, SpacelingId(player as u64 + 1));
+                assert_eq!(state.world.ships[player].owner_id, player);
+            }
+        }
+    }
+    assert_eq!(
+        SurfaceSortieScenario::observe(&a).payload,
+        SurfaceSortieScenario::observe(&b).payload
+    );
+    assert_eq!(
+        a.world.physics.snapshot_bytes(),
+        b.world.physics.snapshot_bytes()
+    );
+}
+
+#[test]
+fn one_seats_loss_gate_does_not_stop_the_other_seats_flight() {
+    let mut state = SurfaceSortieScenario::init_expedition(0, 2);
+    idle(&mut state, 120);
+    state.world.ships[0].translate_life(-state.world.ships[0].life_max);
+    let p2 = SurfaceSortieAction {
+        primary_held: true,
+        ..Default::default()
+    };
+    for _ in 0..90 {
+        SurfaceSortieScenario::step(
+            &mut state,
+            &[
+                SurfaceSortieAction {
+                    primary_held: true,
+                    interact_held: true,
+                    ..Default::default()
+                }
+                .encode(PlayerId::PLAYER_1),
+                p2.encode(PlayerId::PLAYER_2),
+            ],
+            Duration::from_secs_f64(1.0 / 60.0),
+        );
+    }
+    assert!(!state.pilots[0].controls_armed);
+    assert_eq!(state.world.ships[0].thrust, 0.0);
+    assert!(state.pilots[1].controls_armed);
+    assert_eq!(state.world.ships[1].thrust, 1.0);
+    assert!(state.pilots[1].landing.altitude > 20.0);
+    assert_eq!(state.observation(1).recovery.unwrap().ships_lost, 0);
+}
+
+#[test]
+fn rebuilding_requires_balance_and_slow_surface_relative_motion() {
+    for knockdown in [false, true] {
+        let mut state = stranded();
+        state.update_recovery(Duration::from_secs(4));
+        let snapshot = state.spaceling_snapshot(0).unwrap();
+        let body = state.pilots[0].body.as_ref().unwrap().body();
+        let right = Vec2::new(snapshot.up.y, -snapshot.up.x);
+        let frame = state.planet_motion(0);
+        state.world.physics.world.set_velocity(
+            body,
+            snapshot.motion.linear_velocity + right * if knockdown { 20.0 } else { 5.0 },
+            frame.angular_velocity + if knockdown { 10.0 } else { 0.0 },
+            true,
+        );
+        idle(&mut state, 1);
+        let recovery = state.observation(0).recovery.unwrap();
+        assert_eq!(recovery.rebuild_progress, 0.0);
+        assert_eq!(recovery.rebuild_interruptions, 1);
+        assert!(!state.vehicle_available(0));
+        assert!(matches!(
+            recovery.status,
+            SurfaceRecoveryStatus::NeedBalance
+                | SurfaceRecoveryStatus::NeedSettle
+                | SurfaceRecoveryStatus::NeedSupport
+        ));
+    }
+}
+
+#[test]
+fn a_lethal_physics_impact_replaces_the_hull_in_the_same_completed_tick() {
+    let mut state = approach(std::f32::consts::FRAC_PI_2, 2.0, 0.5, 80.0, 0.0);
+    state.enable_recovery();
+    state.world.ships[0].life = 0.001;
+    let mut lost = false;
+    for _ in 0..60 {
+        idle(&mut state, 1);
+        if state.world.ships[0].form == ShipForm::EscapePod {
+            let ship = &state.world.ships[0];
+            let body = state
+                .world
+                .physics
+                .world
+                .motion(state.world.physics.ship_body(0))
+                .unwrap();
+            assert!((body.position - ship.position - POD_PIVOT).length() < 0.0002);
+            assert_eq!(body.linear_velocity, ship.velocity);
+            assert_eq!(
+                state.pilots[0].landing.supported_feet, 0,
+                "old hull contacts cannot land a fresh pod"
+            );
+            assert!(!state.vehicle_settled(0));
+            assert!(state.world.last_step_metrics.added >= 1);
+            assert!(state.world.last_step_metrics.removed >= 1);
+            lost = true;
+            break;
+        }
+    }
+    assert!(
+        lost,
+        "fixture must exercise actual lethal contact, not direct damage"
+    );
+    idle(&mut state, 120);
+    assert_eq!(state.observation(0).recovery.unwrap().ships_lost, 1);
+}
+
+#[test]
+fn unrelated_platform_support_does_not_allow_owned_planet_rebuilding() {
+    let mut state = stranded();
+    let snapshot = state.spaceling_snapshot(0).unwrap();
+    let up = snapshot.up;
+    let platform = PhysicsId::new(45_200);
+    let center = snapshot.motion.position + up * 12.0;
+    assert!(state.world.physics.world.insert_body(
+        PhysicsBodyId::new(platform, BodyRole::PRIMARY),
+        BodySpec {
+            kind: engine_rapier::world::BodyKind::Fixed,
+            position: center,
+            angle: rotation_for_direction(up),
+            ..BodySpec::default()
+        },
+        &[ColliderSpec::cuboid(
+            ColliderId::new(platform, ColliderRole::PRIMARY, 0),
+            8.0,
+            0.5
+        )]
+    ));
+    let body = state.pilots[0].body.as_ref().unwrap().body();
+    state.world.physics.world.set_pose(
+        body,
+        center + up * (0.5 + SurfaceSortieState::spec().half_height() + 0.04),
+        rotation_for_direction(up),
+        true,
+    );
+    state
+        .world
+        .physics
+        .world
+        .set_velocity(body, Vec2::ZERO, 0.0, true);
+    idle(&mut state, 120);
+    assert_eq!(
+        state
+            .spaceling_snapshot(0)
+            .unwrap()
+            .support
+            .unwrap()
+            .collider
+            .entity,
+        platform
+    );
+    state.update_recovery(Duration::from_secs(30));
+    let recovery = state.observation(0).recovery.unwrap();
+    assert_eq!(recovery.status, SurfaceRecoveryStatus::NeedSupport);
+    assert_eq!(recovery.rebuild_progress, 0.0);
+    assert!(!state.vehicle_available(0));
+}
+
+#[test]
+fn pod_access_still_checks_vehicle_ownership() {
+    let mut state = expedition();
+    scuttle(&mut state);
+    idle(&mut state, 300);
+    assert!(state.vehicle_settled(0));
+    state.world.ships[0].owner_id = 1;
+    assert_eq!(state.try_transfer(0), TransferResult::VehicleUnavailable);
+    state.world.ships[0].owner_id = 0;
+    assert_eq!(state.try_transfer(0), TransferResult::Exited);
+}

--- a/scenarios/spacewars/src/surface_sortie/tests/travel_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/travel_tests.rs
@@ -6,7 +6,7 @@ fn pair(preset: SurfaceMotionPreset) -> SurfaceSortieState {
     second.position += Vec2::Y * 300.0;
     world.planets.push(second);
     world.rover_builds.push(RoverBuildState::default());
-    let mut state = SurfaceSortieScenario::on_surface(world, preset, 0, Vec2::Y, -0.34);
+    let mut state = SurfaceSortieScenario::on_surface(world, preset, 0, Vec2::Y, Some(-0.34));
     // Controlled route: both terminals sit beside the respective departure/
     // arrival spots. Only fixture construction writes poses or geometry.
     // The destination spins during the flight; put its terminal on the hatch
@@ -28,7 +28,7 @@ fn pair(preset: SurfaceMotionPreset) -> SurfaceSortieState {
 fn local_service(state: &mut SurfaceSortieState) {
     disembark(state);
     outpost_tests::walk_to(state, |s| {
-        let post = s.focused_outpost();
+        let post = s.focused_outpost(0).unwrap();
         let planet = &s.world.planets[post.planet];
         let up = post
             .up(planet)
@@ -38,38 +38,79 @@ fn local_service(state: &mut SurfaceSortieState) {
                 + SurfaceSortieState::spec().half_height())
     });
     for _ in 0..240 {
-        if state.focused_outpost().owner == Some(state.pilot.owner) {
+        if state.focused_outpost(0).unwrap().owner == Some(state.pilots[0].owner) {
             break;
         }
         idle(state, 1);
     }
-    assert_eq!(state.focused_outpost().owner, Some(state.pilot.owner));
-    assert!(state.observation().outpost.repaired_health > 0.0);
+    assert_eq!(
+        state.focused_outpost(0).unwrap().owner,
+        Some(state.pilots[0].owner)
+    );
+    assert!(
+        state
+            .observation(0)
+            .outpost
+            .as_ref()
+            .unwrap()
+            .repaired_health
+            > 0.0
+    );
     outpost_tests::walk_to(state, |s| {
-        s.access_position() + s.access_up() * SurfaceSortieState::spec().half_height()
+        s.access_position(0) + s.access_up(0) * SurfaceSortieState::spec().half_height()
     });
     interact(state);
     assert_eq!(
-        state.last_transfer,
+        state.pilots[0].last_transfer,
         TransferResult::Boarded,
         "{:?}",
-        state.observation()
+        state.observation(0)
     );
     idle(state, 1);
 }
 
 #[test]
 fn journey_between_two_planets_uses_only_actions_after_setup() {
+    journey(false);
+}
+
+#[test]
+fn claiming_two_planets_and_departing_preserves_both_flags_using_only_actions() {
+    journey(true);
+}
+
+fn local_claim(state: &mut SurfaceSortieState) {
+    disembark(state);
+    idle(state, 240);
+    assert_eq!(
+        state.world.planets[state.motion_observation(0).planet].owner_id,
+        Some(0)
+    );
+    interact(state);
+    assert_eq!(state.pilots[0].last_transfer, TransferResult::Boarded);
+    idle(state, 1);
+}
+
+fn journey(planet_claims: bool) {
     for preset in [
         SurfaceMotionPreset::Stationary,
         SurfaceMotionPreset::Translating,
     ] {
         let mut state = pair(preset);
-        let identity = state.observation();
+        if planet_claims {
+            state = SurfaceSortieScenario::on_surface(state.world, preset, 0, Vec2::Y, None);
+            state.enable_planet_claims();
+        }
+        let capture = if planet_claims {
+            local_claim
+        } else {
+            local_service
+        };
+        let identity = state.observation(0);
         idle(&mut state, 120);
-        assert_eq!(state.ship_support_planet(), Some(0));
-        assert!(state.vehicle_settled());
-        local_service(&mut state);
+        assert_eq!(state.ship_support_planet(0), Some(0));
+        assert!(state.vehicle_settled(0));
+        capture(&mut state);
         for _ in 0..180 {
             tick(
                 &mut state,
@@ -78,11 +119,11 @@ fn journey_between_two_planets_uses_only_actions_after_setup() {
                     ..SurfaceSortieAction::default()
                 },
             );
-            if state.landing.altitude > 32.0 {
+            if state.pilots[0].landing.altitude > 32.0 {
                 break;
             }
         }
-        assert!(state.landing.altitude > 32.0);
+        assert!(state.pilots[0].landing.altitude > 32.0);
         for _ in 0..600 {
             let ship = state.world.ships[0].position + SHIP_PIVOT;
             let midpoint =
@@ -94,12 +135,15 @@ fn journey_between_two_planets_uses_only_actions_after_setup() {
         }
         eprintln!(
             "coast {preset:?}: landing={:?} ship={:?} velocity={:?}",
-            state.landing, state.world.ships[0].position, state.world.ships[0].velocity
+            state.pilots[0].landing, state.world.ships[0].position, state.world.ships[0].velocity
         );
-        assert_eq!(state.landing.planet, Some(1));
-        assert_eq!(state.ship_support_planet(), None);
+        assert_eq!(state.pilots[0].landing.planet, Some(1));
+        assert_eq!(state.ship_support_planet(0), None);
         interact(&mut state);
-        assert_eq!(state.last_transfer, TransferResult::ShipNotSettled);
+        assert_eq!(
+            state.pilots[0].last_transfer,
+            TransferResult::ShipNotSettled
+        );
         // Brake while turning rear-first toward B. This is a bounded scripted
         // input pilot, not a pose/velocity correction or a gameplay autopilot.
         for _ in 0..300 {
@@ -122,39 +166,62 @@ fn journey_between_two_planets_uses_only_actions_after_setup() {
             );
         }
         for _ in 0..900 {
-            if state.vehicle_settled() {
+            if state.vehicle_settled(0) {
                 break;
             }
             idle(&mut state, 1);
         }
-        assert!(state.vehicle_settled());
-        assert_eq!(state.ship_support_planet(), Some(1));
-        assert_eq!(state.outposts[0].owner, Some(state.pilot.owner));
-        assert_eq!(state.outposts[1].owner, None);
+        assert!(state.vehicle_settled(0));
+        assert_eq!(state.ship_support_planet(0), Some(1));
+        if planet_claims {
+            assert_eq!(state.world.planets[0].owner_id, Some(0));
+            assert_eq!(state.world.planets[1].owner_id, None);
+            assert!(state.outposts.is_empty());
+        } else {
+            assert_eq!(state.outposts[0].owner, Some(state.pilots[0].owner));
+            assert_eq!(state.outposts[1].owner, None);
+            assert_eq!(
+                state.observation(0).outposts[0].repair_status,
+                RepairStatus::NeedLanding
+            );
+        }
+        capture(&mut state);
+        if planet_claims {
+            assert!(
+                state
+                    .world
+                    .planets
+                    .iter()
+                    .all(|planet| planet.owner_id == Some(0))
+            );
+            assert!(
+                state
+                    .observation(0)
+                    .planet_claims
+                    .iter()
+                    .all(|claim| claim.captures == 1 && claim.flag.unwrap().raised_fraction == 1.0)
+            );
+        } else {
+            assert!(
+                state
+                    .outposts
+                    .iter()
+                    .all(|post| post.owner == Some(state.pilots[0].owner))
+            );
+            assert!(
+                state
+                    .world
+                    .planets
+                    .iter()
+                    .all(|planet| planet.owner_id.is_none())
+            );
+        }
         assert_eq!(
-            state.observation().outposts[0].repair_status,
-            RepairStatus::NeedLanding
-        );
-        local_service(&mut state);
-        assert!(
-            state
-                .outposts
-                .iter()
-                .all(|post| post.owner == Some(state.pilot.owner))
-        );
-        assert!(
-            state
-                .world
-                .planets
-                .iter()
-                .all(|planet| planet.owner_id.is_none())
-        );
-        assert_eq!(
-            state.observation().physical_bodies,
+            state.observation(0).physical_bodies,
             identity.physical_bodies
         );
-        assert_eq!(state.observation().spaceling, identity.spaceling);
-        assert_eq!(state.observation().vehicle, identity.vehicle);
+        assert_eq!(state.observation(0).spaceling, identity.spaceling);
+        assert_eq!(state.observation(0).vehicle, identity.vehicle);
         for _ in 0..60 {
             tick(
                 &mut state,
@@ -164,20 +231,29 @@ fn journey_between_two_planets_uses_only_actions_after_setup() {
                 },
             );
         }
-        assert!(!state.vehicle_settled());
-        assert!(state.landing.altitude > 10.0);
-        assert_eq!(state.motion_metrics.ship_damage, 0.0);
-        assert_eq!(state.transfers, 4);
+        assert!(!state.vehicle_settled(0));
+        assert!(state.pilots[0].landing.altitude > 10.0);
+        assert_eq!(state.pilots[0].motion_metrics.ship_damage, 0.0);
+        assert_eq!(state.pilots[0].transfers, 4);
         eprintln!(
-            "journey {preset:?}: ticks={} transfers={} captured={} damage={:.1}",
+            "journey {preset:?} claims={planet_claims}: ticks={} transfers={} captured={} damage={:.1}",
             state.world.tick,
-            state.transfers,
-            state
-                .outposts
-                .iter()
-                .filter(|post| post.owner.is_some())
-                .count(),
-            state.motion_metrics.ship_damage
+            state.pilots[0].transfers,
+            if planet_claims {
+                state
+                    .world
+                    .planets
+                    .iter()
+                    .filter(|p| p.owner_id.is_some())
+                    .count()
+            } else {
+                state
+                    .outposts
+                    .iter()
+                    .filter(|post| post.owner.is_some())
+                    .count()
+            },
+            state.pilots[0].motion_metrics.ship_damage
         );
     }
 }
@@ -192,12 +268,10 @@ fn approach_selection_uses_surface_distance_and_hysteresis_without_granting_supp
             .physics
             .world
             .set_pose(body, Vec2::new(500.0, y), 0.0, true);
-        state
-            .pilot
-            .select_approach_planet(&state.world.physics, &state.world.planets);
-        assert_eq!(state.pilot.planet, expected);
-        assert_eq!(state.ship_support_planet(), None);
-        assert_eq!(state.try_transfer(), TransferResult::ShipNotSettled);
+        state.pilots[0].select_approach_planet(&state.world.physics, &state.world.planets);
+        assert_eq!(state.pilots[0].planet, expected);
+        assert_eq!(state.ship_support_planet(0), None);
+        assert_eq!(state.try_transfer(0), TransferResult::ShipNotSettled);
     }
     // Closer center is not necessarily closer ground. Rebuild the fixture's
     // geometry before querying, rather than changing radii under live colliders.
@@ -209,7 +283,7 @@ fn approach_selection_uses_surface_distance_and_hysteresis_without_granting_supp
         SurfaceMotionPreset::Stationary,
         0,
         Vec2::Y,
-        -0.34,
+        Some(-0.34),
     );
     state.enable_travel();
     state
@@ -217,10 +291,8 @@ fn approach_selection_uses_surface_distance_and_hysteresis_without_granting_supp
         .physics
         .world
         .set_pose(body, Vec2::new(500.0, 620.0), 0.0, true);
-    state
-        .pilot
-        .select_approach_planet(&state.world.physics, &state.world.planets);
-    assert_eq!(state.pilot.planet, 1);
+    state.pilots[0].select_approach_planet(&state.world.physics, &state.world.planets);
+    assert_eq!(state.pilots[0].planet, 1);
 }
 
 #[test]
@@ -231,15 +303,15 @@ fn generated_arrivals_find_the_actual_planet_and_do_not_carry_over_settling_time
             .init()
             .unwrap();
         state.enable_travel();
-        state.pilot.planet = 0; // Stale departure frame, not the physical start.
+        state.pilots[0].planet = 0; // Stale departure frame, not the physical start.
         idle(&mut state, 120);
-        assert!(state.vehicle_settled(), "{:?}", state.observation());
-        assert_eq!(state.pilot.planet, planet);
-        assert_eq!(state.ship_support_planet(), Some(planet));
-        assert_eq!(state.focused_outpost().planet, planet);
-        let before = state.landing;
-        state.landing.planet = Some(0);
-        state.landing.update(
+        assert!(state.vehicle_settled(0), "{:?}", state.observation(0));
+        assert_eq!(state.pilots[0].planet, planet);
+        assert_eq!(state.ship_support_planet(0), Some(planet));
+        assert_eq!(state.focused_outpost(0).unwrap().planet, planet);
+        let before = state.pilots[0].landing;
+        state.pilots[0].landing.planet = Some(0);
+        state.pilots[0].landing.update(
             &state.world.physics,
             0,
             planet,
@@ -247,15 +319,15 @@ fn generated_arrivals_find_the_actual_planet_and_do_not_carry_over_settling_time
             &state.world.ships[0],
             1.0 / 60.0,
         );
-        assert_eq!(state.landing.supported_feet, 2);
-        assert_eq!(state.landing.settled_seconds, 1.0 / 60.0);
-        assert_ne!(state.landing.phase, LandingPhase::Landed);
-        state.landing = before;
+        assert_eq!(state.pilots[0].landing.supported_feet, 2);
+        assert_eq!(state.pilots[0].landing.settled_seconds, 1.0 / 60.0);
+        assert_ne!(state.pilots[0].landing.phase, LandingPhase::Landed);
+        state.pilots[0].landing = before;
         disembark(&mut state);
-        assert_eq!(state.pilot_support_planet(), Some(planet));
-        assert_eq!(state.motion_observation().planet, planet);
+        assert_eq!(state.pilot_support_planet(0), Some(planet));
+        assert_eq!(state.motion_observation(0).planet, planet);
         interact(&mut state);
-        assert_eq!(state.last_transfer, TransferResult::Boarded);
+        assert_eq!(state.pilots[0].last_transfer, TransferResult::Boarded);
     }
 }
 
@@ -263,8 +335,8 @@ fn generated_arrivals_find_the_actual_planet_and_do_not_carry_over_settling_time
 fn nearby_friendly_outpost_cannot_repair_a_ship_landed_on_a_different_planet() {
     let mut state = pair(SurfaceMotionPreset::Stationary);
     idle(&mut state, 120);
-    assert_eq!(state.ship_support_planet(), Some(0));
-    state.outposts[1].owner = Some(state.pilot.owner);
+    assert_eq!(state.ship_support_planet(0), Some(0));
+    state.outposts[1].owner = Some(state.pilots[0].owner);
     // Isolate the service policy with a foreign site at zero distance. There
     // is deliberately no physics step after this policy-only geometry setup.
     let ship = state.world.ships[0].position + SHIP_PIVOT;
@@ -275,10 +347,10 @@ fn nearby_friendly_outpost_cannot_repair_a_ship_landed_on_a_different_planet() {
     state.update_outpost(Duration::from_secs(1));
     assert_eq!(state.world.ships[0].life, health);
     assert_eq!(
-        state.observation().outposts[1].repair_status,
+        state.observation(0).outposts[1].repair_status,
         RepairStatus::NeedLanding
     );
-    assert_eq!(state.observation().outposts[1].repaired_health, 0.0);
+    assert_eq!(state.observation(0).outposts[1].repaired_health, 0.0);
 }
 
 #[test]
@@ -286,9 +358,9 @@ fn boarding_requires_support_from_the_landed_planet_not_a_nearby_platform() {
     let mut state = pair(SurfaceMotionPreset::Stationary);
     state.world.planets[0].wrapper_omega = 0.0;
     idle(&mut state, 120);
-    assert!(state.vehicle_settled());
-    let up = state.access_up();
-    let hatch = state.access_position();
+    assert!(state.vehicle_settled(0));
+    let up = state.access_up(0);
+    let hatch = state.access_position(0);
     let platform = PhysicsId::new(45_123);
     let body = PhysicsBodyId::new(platform, BodyRole::PRIMARY);
     assert!(state.world.physics.world.insert_body(
@@ -305,36 +377,36 @@ fn boarding_requires_support_from_the_landed_planet_not_a_nearby_platform() {
             0.2
         )]
     ));
-    state.pilot.body = SpacelingAssembly::insert(
+    state.pilots[0].body = SpacelingAssembly::insert(
         &mut state.world.physics.world,
-        PILOT_PHYSICS_ID,
+        pilot_physics_id(PlayerId::PLAYER_1),
         hatch + up * 1.65,
         rotation_for_direction(up),
         SurfaceSortieState::spec(),
     );
     idle(&mut state, 60);
-    let snapshot = state.spaceling_snapshot().unwrap();
+    let snapshot = state.spaceling_snapshot(0).unwrap();
     assert!(snapshot.grounded());
     assert_eq!(snapshot.balance, SpacelingBalance::Balanced);
     assert!(
         snapshot
             .motion
             .position
-            .distance_to(state.access_position())
+            .distance_to(state.access_position(0))
             < BOARDING_RANGE
     );
-    assert_eq!(state.pilot_support_planet(), None);
-    assert_eq!(state.try_transfer(), TransferResult::MustBeSupported);
+    assert_eq!(state.pilot_support_planet(0), None);
+    assert_eq!(state.try_transfer(0), TransferResult::MustBeSupported);
     state.world.physics.world.remove_entity(platform);
     idle(&mut state, 120);
-    assert_eq!(state.pilot_support_planet(), Some(0));
-    assert_eq!(state.try_transfer(), TransferResult::Boarded);
+    assert_eq!(state.pilot_support_planet(0), Some(0));
+    assert_eq!(state.try_transfer(0), TransferResult::Boarded);
 }
 
 #[test]
-fn expedition_replays_restarts_and_adds_only_one_site_collider_per_planet() {
-    let mut a = SurfaceSortieScenario::init_expedition(0);
-    let mut b = SurfaceSortieScenario::init_expedition(0);
+fn expedition_replays_restarts_and_claims_planets_without_site_colliders() {
+    let mut a = SurfaceSortieScenario::init_expedition(0, 1);
+    let mut b = SurfaceSortieScenario::init_expedition(0, 1);
     let baseline = SurfaceSortieScenario::init(SurfaceMotionPreset::GeneratedSurfaceV1, 0);
     assert!(!baseline.travel_enabled());
     assert!(a.travel_enabled());
@@ -345,26 +417,16 @@ fn expedition_replays_restarts_and_adds_only_one_site_collider_per_planet() {
     );
     assert_eq!(
         a.world.physics.world.collider_count(),
-        baseline.world.physics.world.collider_count() + a.world.planets.len() - 1
+        baseline.world.physics.world.collider_count() - 1
     );
-    assert_eq!(a.outposts.len(), a.world.planets.len());
-    for (index, post) in a.outposts.iter().enumerate() {
-        assert_eq!(post.planet, index);
-        assert_eq!(post.id, OutpostId(index as u64 + 1));
+    assert!(a.outposts.is_empty());
+    assert_eq!(a.claims.len(), a.world.planets.len());
+    for (index, claim) in a.claims.iter().enumerate() {
+        assert_eq!(claim.planet, index);
     }
     for frame in 0..650 {
         let input = SurfaceSortieAction {
             interact_held: frame == 60,
-            horizontal: if frame > 120
-                && a.observation()
-                    .position
-                    .distance_to(a.observation().outpost.position)
-                    > 2.35
-            {
-                1.0
-            } else {
-                0.0
-            },
             ..SurfaceSortieAction::default()
         };
         tick(&mut a, input);
@@ -374,32 +436,49 @@ fn expedition_replays_restarts_and_adds_only_one_site_collider_per_planet() {
             SurfaceSortieScenario::observe(&b).payload
         );
     }
-    assert_eq!(a.outposts[0].owner, Some(a.pilot.owner));
-    assert!(a.outposts[1..].iter().all(|post| post.owner.is_none()));
-    let fresh = SurfaceSortieScenario::init_expedition(0);
-    assert!(fresh.outposts.iter().all(|post| post.owner.is_none()));
-    assert_eq!(fresh.observation().transfers, 0);
-    assert_eq!(fresh.observation().ship_health, 75.0);
-    let before = a.observation();
+    assert_eq!(a.world.planets[0].owner_id, Some(0));
+    assert!(
+        a.world.planets[1..]
+            .iter()
+            .all(|planet| planet.owner_id.is_none())
+    );
+    let fresh = SurfaceSortieScenario::init_expedition(0, 1);
+    assert!(
+        fresh
+            .world
+            .planets
+            .iter()
+            .all(|planet| planet.owner_id.is_none())
+    );
+    assert!(
+        fresh
+            .observation(0)
+            .planet_claims
+            .iter()
+            .all(|claim| claim.flag.is_none())
+    );
+    assert_eq!(fresh.observation(0).transfers, 0);
+    assert_eq!(fresh.observation(0).ship_health, 100.0);
+    let before = a.observation(0);
     SurfaceSortieScenario::render_frame(&a);
-    SurfaceSortieScenario::minimap_frame(&a, 16.0 / 9.0);
+    SurfaceSortieScenario::minimap_frame(&a, 0, 16.0 / 9.0);
     SurfaceSortieScenario::step(&mut a, &[], Duration::ZERO);
-    assert_eq!(a.observation(), before);
+    assert_eq!(a.observation(0), before);
 }
 
 #[test]
 fn airborne_pilot_focus_does_not_follow_the_parked_ships_planet() {
     let mut state = pair(SurfaceMotionPreset::Stationary);
     let position = state.world.planets[1].position + Vec2::Y * 90.0;
-    state.pilot.body = SpacelingAssembly::insert(
+    state.pilots[0].body = SpacelingAssembly::insert(
         &mut state.world.physics.world,
-        PILOT_PHYSICS_ID,
+        pilot_physics_id(PlayerId::PLAYER_1),
         position,
         0.0,
         SurfaceSortieState::spec(),
     );
-    assert_eq!(state.pilot_support_planet(), None);
-    assert_eq!(state.pilot.planet, 0);
-    assert_eq!(state.motion_observation().planet, 1);
-    assert_eq!(state.focused_outpost().planet, 1);
+    assert_eq!(state.pilot_support_planet(0), None);
+    assert_eq!(state.pilots[0].planet, 0);
+    assert_eq!(state.motion_observation(0).planet, 1);
+    assert_eq!(state.focused_outpost(0).unwrap().planet, 1);
 }

--- a/scenarios/spacewars/src/surface_sortie/travel.rs
+++ b/scenarios/spacewars/src/surface_sortie/travel.rs
@@ -165,6 +165,7 @@ impl SurfaceSortieScenario {
                 .physics
                 .enable_surface_sortie(&[0, 1], &state.world.ships);
         }
+        state.enable_recovery();
         state
     }
 }

--- a/scenarios/spacewars/src/surface_sortie/travel.rs
+++ b/scenarios/spacewars/src/surface_sortie/travel.rs
@@ -1,4 +1,4 @@
-//! Single-pilot travel policy. Raw/profile probes remain pinned positive controls.
+//! Per-pilot travel policy. Raw/profile probes remain pinned positive controls.
 use super::*;
 
 // Avoid switching approach frames back and forth at a free-space bisector.
@@ -43,29 +43,29 @@ impl SurfacePilot {
 
 impl SurfaceSortieState {
     pub fn travel_enabled(&self) -> bool {
-        self.pilot.travel_enabled
+        self.pilots[0].travel_enabled
     }
 
-    pub(super) fn ship_support_planet(&self) -> Option<usize> {
-        (self.landing.supported_feet > 0)
-            .then_some(self.landing.planet)
+    pub(super) fn ship_support_planet(&self, player: usize) -> Option<usize> {
+        (self.pilots[player].landing.supported_feet > 0)
+            .then_some(self.pilots[player].landing.planet)
             .flatten()
     }
 
-    pub(super) fn pilot_support_planet(&self) -> Option<usize> {
-        let support = self.spaceling_snapshot()?.support?;
+    pub(super) fn pilot_support_planet(&self, player: usize) -> Option<usize> {
+        let support = self.spaceling_snapshot(player)?.support?;
         physics::planet_surface_support_index(support.collider)
             .filter(|&index| index < self.world.planets.len())
     }
 
-    pub(super) fn motion_planet_index(&self) -> usize {
+    pub(super) fn motion_planet_index(&self, player: usize) -> usize {
         if !self.travel_enabled() {
-            return self.pilot.planet;
+            return self.pilots[player].planet;
         }
-        if let Some(planet) = self.pilot_support_planet() {
+        if let Some(planet) = self.pilot_support_planet(player) {
             return planet;
         }
-        if let Some(snapshot) = self.spaceling_snapshot() {
+        if let Some(snapshot) = self.spaceling_snapshot(player) {
             // An airborne pilot's diagnostics/site focus must not follow the
             // unoccupied ship if it has independently reached another planet.
             return self
@@ -81,21 +81,22 @@ impl SurfaceSortieState {
                     };
                     distance(*a, pa.radius).total_cmp(&distance(*b, pb.radius))
                 })
-                .map_or(self.pilot.planet, |(index, _)| index);
+                .map_or(self.pilots[player].planet, |(index, _)| index);
         }
-        self.pilot.planet
+        self.pilots[player].planet
     }
 
-    pub(super) fn focused_outpost(&self) -> &outpost::SurfaceOutpost {
-        let planet = self.motion_planet_index();
+    pub(super) fn focused_outpost(&self, player: usize) -> Option<&outpost::SurfaceOutpost> {
+        let planet = self.motion_planet_index(player);
         self.outposts
             .iter()
             .find(|post| post.planet == planet)
-            .unwrap_or(&self.outposts[0])
+            .or_else(|| self.outposts.first())
     }
 
-    /// One intact site per generated body for this experiment, not a universal
-    /// planet-claim rule. Identity/ownership survive changes of the active frame.
+    /// Retain the earlier outpost-based travel journey as a regression fixture.
+    /// Playable Expedition now uses planet claims without site infrastructure.
+    #[cfg(test)]
     pub(super) fn enable_travel(&mut self) {
         for (index, planet) in self.world.planets.iter().enumerate() {
             if self.outposts.iter().any(|post| post.planet == index) {
@@ -118,16 +119,52 @@ impl SurfaceSortieState {
             ));
         }
         self.outposts.sort_by_key(|post| post.planet);
-        self.pilot.travel_enabled = true;
+        for pilot in &mut self.pilots {
+            pilot.travel_enabled = true;
+        }
     }
 }
 
 impl SurfaceSortieScenario {
     /// Opt-in travel on the named Surface V1 world. Compatibility cases still
     /// use their original single-site, pinned-planet setup for paired evidence.
-    pub fn init_expedition(seed: u64) -> SurfaceSortieState {
-        let mut state = Self::init(SurfaceMotionPreset::GeneratedSurfaceV1, seed);
-        state.enable_travel();
+    pub fn init_expedition(seed: u64, player_count: usize) -> SurfaceSortieState {
+        assert!((1..=SPACEWARS_PLAYER_COUNT).contains(&player_count));
+        let mut state = compatibility::GeneratedSurfaceCase::new(seed, 0, 0)
+            .with_profile(GeneratedSurfaceProfile::SurfaceV1)
+            .init_with_outpost(false)
+            .expect("default generated world has a planet");
+        state.enable_planet_claims();
+        state.world.ships[0].life = state.world.ships[0].life_max;
+        if player_count == 2 {
+            let index = (state.pilots[0].planet + 1) % state.world.planets.len();
+            let planet = state.world.planets[index];
+            let up = state
+                .world
+                .sun
+                .map_or(Vec2::Y, |sun| (planet.position - sun.position).normalized());
+            let up = if index == state.pilots[0].planet {
+                -up
+            } else {
+                up
+            };
+            let center = planet.position + up * (planet.radius * BODY_BOUNDS_RADIUS_SCALE + 5.5);
+            let ship = &mut state.world.ships[1];
+            ship.position = center - SHIP_PIVOT;
+            ship.rotation_radians = rotation_for_direction(up);
+            ship.direction = up;
+            ship.velocity = state.motion_preset.initial_velocity(&planet)
+                + Vec2::new(-(center - planet.position).y, (center - planet.position).x)
+                    * planet.wrapper_omega;
+            ship.life = ship.life_max;
+            state
+                .pilots
+                .push(SurfacePilot::new(PlayerId::PLAYER_2, index, true));
+            state
+                .world
+                .physics
+                .enable_surface_sortie(&[0, 1], &state.world.ships);
+        }
         state
     }
 }


### PR DESCRIPTION
## Summary

Extend the existing **Surface Expedition** scenario with two-player shared-world play, proximity-based planet flags, and a complete ship-loss/recovery loop. This evolves the existing launcher entry; it does not add another scenario.

## Gameplay

- Persisted one/two-player selection, independent keyboard/gamepad controls, split-screen cameras, HUDs and minimaps. Each pilot retains its own assigned vehicle and release-to-neutral input gates.
- Claim neutral planets by standing balanced and still on their actual terrain for **3 seconds**. Enemy flags must first be lowered **within 3 world units for 3 seconds**, then a replacement raised for another 3 seconds. Local contests pause progress; lost eligibility resets the unfinished stage. Expedition no longer requires an outpost or provides its repair service.
- Destroying an occupied ship preserves its pilot aboard a flyable, naturally landable escape pod. Destroying an empty ship preserves the on-foot pilot without creating a phantom pod.
- Without a full ship, stand balanced and still on owned terrain for **8 seconds** to rebuild nearby. Placement uses bounded terrain/clearance queries; blocked placement retains 100% progress and retries at half-second intervals. The replacement must settle before normal boarding, and any old pod is removed.
- Hold **A+B+Down for 3 seconds** for the Expedition-only scuttle drill; releasing early cancels. Existing HUD guidance reports eligibility, rebuild percentage and blocked placement.

## Architecture and compatibility

- Both seats share one Rapier step and gravity solve. Stable pilot identities, bounded per-seat lifecycle work, and at most one exterior capsule and one live assigned vehicle per seat.
- Ownership uses the existing canonical planet owner. Flags are surface-local visual attachments with **no bodies or colliders**.
- Player-addressed Surface action V2 and observation version 10 expose per-seat landing, claim, recovery and lifecycle diagnostics. This does not add a live IPC telemetry endpoint.
- Expedition breakup fragments receive a half-second owner-contact grace period to disperse; terrain, debris and opponent-vehicle collisions remain active.
- Ordinary Spacewars docking, services, bots and protocols remain unchanged. Pinned Sortie/outpost/compatibility fixtures and frozen agent baselines are retained.

## Validation

- **861 workspace/all-target tests** and **14 real UI workflows** passed.
- **16 recovery tests** passed in debug and release, including the input-driven pod → claim → rebuild → board → takeoff journey, controlled pod landings, lethal contact, empty-ship loss, blocked placement, eligibility resets, input gates and deterministic two-seat recovery.
- Fresh pre-commit rerun: all 16 recovery tests and 8 surface client tests passed; formatting and diff checks clean.
- Frozen navigation-v1 (6 episodes) and strategy-v1 (12 episodes) baselines match.
- Windows client and ARM64 scenario all-target compile checks passed. Clippy completed with existing warnings outside the changed surface paths.
- Deployed through the Pi A/B updater: package checksum verified, settings unchanged, two-player smoke sample **60.1 FPS / 60.1 UPS**, zero service restarts.
- User accepted multiplayer/flag playtesting and subsequently reported the occupied recovery loop working after scuttling both in flight and while landed. Existing rebuild percentage/“stand still” guidance was visible. Empty-ship loss and multiplayer failure cases have automated coverage, but were not specifically reported as manually tested.

## Remaining boundaries

Pods and spacelings remain invulnerable. No weapons, pilot elimination, ship swapping, remote rescue, economy or bot surface intents are added. Known Surface V1 approach/route/long-idle limitations remain; destructible-terrain integration is separate work.

See [Surface Expedition documentation](https://github.com/aortez/space-wars/blob/surface-expedition-multiplayer/docs/surface-expedition.md) for controls, lifecycle rules, verification commands and playtest details.
