### PR TITLE
Add bounded Clock Meltdown and drain event

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ The local launcher currently has twelve entries across eight scenario families:
   seven-segment square cells. The deterministic scenario receives versioned
   clock readings from its client adapter. Lit segments occasionally fall as
   rigid bars, collide with the floor, and reform with the latest time. Choose
-  Off, Calm, or Demo in Settings and enable Falling and Color Cycle individually.
+  Off, Calm, or Demo in Settings and enable Falling, Color Cycle, and Meltdown individually.
   Events share a deterministic, non-overlapping schedule; Color Cycle changes
-  the readable face palette without physics. **Pause → Clock Controls** (or the
+  the readable face palette without physics. Meltdown turns individual cells into
+  a bounded pool that drains through the floor before the face reforms.
+  **Pause → Clock Controls** (or the
   on-face touch button) changes live settings and offers **Preview & Resume**.
   See [Clock](docs/clock.md) for
   timing, the event catalog, and synchronized preview controls.

--- a/crates/engine-client/src/client_scenarios/clock.rs
+++ b/crates/engine-client/src/client_scenarios/clock.rs
@@ -137,6 +137,7 @@ impl ClientScenario for ClockClientScenario {
             },
             body_count: self.state.body_count(),
             collider_count: self.state.collider_count(),
+            meltdown: self.state.meltdown_state(),
             reading: self
                 .state
                 .reading()
@@ -237,5 +238,98 @@ mod tests {
             ClockAction::decode(&actions[0]),
             Some(ClockAction::SetReading(second))
         );
+    }
+
+    #[test]
+    fn meltdown_reaches_both_render_paths_and_raster_water_is_visible() {
+        for viewport in [
+            Viewport::new(800.0, 480.0),
+            Viewport::new(480.0, 800.0),
+            Viewport::new(1280.0, 720.0),
+        ] {
+            let mut state = ClockScenario::init(
+                ClockConfig {
+                    aspect_ratio: viewport.aspect_ratio(),
+                    event_profile: engine_common::ClockEventProfile::Off,
+                    ..ClockConfig::default()
+                },
+                42,
+            );
+            ClockScenario::step(
+                &mut state,
+                &[
+                    ClockAction::set_reading(ClockReading::new(8, 8, 0).unwrap()),
+                    ClockAction::trigger_event(engine_common::ClockEventKind::Meltdown),
+                ],
+                Duration::ZERO,
+            );
+            let mut scenario = ClockClientScenario {
+                state,
+                last_emitted_reading: Cell::new(None),
+            };
+            let mut renderer = crate::raster::RasterRenderer::new();
+            for tick in 0..=510 {
+                if tick > 0 {
+                    scenario.step(&[], Duration::from_nanos(16_666_667));
+                }
+                if ![0, 75, 125, 210, 450, 510].contains(&tick) {
+                    continue;
+                }
+                let frames = scenario.render_frames(RenderBackend::Raster, viewport);
+                assert_eq!(
+                    frames,
+                    scenario.render_frames(RenderBackend::Vector, viewport)
+                );
+                assert!(
+                    frames[0]
+                        .layers
+                        .iter()
+                        .map(|l| l.primitives.len())
+                        .sum::<usize>()
+                        <= 500
+                );
+                let presentation = crate::render::scene_presentation_from_frames_with_layout(
+                    &frames,
+                    viewport,
+                    scenario.frame_layout(),
+                );
+                assert!(!presentation.main_primitives.is_empty());
+                let image = renderer.image_from_frames_with_layout(
+                    &frames,
+                    viewport,
+                    scenario.frame_layout(),
+                    crate::raster::RasterOptions::default(),
+                );
+                let pixels = image.to_rgb8().unwrap();
+                let blue = pixels
+                    .as_slice()
+                    .iter()
+                    .filter(|p| p.r < 50 && p.g > 100 && p.b > 180)
+                    .count();
+                if tick == 125 || tick == 210 {
+                    assert!(blue > 100, "missing water at tick {tick} {viewport:?}");
+                }
+                if tick == 0 || tick == 510 {
+                    assert_eq!(blue, 0);
+                }
+                if let Some(directory) = std::env::var_os("SPACEWARS_CLOCK_ARTIFACTS") {
+                    let directory = std::path::PathBuf::from(directory);
+                    std::fs::create_dir_all(&directory).unwrap();
+                    let file = std::fs::File::create(directory.join(format!(
+                        "meltdown-{tick}-{}x{}.png",
+                        viewport.width, viewport.height
+                    )))
+                    .unwrap();
+                    let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
+                    encoder.set_color(png::ColorType::Rgb);
+                    encoder.set_depth(png::BitDepth::Eight);
+                    encoder
+                        .write_header()
+                        .unwrap()
+                        .write_image_data(pixels.as_bytes())
+                        .unwrap();
+                }
+            }
+        }
     }
 }

--- a/crates/engine-client/src/clock_controls.rs
+++ b/crates/engine-client/src/clock_controls.rs
@@ -20,6 +20,7 @@ pub(crate) fn publish_settings(window: &MainWindow, settings: ClockSettings) {
     );
     window.set_launcher_clock_falling_enabled(settings.events.falling);
     window.set_launcher_clock_color_cycle_enabled(settings.events.color_cycle);
+    window.set_launcher_clock_meltdown_enabled(settings.events.meltdown);
 }
 
 pub(crate) fn install(
@@ -135,6 +136,7 @@ fn adjusted_settings(mut settings: ClockSettings, index: i32, delta: i32) -> Opt
         }
         2 => settings.events.falling = !settings.events.falling,
         3 => settings.events.color_cycle = !settings.events.color_cycle,
+        7 => settings.events.meltdown = !settings.events.meltdown,
         _ => return None,
     }
     Some(settings)
@@ -158,7 +160,7 @@ pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
             window.set_ingame_clock_focus_index(ui_navigation::moved_clock_selection(index, action))
         }
         UiAction::Left | UiAction::Right => {
-            if matches!(index, 2 | 3 | 5 | 6) {
+            if matches!(index, 2 | 3 | 5 | 6 | 7) {
                 window.set_ingame_clock_focus_index(ui_navigation::moved_clock_selection(
                     index, action,
                 ));
@@ -169,7 +171,9 @@ pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
                 );
             }
         }
-        UiAction::Confirm if index <= 4 => window.invoke_ingame_clock_adjust(index, 1),
+        UiAction::Confirm if index <= 4 || index == 7 => {
+            window.invoke_ingame_clock_adjust(index, 1)
+        }
         UiAction::Confirm if index == 6 => window.invoke_ingame_clock_preview(),
         UiAction::Confirm | UiAction::Back | UiAction::Controls => {
             window.set_ingame_clock_visible(false)

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -787,6 +787,7 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
             clock_event_profile: window.get_launcher_clock_event_profile().to_string(),
             clock_falling_enabled: window.get_launcher_clock_falling_enabled(),
             clock_color_cycle_enabled: window.get_launcher_clock_color_cycle_enabled(),
+            clock_meltdown_enabled: window.get_launcher_clock_meltdown_enabled(),
             nes_cartridge_name: window.get_launcher_nes_rom_name().to_string(),
         },
     );

--- a/crates/engine-client/src/keyboard_tests.rs
+++ b/crates/engine-client/src/keyboard_tests.rs
@@ -115,9 +115,22 @@ fn backend_neutral_keyboard_reaches_clock_settings_and_does_not_repeat_shortcuts
     // Pi-sized page: left-hand event switch and time-format row are hittable.
     click(&window, 240.0, 222.0);
     assert_eq!(adjusted.get(), Some((2, 1)));
+    click(&window, 585.0, 222.0);
+    assert_eq!(adjusted.get(), Some((7, 1)));
     adjusted.set(None);
     click(&window, 649.0, 110.0);
     assert_eq!(adjusted.get(), Some((0, 1)));
+    // The extra launcher row must not overlap Back/Start at 800×480.
+    window.set_ingame_menu_visible(false);
+    window.set_launcher_visible(true);
+    window.set_launcher_settings_visible(true);
+    assert!(window.get_launcher_clock_meltdown_enabled());
+    click(&window, 728.0, 324.0);
+    assert!(!window.get_launcher_clock_meltdown_enabled());
+    assert!(window.get_launcher_settings_visible());
+    assert_eq!(window.get_launcher_settings_focus_index(), 6);
+    click(&window, 100.0, 384.0);
+    assert!(!window.get_launcher_settings_visible());
 }
 
 fn click(window: &MainWindow, x: f32, y: f32) {

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -623,6 +623,7 @@ fn show_launcher(
     )));
     window.set_launcher_clock_falling_enabled(settings.clock.events.falling);
     window.set_launcher_clock_color_cycle_enabled(settings.clock.events.color_cycle);
+    window.set_launcher_clock_meltdown_enabled(settings.clock.events.meltdown);
     refresh_nes_rom_library(window, settings, rom_catalog);
     window.set_launcher_error_text(SharedString::from(""));
     window.set_launcher_focus_index(0);
@@ -1191,7 +1192,7 @@ fn launcher_settings_item_count(window: &MainWindow) -> i32 {
     match window.get_launcher_scenario().as_str() {
         "spacewars" => 8,
         "pizza" => 5,
-        "clock" => 7,
+        "clock" => 8,
         "falling" => 1,
         "nes" => 2,
         "surface-expedition" => 4,
@@ -1328,6 +1329,10 @@ fn adjust_pizza_launcher_setting(window: &MainWindow, focus: i32, delta: i32) {
 }
 
 fn adjust_clock_launcher_setting(window: &MainWindow, focus: i32, delta: i32) {
+    if focus == 6 {
+        window.set_launcher_clock_meltdown_enabled(!window.get_launcher_clock_meltdown_enabled());
+        return;
+    }
     if focus == 4 {
         window.set_launcher_clock_falling_enabled(!window.get_launcher_clock_falling_enabled());
         return;
@@ -1845,6 +1850,7 @@ fn clock_setup_from_window(window: &MainWindow) -> Result<ClockSettings, String>
         events: engine_common::ClockEvents {
             falling: window.get_launcher_clock_falling_enabled(),
             color_cycle: window.get_launcher_clock_color_cycle_enabled(),
+            meltdown: window.get_launcher_clock_meltdown_enabled(),
         },
     })
 }
@@ -2631,6 +2637,7 @@ mod tests {
                 events: engine_common::ClockEvents {
                     falling: false,
                     color_cycle: true,
+                    meltdown: false,
                 },
             },
             spacewars: SpacewarsSettings {

--- a/crates/engine-client/src/settings.rs
+++ b/crates/engine-client/src/settings.rs
@@ -310,6 +310,7 @@ mod tests {
             loaded.settings.clock.events = engine_common::ClockEvents {
                 falling: false,
                 color_cycle: true,
+                meltdown: false,
             };
             save_settings(&loaded.settings, &path).unwrap();
             assert_eq!(
@@ -317,6 +318,15 @@ mod tests {
                 loaded.settings.clock
             );
         }
+    }
+
+    #[test]
+    fn older_event_switches_keep_their_values_when_meltdown_defaults_on() {
+        let settings: Settings =
+            toml::from_str("[clock.events]\nfalling = false\ncolor_cycle = false\n").unwrap();
+        assert!(!settings.clock.events.falling);
+        assert!(!settings.clock.events.color_cycle);
+        assert!(settings.clock.events.meltdown);
     }
 
     #[test]

--- a/crates/engine-client/src/ui_activation.rs
+++ b/crates/engine-client/src/ui_activation.rs
@@ -86,6 +86,7 @@ fn activation_target(control_id: &str, benchmark_available: bool) -> Option<Acti
         "pause.clock.event-profile.next" => pause_clock(1, UiAction::Right),
         "pause.clock.falling" => pause_clock(2, UiAction::Confirm),
         "pause.clock.color-cycle" => pause_clock(3, UiAction::Confirm),
+        "pause.clock.meltdown" => pause_clock(7, UiAction::Confirm),
         "pause.clock.preview-event.previous" => pause_clock(4, UiAction::Left),
         "pause.clock.preview-event.next" => pause_clock(4, UiAction::Right),
         "pause.clock.back" => pause_clock(5, UiAction::Confirm),
@@ -127,7 +128,7 @@ fn launcher_setting_target(control_id: &str) -> Option<ActivationTarget> {
         | "launcher.settings.clock.event-profile" => 3,
         "launcher.settings.spacewars.asteroids" | "launcher.settings.clock.falling" => 4,
         "launcher.settings.spacewars.player-health" | "launcher.settings.clock.color-cycle" => 5,
-        "launcher.settings.spacewars.player-2" => 6,
+        "launcher.settings.spacewars.player-2" | "launcher.settings.clock.meltdown" => 6,
         _ => return None,
     };
     Some(launcher_settings(Some(focus_index), action))

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -68,6 +68,7 @@ pub(crate) struct UiInventoryContext {
     pub(crate) clock_event_profile: String,
     pub(crate) clock_falling_enabled: bool,
     pub(crate) clock_color_cycle_enabled: bool,
+    pub(crate) clock_meltdown_enabled: bool,
     pub(crate) nes_cartridge_name: String,
 }
 
@@ -291,6 +292,10 @@ fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
                     "launcher.settings.clock.color-cycle",
                     context.clock_color_cycle_enabled,
                 ),
+                (
+                    "launcher.settings.clock.meltdown",
+                    context.clock_meltdown_enabled,
+                ),
             ] {
                 push_choice(&mut controls, id, if enabled { "On" } else { "Off" });
             }
@@ -301,6 +306,7 @@ fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
                 "launcher.settings.clock.event-profile",
                 "launcher.settings.clock.falling",
                 "launcher.settings.clock.color-cycle",
+                "launcher.settings.clock.meltdown",
                 "launcher.settings.back",
             ]
         }
@@ -463,6 +469,15 @@ fn pause_clock_inventory(context: &UiInventoryContext) -> UiInventory {
         "pause.clock.preview-event",
         &context.clock_preview,
     );
+    controls.push(
+        UiControl::new("pause.clock.meltdown", "Meltdown", true).with_value(
+            if context.clock_meltdown_enabled {
+                "On"
+            } else {
+                "Off"
+            },
+        ),
+    );
     controls.push(UiControl::new("pause.clock.back", "Back", true));
     controls.push(UiControl::new(
         "pause.clock.preview",
@@ -482,6 +497,7 @@ fn pause_clock_inventory(context: &UiInventoryContext) -> UiInventory {
                 "pause.clock.preview-event",
                 "pause.clock.back",
                 "pause.clock.preview",
+                "pause.clock.meltdown",
             ],
             context.ingame_clock_focus_index,
         ),
@@ -526,6 +542,7 @@ mod tests {
             clock_event_profile: "Calm".into(),
             clock_falling_enabled: true,
             clock_color_cycle_enabled: true,
+            clock_meltdown_enabled: true,
             nes_cartridge_name: "Demo Cartridge".into(),
             ..Default::default()
         }
@@ -673,7 +690,7 @@ mod tests {
         let cases = [
             ("spacewars", 16, "launcher.settings.spacewars.player-2"),
             ("pizza", 10, "launcher.settings.pizza.spawn-rate"),
-            ("clock", 14, "launcher.settings.clock.color-cycle"),
+            ("clock", 16, "launcher.settings.clock.meltdown"),
             ("rover-lab", 6, "launcher.settings.raster-scale"),
             ("falling", 2, "launcher.settings.back"),
             ("nes", 4, "launcher.settings.nes.cartridge"),
@@ -690,7 +707,7 @@ mod tests {
                 "surface-expedition" => 2,
                 "spacewars" => 6,
                 "pizza" => 3,
-                "clock" => 5,
+                "clock" => 6,
                 "rover-lab" => 1,
                 "falling" => 0,
                 "nes" => 0,
@@ -881,7 +898,7 @@ mod tests {
             inventory.selected_control.as_deref(),
             Some("pause.clock.color-cycle")
         );
-        assert_eq!(inventory.controls.len(), 10);
+        assert_eq!(inventory.controls.len(), 11);
         assert!(inventory.controls.iter().all(|control| control.enabled));
         context.clock_controls_pending = true;
         let pending = inventory_for_screen(UiScreen::PauseClock, &context);

--- a/crates/engine-client/src/ui_navigation.rs
+++ b/crates/engine-client/src/ui_navigation.rs
@@ -52,11 +52,14 @@ pub(crate) fn moved_ingame_selection(
 }
 
 pub(crate) fn moved_clock_selection(current: i32, action: UiAction) -> i32 {
-    let current = current.clamp(0, 6) as usize;
+    // Keep existing control indices stable: the event row is [2, 3, 7],
+    // followed by preview choice 4 and the [5, 6] action row.
+    let current = current.clamp(0, 7) as usize;
     match action {
-        UiAction::Up => [5, 0, 1, 1, 2, 4, 4][current],
-        UiAction::Down => [1, 2, 4, 4, 5, 0, 0][current],
-        UiAction::Left | UiAction::Right => [0, 1, 3, 2, 4, 6, 5][current],
+        UiAction::Up => [5, 0, 1, 1, 2, 4, 4, 1][current],
+        UiAction::Down => [1, 2, 4, 4, 5, 0, 0, 4][current],
+        UiAction::Left => [0, 1, 7, 2, 4, 6, 5, 3][current],
+        UiAction::Right => [0, 1, 3, 7, 4, 6, 5, 2][current],
         _ => current as i32,
     }
 }
@@ -70,6 +73,17 @@ mod tests {
         assert_eq!(moved_selection(0, 5, -1), 4);
         assert_eq!(moved_selection(4, 5, 1), 0);
         assert_eq!(moved_selection(2, 5, 1), 3);
+    }
+
+    #[test]
+    fn clock_event_row_reaches_every_switch_without_changing_preview() {
+        assert_eq!(moved_clock_selection(2, UiAction::Right), 3);
+        assert_eq!(moved_clock_selection(3, UiAction::Right), 7);
+        assert_eq!(moved_clock_selection(7, UiAction::Right), 2);
+        assert_eq!(moved_clock_selection(7, UiAction::Left), 3);
+        assert_eq!(moved_clock_selection(2, UiAction::Left), 7);
+        assert_eq!(moved_clock_selection(7, UiAction::Down), 4);
+        assert_eq!(moved_clock_selection(7, UiAction::Up), 1);
     }
 
     #[test]

--- a/crates/engine-client/tests/ui_control_functional/clock.rs
+++ b/crates/engine-client/tests/ui_control_functional/clock.rs
@@ -21,6 +21,7 @@ fn live_clock_controls_preserve_events_preview_and_persist_across_restart_and_re
         page = harness.change_clock_setting("pause.clock.event-profile.previous", "Off", &page);
         page = harness.change_clock_setting("pause.clock.falling", "Off", &page);
         page = harness.change_clock_setting("pause.clock.color-cycle", "Off", &page);
+        page = harness.change_clock_setting("pause.clock.meltdown", "Off", &page);
         let configured = harness.clock_state();
         assert_eq!(configured.scenario_revision, initial.scenario_revision);
         assert_eq!(configured.event_id, paused.event_id);
@@ -296,7 +297,10 @@ fn demo_profile_automatically_runs_multiple_bounded_events() {
                 assert!((5..=32).contains(&active.body_count));
                 assert!(active.collider_count <= 100);
             } else {
-                assert_eq!(active.event_kind, Some(ClockEventKind::ColorCycle));
+                assert!(matches!(
+                    active.event_kind,
+                    Some(ClockEventKind::ColorCycle | ClockEventKind::Meltdown)
+                ));
                 assert_eq!((active.body_count, active.collider_count), (0, 0));
             }
             let recovered = harness.clock_wait(&initial, "idle", event_id, 0);
@@ -319,6 +323,7 @@ fn color_cycle_preview_preserves_time_and_resets_after_pause_restart_and_relaunc
         for id in [
             "launcher.settings.clock.falling.next",
             "launcher.settings.clock.color-cycle.next",
+            "launcher.settings.clock.meltdown.next",
         ] {
             assert_eq!(control_value(&state, id), Some("On"));
             state = harness.activate_guarded(id, &state);
@@ -392,6 +397,7 @@ fn color_cycle_preview_preserves_time_and_resets_after_pause_restart_and_relaunc
         for id in [
             "launcher.settings.clock.falling.next",
             "launcher.settings.clock.color-cycle.next",
+            "launcher.settings.clock.meltdown.next",
         ] {
             assert_eq!(control_value(&settings, id), Some("Off"));
         }
@@ -527,4 +533,104 @@ impl FunctionalHarness {
             TRANSITION_TIMEOUT,
         )
     }
+}
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn meltdown_pools_drains_previews_and_cleans_up_through_the_real_client() {
+    run_functional_test("clock-meltdown", |harness| {
+        let state = harness.wait_until_ready();
+        let state = harness.activate_until_scenario("clock", state);
+        let state = harness.activate_guarded("launcher.settings", &state);
+        let state =
+            harness.activate_guarded("launcher.settings.clock.event-profile.previous", &state);
+        assert_eq!(
+            control_value(&state, "launcher.settings.clock.event-profile.next"),
+            Some("Off")
+        );
+        harness.activate_guarded("launcher.settings.start", &state);
+        let gameplay = harness.wait_clock_screen(UiScreen::Gameplay, state.revision);
+        let initial = harness.clock_state();
+        harness.clock_trigger_event(&initial, ClockEventKind::Meltdown);
+        let melting = harness.clock_wait(&initial, "melting", 1, 75);
+        assert!(melting.meltdown.unwrap().airborne_cells > 0);
+        assert_eq!((melting.body_count, melting.collider_count), (0, 0));
+        harness.capture_screenshot("clock-melting.png");
+        harness.activate_guarded("gameplay.clock-controls", &gameplay);
+        let mut page = harness.wait_clock_screen(UiScreen::PauseClock, gameplay.revision);
+        let paused = harness.clock_state();
+        harness.assert_clock_stays_paused(&paused);
+        page = harness.change_clock_setting("pause.clock.meltdown", "Off", &page);
+        assert_eq!(harness.clock_state().meltdown, paused.meltdown);
+        // All three event switches remain reachable through controller navigation.
+        let page = harness.press_guarded(UiAction::Left, &page);
+        assert_eq!(
+            page.selected_control.as_deref(),
+            Some("pause.clock.color-cycle")
+        );
+        let page = harness.press_guarded(UiAction::Right, &page);
+        assert_eq!(
+            page.selected_control.as_deref(),
+            Some("pause.clock.meltdown")
+        );
+        let page = harness.activate_guarded("pause.clock.preview-event.next", &page);
+        let page = harness.activate_guarded("pause.clock.preview-event.next", &page);
+        assert_eq!(
+            control_value(&page, "pause.clock.preview-event.next"),
+            Some("Meltdown")
+        );
+        harness.capture_screenshot("clock-meltdown-controls.png");
+        harness.activate_guarded("pause.clock.preview", &page);
+        let gameplay = harness.wait_clock_screen(UiScreen::Gameplay, page.revision);
+        let draining = harness.clock_wait(&initial, "draining", 2, 10);
+        let material = draining.meltdown.unwrap();
+        assert!(material.drained_microunits > 0 && material.pooled_microunits > 0);
+        assert!(material.water_columns <= scenario_clock::WATER_COLUMNS);
+        assert_eq!(draining.scenario_revision, initial.scenario_revision);
+        assert!(!draining.settings.events.meltdown);
+        harness.capture_screenshot("clock-draining.png");
+        harness.pause_guarded(&gameplay);
+        let menu = harness.wait_clock_screen(UiScreen::PauseMain, gameplay.revision);
+        let paused = harness.clock_state();
+        harness.assert_clock_stays_paused(&paused);
+        harness.activate_guarded("pause.resume", &menu);
+        let reforming = harness.clock_wait(&initial, "reforming", 2, 15);
+        let material = reforming.meltdown.unwrap();
+        assert_eq!(
+            (
+                material.waiting_cells,
+                material.airborne_cells,
+                material.water_columns
+            ),
+            (0, 0, 0)
+        );
+        assert!(material.drained_microunits > material.initial_cells as u64 * 990_000);
+        harness.capture_screenshot("clock-melt-reforming.png");
+        let idle = harness.clock_wait(&initial, "idle", 2, 0);
+        assert_eq!(idle.meltdown, None);
+        assert_eq!(idle.next_event_tick, None);
+        harness.capture_screenshot("clock-melt-recovered.png");
+        harness.clock_trigger_event(&idle, ClockEventKind::Meltdown);
+        harness.clock_wait(&idle, "melting", 3, 30);
+        let gameplay = harness.state();
+        harness.pause_guarded(&gameplay);
+        let menu = harness.wait_clock_screen(UiScreen::PauseMain, gameplay.revision);
+        harness.activate_guarded("pause.restart", &menu);
+        let gameplay = harness.wait_clock_screen(UiScreen::Gameplay, menu.revision);
+        let restarted = harness.clock_state();
+        assert_ne!(restarted.scenario_revision, idle.scenario_revision);
+        assert_eq!(restarted.meltdown, None);
+        assert_eq!(restarted.event_id, 0);
+        assert!(!restarted.settings.events.meltdown);
+        harness.pause_guarded(&gameplay);
+        let menu = harness.wait_clock_screen(UiScreen::PauseMain, gameplay.revision);
+        harness.activate_guarded("pause.return-to-launcher", &menu);
+        let launcher = harness.wait_clock_screen(UiScreen::LauncherMain, menu.revision);
+        harness.activate_guarded("launcher.start", &launcher);
+        harness.wait_clock_screen(UiScreen::Gameplay, launcher.revision);
+        let relaunched = harness.clock_state();
+        assert_ne!(relaunched.scenario_revision, restarted.scenario_revision);
+        assert_eq!(relaunched.meltdown, None);
+        assert!(!relaunched.settings.events.meltdown);
+    });
 }

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -303,6 +303,7 @@ export component MainWindow inherits Window {
     in-out property <string> launcher-clock-event-profile: "Calm";
     in-out property <bool> launcher-clock-falling-enabled: true;
     in-out property <bool> launcher-clock-color-cycle-enabled: true;
+    in-out property <bool> launcher-clock-meltdown-enabled: true;
     in-out property <string> launcher-nes-rom-id: "";
     in-out property <string> launcher-nes-rom-name: "No cartridges found";
     in-out property <string> launcher-nes-rom-status: "Copy a .nes file into the ROM library.";
@@ -864,22 +865,32 @@ export component MainWindow inherits Window {
                 MenuButton {
                     x: 0px;
                     y: 112px;
-                    width: (parent.width - 10px) / 2;
+                    width: (parent.width - 20px) / 3;
                     height: 48px;
-                    text: "Falling: " + (root.launcher-clock-falling-enabled ? "On" : "Off");
+                    text: "Falling\n" + (root.launcher-clock-falling-enabled ? "On" : "Off");
                     selected: root.ingame-clock-focus-index == 2;
                     enabled: !root.clock-controls-pending;
                     activated => { root.ingame-clock-adjust(2, 1); }
                 }
                 MenuButton {
-                    x: (parent.width + 10px) / 2;
+                    x: (parent.width + 10px) / 3;
                     y: 112px;
-                    width: (parent.width - 10px) / 2;
+                    width: (parent.width - 20px) / 3;
                     height: 48px;
-                    text: "Color Cycle: " + (root.launcher-clock-color-cycle-enabled ? "On" : "Off");
+                    text: "Color Cycle\n" + (root.launcher-clock-color-cycle-enabled ? "On" : "Off");
                     selected: root.ingame-clock-focus-index == 3;
                     enabled: !root.clock-controls-pending;
                     activated => { root.ingame-clock-adjust(3, 1); }
+                }
+                MenuButton {
+                    x: 2 * (parent.width + 10px) / 3;
+                    y: 112px;
+                    width: (parent.width - 20px) / 3;
+                    height: 48px;
+                    text: "Meltdown\n" + (root.launcher-clock-meltdown-enabled ? "On" : "Off");
+                    selected: root.ingame-clock-focus-index == 7;
+                    enabled: !root.clock-controls-pending;
+                    activated => { root.ingame-clock-adjust(7, 1); }
                 }
                 ChoiceRow {
                     y: 168px;
@@ -1248,7 +1259,7 @@ export component MainWindow inherits Window {
                         visible: root.launcher-scenario != "falling" && root.launcher-scenario != "nes";
                         x: 0px;
                         y: 0px;
-                        width: root.launcher-scenario == "spacewars" ? (parent.width - 12px) / 2 : parent.width;
+                        width: root.launcher-scenario == "spacewars" || root.launcher-scenario == "clock" ? (parent.width - 12px) / 2 : parent.width;
                         height: 48px;
                         label: "Renderer";
                         value: root.launcher-renderer;
@@ -1265,9 +1276,9 @@ export component MainWindow inherits Window {
 
                     ChoiceRow {
                         visible: root.launcher-scenario != "falling" && root.launcher-scenario != "nes";
-                        x: root.launcher-scenario == "spacewars" ? parent.width / 2 + 6px : 0px;
-                        y: root.launcher-scenario == "spacewars" ? 0px : 52px;
-                        width: root.launcher-scenario == "spacewars" ? (parent.width - 12px) / 2 : parent.width;
+                        x: root.launcher-scenario == "spacewars" || root.launcher-scenario == "clock" ? parent.width / 2 + 6px : 0px;
+                        y: root.launcher-scenario == "spacewars" || root.launcher-scenario == "clock" ? 0px : 52px;
+                        width: root.launcher-scenario == "spacewars" || root.launcher-scenario == "clock" ? (parent.width - 12px) / 2 : parent.width;
                         height: 48px;
                         label: "Raster Scale";
                         value: root.launcher-raster-scale-text + "×";
@@ -1418,7 +1429,7 @@ export component MainWindow inherits Window {
                     ChoiceRow {
                         visible: root.launcher-scenario == "clock";
                         x: 0px;
-                        y: 104px;
+                        y: 52px;
                         width: parent.width;
                         height: 48px;
                         label: "Time Format";
@@ -1437,7 +1448,7 @@ export component MainWindow inherits Window {
                     ChoiceRow {
                         visible: root.launcher-scenario == "clock";
                         x: 0px;
-                        y: 156px;
+                        y: 104px;
                         width: parent.width;
                         height: 48px;
                         label: "Event Profile";
@@ -1456,7 +1467,7 @@ export component MainWindow inherits Window {
                     ChoiceRow {
                         visible: root.launcher-scenario == "clock";
                         x: 0px;
-                        y: 208px;
+                        y: 156px;
                         width: (parent.width - 12px) / 2;
                         height: 48px;
                         label: "Falling";
@@ -1475,7 +1486,7 @@ export component MainWindow inherits Window {
                     ChoiceRow {
                         visible: root.launcher-scenario == "clock";
                         x: parent.width / 2 + 6px;
-                        y: 208px;
+                        y: 156px;
                         width: (parent.width - 12px) / 2;
                         height: 48px;
                         label: "Color Cycle";
@@ -1487,6 +1498,25 @@ export component MainWindow inherits Window {
                         }
                         next => {
                             root.launcher-settings-focus-index = 5;
+                            root.ui-action(3);
+                        }
+                    }
+
+                    ChoiceRow {
+                        visible: root.launcher-scenario == "clock";
+                        x: 0px;
+                        y: 208px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Meltdown";
+                        value: root.launcher-clock-meltdown-enabled ? "On" : "Off";
+                        selected: root.launcher-settings-focus-index == 6;
+                        previous => {
+                            root.launcher-settings-focus-index = 6;
+                            root.ui-action(2);
+                        }
+                        next => {
+                            root.launcher-settings-focus-index = 6;
                             root.ui-action(3);
                         }
                     }
@@ -1562,7 +1592,7 @@ export component MainWindow inherits Window {
                         width: 150px;
                         height: 44px;
                         text: "Back";
-                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" ? 7 : root.launcher-scenario == "clock" ? 6 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : root.launcher-scenario == "surface-expedition" ? 3 : 2);
+                        selected: root.launcher-settings-focus-index == (root.launcher-scenario == "spacewars" || root.launcher-scenario == "clock" ? 7 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : root.launcher-scenario == "surface-expedition" ? 3 : 2);
                         activated => {
                             root.launcher-settings-visible = false;
                         }

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -228,15 +228,17 @@ pub struct ClockSettings {
 pub enum ClockEventKind {
     Falling = 0,
     ColorCycle = 1,
+    Meltdown = 2,
 }
 
 impl ClockEventKind {
-    pub const ALL: [Self; 2] = [Self::Falling, Self::ColorCycle];
+    pub const ALL: [Self; 3] = [Self::Falling, Self::ColorCycle, Self::Meltdown];
 
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Falling => "falling",
             Self::ColorCycle => "color-cycle",
+            Self::Meltdown => "meltdown",
         }
     }
 
@@ -244,6 +246,7 @@ impl ClockEventKind {
         match self {
             Self::Falling => "Falling",
             Self::ColorCycle => "Color Cycle",
+            Self::Meltdown => "Meltdown",
         }
     }
 }
@@ -254,6 +257,7 @@ impl ClockEventKind {
 pub struct ClockEvents {
     pub falling: bool,
     pub color_cycle: bool,
+    pub meltdown: bool,
 }
 
 impl Default for ClockEvents {
@@ -261,6 +265,7 @@ impl Default for ClockEvents {
         Self {
             falling: true,
             color_cycle: true,
+            meltdown: true,
         }
     }
 }
@@ -270,8 +275,23 @@ impl ClockEvents {
         match kind {
             ClockEventKind::Falling => self.falling,
             ClockEventKind::ColorCycle => self.color_cycle,
+            ClockEventKind::Meltdown => self.meltdown,
         }
     }
+}
+
+/// Bounded Clock-local material, not Rapier bodies. One original square is
+/// 1,000,000 volume units. Rounding each aggregate can differ by one unit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClockMeltdownState {
+    pub initial_cells: usize,
+    pub waiting_cells: usize,
+    pub airborne_cells: usize,
+    pub water_columns: usize,
+    pub pooled_microunits: u64,
+    pub drained_microunits: u64,
+    /// Residue removed by the bounded reform phase, not counted as drainage.
+    pub reclaimed_microunits: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/spacewars-cli/src/clock.rs
+++ b/crates/spacewars-cli/src/clock.rs
@@ -19,7 +19,7 @@ pub enum ClockCommand {
     },
     /// Preview an event from idle, including with Off or that event disabled.
     Trigger {
-        /// Event ID: falling or color-cycle.
+        /// Event ID: falling, color-cycle or meltdown.
         #[arg(value_parser = parse_event)]
         event: ClockEventKind,
         /// Reject a stale Clock instance; defaults to the current instance.
@@ -39,7 +39,7 @@ pub enum ClockCommand {
     Wait {
         #[arg(long, value_parser = ["idle", "active", "cooldown"])]
         lifecycle: Option<String>,
-        #[arg(long, value_parser = ["falling", "reforming", "cycling"])]
+        #[arg(long, value_parser = ["falling", "reforming", "cycling", "melting", "draining"])]
         phase: Option<String>,
         #[arg(long, value_parser = parse_event)]
         event: Option<ClockEventKind>,
@@ -61,7 +61,9 @@ fn parse_event(value: &str) -> Result<ClockEventKind, String> {
     ClockEventKind::ALL
         .into_iter()
         .find(|kind| kind.as_str() == value)
-        .ok_or_else(|| format!("Unknown Clock event {value:?}; choose falling or color-cycle"))
+        .ok_or_else(|| {
+            format!("Unknown Clock event {value:?}; choose falling, color-cycle or meltdown")
+        })
 }
 
 pub fn run(client: &ControlClient, command: ClockCommand) -> Result<(), CliError> {
@@ -198,6 +200,17 @@ fn print_state(state: &ClockState, json: bool) -> Result<(), CliError> {
             state.next_event_tick,
             state.can_trigger
         );
+        if let Some(material) = state.meltdown {
+            println!(
+                "Meltdown: {} waiting, {} airborne, {} wet columns; water {:.3}, drained {:.3}, reclaimed {:.3} cell-volumes",
+                material.waiting_cells,
+                material.airborne_cells,
+                material.water_columns,
+                material.pooled_microunits as f64 / 1_000_000.0,
+                material.drained_microunits as f64 / 1_000_000.0,
+                material.reclaimed_microunits as f64 / 1_000_000.0
+            );
+        }
     }
     Ok(())
 }

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -775,6 +775,21 @@ mod tests {
         assert!(Args::try_parse_from(["spacewars-cli", "clock", "state", "--json"]).is_ok());
         assert!(Args::try_parse_from(["spacewars-cli", "clock", "events", "--json"]).is_ok());
         assert!(Args::try_parse_from(["spacewars-cli", "clock", "trigger", "falling"]).is_ok());
+        assert!(Args::try_parse_from(["spacewars-cli", "clock", "trigger", "meltdown"]).is_ok());
+        for phase in ["melting", "draining", "reforming"] {
+            assert!(
+                Args::try_parse_from([
+                    "spacewars-cli",
+                    "clock",
+                    "wait",
+                    "--event",
+                    "meltdown",
+                    "--phase",
+                    phase
+                ])
+                .is_ok()
+            );
+        }
         assert!(Args::try_parse_from(["spacewars-cli", "clock", "trigger", "unknown"]).is_err());
         assert!(Args::try_parse_from(["spacewars-cli", "clock", "trigger"]).is_err());
         assert!(

--- a/crates/spacewars-control/src/clock.rs
+++ b/crates/spacewars-control/src/clock.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 pub const CLOCK_STATE_COMMAND: &str = "clock state";
 pub const CLOCK_TRIGGER_COMMAND: &str = "clock trigger";
-pub const CLOCK_STATE_SCHEMA_VERSION: u32 = 3;
+pub const CLOCK_STATE_SCHEMA_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClockEventInfo {
@@ -38,6 +38,7 @@ pub struct ClockState {
     pub palette_rgb: [u8; 3],
     pub body_count: usize,
     pub collider_count: usize,
+    pub meltdown: Option<engine_common::ClockMeltdownState>,
     pub reading: Option<[u8; 3]>,
     /// Latest target digits, including during a fall. Blank 12-hour slots are null.
     pub display_digits: [Option<u8>; 4],
@@ -247,6 +248,7 @@ mod tests {
             palette_rgb: [170, 140, 255],
             body_count: 0,
             collider_count: 0,
+            meltdown: None,
             reading: Some([12, 34, 56]),
             display_digits: [Some(1), Some(2), Some(3), Some(4)],
             can_trigger: false,
@@ -334,9 +336,33 @@ mod tests {
             r#"{"schema_version":2,"expected_scenario_revision":7,"expected_event_id":3}"#,
             r#"{"schema_version":1,"event":"falling","expected_scenario_revision":7,"expected_event_id":3}"#,
             r#"{"schema_version":2,"event":"unknown","expected_scenario_revision":7,"expected_event_id":3}"#,
+            r#"{"schema_version":3,"event":"falling","expected_scenario_revision":7,"expected_event_id":3}"#,
         ] {
             assert!(ClockTriggerRequest::from_json(json).is_err());
         }
+    }
+
+    #[test]
+    fn meltdown_diagnostics_and_named_trigger_round_trip() {
+        let mut state = clock_state();
+        state.event_kind = Some(ClockEventKind::Meltdown);
+        state.phase = Some("draining".into());
+        state.meltdown = Some(engine_common::ClockMeltdownState {
+            initial_cells: 70,
+            water_columns: 60,
+            pooled_microunits: 30_000_000,
+            drained_microunits: 40_000_000,
+            ..Default::default()
+        });
+        assert_eq!(
+            ClockState::from_json(&state.to_json().unwrap()).unwrap(),
+            state
+        );
+        let request = ClockTriggerRequest::new(&state, ClockEventKind::Meltdown);
+        assert_eq!(
+            ClockTriggerRequest::from_json(&request.to_json().unwrap()).unwrap(),
+            request
+        );
     }
 
     fn after(state: &ClockState) -> ClockStatePredicate {

--- a/docs/clock.md
+++ b/docs/clock.md
@@ -8,8 +8,8 @@ reads the system clock. Configure the device's timezone/NTP as described in
 ## Events
 
 Choose **Clock → Settings → Event Profile** using touch, keyboard, or gamepad.
-The **Falling** and **Color Cycle** switches select the automatic event mix;
-both default to On and are saved with the other Clock settings. These values
+The **Falling**, **Color Cycle**, and **Meltdown** switches select the automatic event mix;
+all default to On and are saved with the other Clock settings. These values
 can also be changed live through **Pause → Clock Controls**, without relaunching.
 
 | Profile | Idle wait before selecting an event |
@@ -23,12 +23,15 @@ kind when another is eligible. Adding event types does not multiply the trigger
 rate. Events never overlap. After completion or cancellation, there is a shared
 2-second cooldown, followed by a new idle wait. Each kind also has an automatic
 reuse delay; the scheduler waits longer if no enabled event is eligible yet.
-With both switches Off, no automatic event is scheduled.
+With all switches Off, no automatic event is scheduled. Older settings files
+retain their existing switches and default the new Meltdown switch to On;
+the Off profile still disables every automatic event.
 
 | Event ID | Effect | Duration | Automatic reuse delay after completion |
 | --- | --- | --- | --- |
 | `falling` | Digit geometry / rigid bodies | 3.5 s fall + 1.5 s reform | 30 s |
 | `color-cycle` | Appearance only | 6 s | 15 s |
+| `meltdown` | Individual cells, pooling water and drain | 3 s melt + 4 s drain + 1.5 s reform | 40 s |
 
 Falling releases the illuminated seven-segment bars as compound rigid
 bodies: their square cells stay together while the bars tumble and collide
@@ -38,6 +41,22 @@ open. Dim anchor cells remain visible behind the action.
 Color Cycle eases the illuminated cells and colon through violet, pink, gold,
 and green, returning to the normal cyan palette. Digits remain anchored and
 follow live time throughout; the event creates no physics objects.
+
+Meltdown releases the lit digit cells individually, with seeded release delays,
+gravity, spin and side-wall reflection. On first floor contact a cell becomes
+water, which pools, flows toward the existing center opening and drains away.
+The colon and dim face outline stay visible. After seven seconds, the latest
+time fades back in over 1.5 seconds. Water is a lightweight Clock-local effect:
+ballistic cells do not collide with each other, and the pool uses conservative
+neighbor leveling plus a stylized inward current, not a general fluid solver.
+
+The resource ceiling is **96 cells and 128 water columns**, with no Rapier bodies
+or growing droplet lists. The two floor halves meet the existing drain lips
+exactly. Each fixed tick performs two bounded pool passes. Drain-stream geometry
+is visual only; it never introduces additional simulated volume. The reform
+boundary accounts for and clears any remaining material rather than reporting
+it as successfully drained. Preview replacement, resize and restart drop the
+whole event-local representation. This does not depend on destructible terrain.
 
 All durations use fixed 60 Hz simulation ticks, so pause freezes the event and
 its schedule. The strict `clock trigger` command requires unpaused, synchronized,
@@ -57,7 +76,7 @@ desktop and LinuxKMS; physical gameplay key bindings for other scenarios are
 unchanged.
 
 The page changes **12/24-hour format**, **Off/Calm/Demo cadence**, and the
-**Falling/Color Cycle automatic switches**. Changes apply at the next host tick,
+**Falling/Color Cycle/Meltdown automatic switches**. Changes apply at the next host tick,
 even while paused, and are saved for restart/relaunch. A save failure is shown
 on the page; settings then remain active for the current session. Setting
 changes do not interrupt the current animation or reset its physics, event ID,
@@ -88,7 +107,7 @@ mutation. Animation ticks still do not invalidate UI revision guards.
 
 The face reforms using the **latest** reading, even across minute/hour changes
 or a host-time correction. Resizing during an event restores the current face
-and enters cooldown. Restart/relaunch starts a fresh seeded schedule. Physics
+and enters cooldown. Restart/relaunch starts a fresh seeded schedule. Rapier
 exists only during the falling phase: at most 28 moving bars plus four arena
 bodies and 100 colliders, with no accumulating debris.
 
@@ -107,8 +126,8 @@ resizing drops the active event and restores the latest face and base palette.
 Restart/relaunch constructs a fresh scenario. There is no plugin framework and
 no concurrent composition yet: affected-area metadata does not permit overlap.
 
-This slice does not implement time-change triggers, cell disintegration,
-melting/water, or duck events. Those can add bounded event-local representations
+This slice does not implement time-change triggers or duck events. Those can
+add bounded event-local representations
 without moving scheduling or wall-clock reads into the individual animations.
 
 ## Public controls and synchronized captures
@@ -127,6 +146,12 @@ spacewars-cli clock wait --lifecycle idle --event-id 1
 spacewars-cli clock trigger color-cycle --json
 spacewars-cli clock wait --event color-cycle --phase cycling --event-id 2 --min-phase-tick 72
 spacewars-cli screenshot /tmp/clock-color-cycle.png
+spacewars-cli clock wait --lifecycle idle --event-id 2
+spacewars-cli clock trigger meltdown --json
+spacewars-cli clock wait --event meltdown --phase melting --event-id 3 --min-phase-tick 75
+spacewars-cli screenshot /tmp/clock-melting.png
+spacewars-cli clock wait --event meltdown --phase draining --event-id 3 --min-phase-tick 10
+spacewars-cli screenshot /tmp/clock-draining.png
 ```
 
 Use the event ID returned by `trigger`, not necessarily `1`. For robust remote
@@ -134,15 +159,22 @@ captures, run wait and screenshot in the same SSH session; do not manually race
 the animation or sleep a guessed duration. A screenshot captures the next
 available rendered frame, not an exact simulation tick.
 
-`clock state` uses schema version **3** and reports scenario-instance revision,
+`clock state` uses schema version **4** and reports scenario-instance revision,
 event ID, lifecycle (`idle`, `active`, `cooldown`), active event kind, event-local
-phase (`falling`, `reforming`, `cycling`), pause state, profile, schedule, current
+phase (`falling`, `reforming`, `cycling`, `melting`, `draining`), pause state, profile, schedule, current
 reading/target digits, palette RGB, physics counts, and typed live `settings`.
 Kind and phase are null
 outside an active event. `phase_tick` counts ticks in the event's current phase,
 or in idle/cooldown when no event is active. The embedded event catalog includes
 enablement and per-kind automatic-ready ticks; `clock events` displays it.
-These diagnostics do not affect `ui state` revisions.
+These diagnostics do not affect `ui state` revisions. The optional `meltdown`
+object is present only during Meltdown (including its reform phase). It reports
+initial/waiting/airborne cells, occupied water columns, and pooled, drained and
+reclaimed volume. One original cell equals 1,000,000 micro-units; independently
+rounded totals can differ by one unit. Waiting plus airborne cell volume plus
+the three volume aggregates must equal the initial material. Reclaimed volume
+is explicit deadline cleanup, not drainage. Idle and other events report null.
+Use matching client/CLI builds: schema 3 requests are rejected.
 
 `clock trigger` fetches state and guards the mutation with both instance revision
 and event ID; `--expect-scenario-revision` and `--expect-event-id` override those
@@ -152,8 +184,8 @@ a pending trigger. `clock wait` binds to the current instance by default and
 fails if it changes. `--timeout` bounds the entire CLI operation. Structured
 failures retain the current Clock state when available, including on timeout.
 Wait predicates can combine lifecycle, kind, phase, event ID, and minimum phase
-tick. A raw `clock trigger` request must include schema version 3, `event`
-(`falling` or `color-cycle`), `expected_scenario_revision`, and
+tick. A raw `clock trigger` request must include schema version 4, `event`
+(`falling`, `color-cycle`, or `meltdown`), `expected_scenario_revision`, and
 `expected_event_id`. Unknown events, missing guards, and old schemas are rejected.
 
 ## Verification
@@ -168,6 +200,42 @@ SPACEWARS_KEEP_FUNCTIONAL_ARTIFACTS=1 xvfb-run -a \
 See [functional tests](functional-tests.md) for display setup, coverage, and
 failure artifacts. The same CLI works on the deployed Pi for phase-aware smoke
 tests and screenshots.
+
+### Meltdown local validation (2026-09-09)
+
+The workspace/all-target suite passed **869 tests**, with 15 display-dependent
+workflows ignored in that command. The five Clock workflows were run explicitly
+on the local X display and passed. Strict Clippy passed for the Clock/common/
+control/CLI packages; client Clippy completed with existing unrelated warnings.
+The final launcher layout was rechecked through the Color Cycle workflow and
+an 800×480 pointer test after screenshot review caught an overlapping new row.
+
+Focused tests verify seeded motion, nonnegative/conserved pool volume, more than
+99% drainage before reform, pause and latest-time recovery, all event replacements,
+resize in every phase, and repeated cleanup at aspect ratios 0.25, 0.75, 800/480
+and 4. Raster checks at 800×480, 480×800 and 1280×720 require visible water during
+the effect and no water after recovery; the same draw lists reach the vector path.
+Five real Clock UI workflows pass locally, including Meltdown's switches,
+disabled-event preview, pause, restart/relaunch and state diagnostics.
+
+The reproducible release benchmark runs 24 seeded events at each of three sizes:
+
+```sh
+cargo run --locked --release -p scenario-clock --example meltdown_benchmark
+SPACEWARS_CLOCK_ARTIFACTS=/tmp/clock-captures \
+  cargo test --locked -p engine-client meltdown_reaches -- --nocapture
+```
+
+On this desktop with Rust 1.89, the 72 events (612 simulated seconds) had a
+per-size step p95 of 0.0009 ms and draw-list p95 of 0.0042–0.0043 ms. The largest
+observed step was 0.0028 ms. Peak usage was 88 cells, 128 wet columns and 416
+draw primitives, with at most 0.000028 cell-volumes reclaimed at the deadline.
+The injected `08:08` face is deliberately dense. These timings exclude
+rasterization, presentation and host work; they are not device FPS measurements.
+
+**Meltdown has not been deployed or tested on the Pi.** Coordinate with the
+other task using `spacewars.local` and obtain confirmation before deployment.
+The device captures below document the earlier events, not Meltdown.
 
 ## Device captures
 

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -36,10 +36,10 @@ The initial workflows verify:
   a fresh Clock scenario revision.
 
 Clock event workflows additionally verify Off/Calm/Demo controls, individual
-Falling/Color Cycle switches, the public event catalog, named manual previews
+Falling/Color Cycle/Meltdown switches, the public event catalog, named manual previews
 (including disabled events), and automatic mixed-event selection. They check
 bounded body/collider counts, physics cleanup, recovery to the latest 12-hour
-time, and pause/resume during both event kinds. Color Cycle must preserve live
+time, and pause/resume during each event kind. Color Cycle must preserve live
 digits, create no physics objects, change the visible palette, and restore cyan.
 Restart and relaunch must create clean instances and retain event settings.
 Busy, paused, stale-instance, stale-event, and inactive-Clock controls are
@@ -55,7 +55,7 @@ scripted replies and virtual time: no-reply and last-reply timeouts, shared
 deadlines and bounded retry sleeps, successful matches, and error propagation.
 
 The live Clock-controls workflow enters `pause.clock` through the on-face
-control, changes and persists all four settings without replacing the paused
+control, changes and persists all five settings without replacing the paused
 event, replaces Falling with a Color Cycle preview and vice versa, navigates
 the controller-style menu grid, rejects stale UI guards, and checks both
 restart/relaunch and the saved settings file. Captures include the live settings
@@ -65,6 +65,13 @@ Clock settings, host shortcuts, suppression of repeated toggle keys, and
 pointer hits on the 800×480 controls. Another non-Winit test runs the real host
 timer through keyboard pause and Q-to-launcher, verifying input is released
 before the launcher callback re-borrows it.
+
+The Meltdown workflow observes actual airborne cells and pooled/drained volume
+through Clock schema 4, pauses both melting and drainage, changes enablement
+without resetting material, and previews the disabled event through live
+controls. It checks reform cleanup, idle, restart and relaunch, and captures
+each visible phase. Seeded multi-aspect conservation and repeated-event cleanup
+remain deterministic core tests; UI waits use bounded state predicates.
 
 Spaceling Lab's workflow selects the scenario, renders it through both vector and
 raster paths, and verifies pause, restart, return, and relaunch with fresh

--- a/scenarios/clock/examples/meltdown_benchmark.rs
+++ b/scenarios/clock/examples/meltdown_benchmark.rs
@@ -1,0 +1,80 @@
+//! Bounded desktop/Pi workload; no display, wall-clock input or sleeping.
+use engine_common::{ClockEventKind, ClockEventProfile, Scenario};
+use scenario_clock::{ClockAction, ClockConfig, ClockReading, ClockScenario, EVENT_CATALOG};
+use std::{
+    hint::black_box,
+    time::{Duration, Instant},
+};
+
+fn summary(label: &str, values: &mut [f64]) {
+    values.sort_by(f64::total_cmp);
+    println!(
+        "{label}: p95={:.4}ms max={:.4}ms",
+        values[values.len() * 95 / 100],
+        values[values.len() - 1]
+    );
+}
+
+fn main() {
+    let duration = EVENT_CATALOG[ClockEventKind::Meltdown as usize].duration_ticks;
+    for (width, height) in [(800, 480), (480, 800), (1280, 720)] {
+        let mut steps = Vec::new();
+        let mut frames = Vec::new();
+        let mut peak_primitives = 0;
+        let mut peak_cells = 0;
+        let mut peak_columns = 0;
+        let mut max_residue = 0;
+        for seed in 0..24 {
+            let mut state = ClockScenario::init(
+                ClockConfig {
+                    aspect_ratio: width as f32 / height as f32,
+                    event_profile: ClockEventProfile::Off,
+                    ..ClockConfig::default()
+                },
+                seed,
+            );
+            ClockScenario::step(
+                &mut state,
+                &[
+                    ClockAction::set_reading(ClockReading::new(8, 8, 0).unwrap()),
+                    ClockAction::trigger_event(ClockEventKind::Meltdown),
+                ],
+                Duration::ZERO,
+            );
+            for _ in 0..duration {
+                let started = Instant::now();
+                ClockScenario::step(&mut state, &[], Duration::from_nanos(16_666_667));
+                steps.push(started.elapsed().as_secs_f64() * 1000.0);
+                let started = Instant::now();
+                let frame = black_box(ClockScenario::render_frame(&state));
+                frames.push(started.elapsed().as_secs_f64() * 1000.0);
+                peak_primitives = peak_primitives.max(
+                    frame
+                        .layers
+                        .iter()
+                        .map(|l| l.primitives.len())
+                        .sum::<usize>(),
+                );
+                if let Some(m) = state.meltdown_state() {
+                    let accounted = ((m.waiting_cells + m.airborne_cells) as u64) * 1_000_000
+                        + m.pooled_microunits
+                        + m.drained_microunits
+                        + m.reclaimed_microunits;
+                    assert!(accounted.abs_diff(m.initial_cells as u64 * 1_000_000) <= 1);
+                    peak_cells = peak_cells.max(m.waiting_cells + m.airborne_cells);
+                    peak_columns = peak_columns.max(m.water_columns);
+                    max_residue = max_residue.max(m.reclaimed_microunits);
+                }
+            }
+            assert_eq!(state.meltdown_state(), None);
+            assert_eq!((state.body_count(), state.collider_count()), (0, 0));
+        }
+        println!(
+            "{width}x{height}: 24 events, {} ticks, peak cells={peak_cells} columns={peak_columns} primitives={peak_primitives} residue={:.6} cell-volumes",
+            steps.len(),
+            max_residue as f64 / 1_000_000.0
+        );
+        summary("step", &mut steps);
+        summary("draw list (not raster/presentation)", &mut frames);
+    }
+}

--- a/scenarios/clock/src/digits.rs
+++ b/scenarios/clock/src/digits.rs
@@ -42,6 +42,8 @@ pub struct SegmentId {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SegmentRepresentation {
     Anchored,
+    /// The event owns individual lit cells; the face draws only dim anchors.
+    Disintegrated,
     Rigid {
         position: Vec2,
         angle: f32,

--- a/scenarios/clock/src/event_tests.rs
+++ b/scenarios/clock/src/event_tests.rs
@@ -9,6 +9,7 @@ fn ready(profile: ClockEventProfile, seed: u64) -> ClockState {
             events: ClockEvents {
                 falling: true,
                 color_cycle: false,
+                meltdown: false,
             },
             ..ClockConfig::default()
         },
@@ -375,7 +376,7 @@ fn mixed_events_replay_schedule_color_and_physics_exactly() {
     let reading = ClockAction::set_reading(ClockReading::new(23, 58, 0).unwrap());
     ClockScenario::step(&mut a, std::slice::from_ref(&reading), Duration::ZERO);
     ClockScenario::step(&mut b, &[reading], Duration::ZERO);
-    let mut seen = [false; 2];
+    let mut seen = [false; ClockEventKind::ALL.len()];
     for _ in 0..90 * 60 {
         ticks(&mut a, 1);
         ticks(&mut b, 1);
@@ -395,9 +396,10 @@ fn mixed_events_replay_schedule_color_and_physics_exactly() {
         );
         assert_eq!(a.segments(), b.segments());
         assert_eq!(a.palette(), b.palette());
+        assert_eq!(a.meltdown_state(), b.meltdown_state());
         if let Some(kind) = a.event_kind() {
             seen[kind as usize] = true;
         }
     }
-    assert_eq!(seen, [true, true]);
+    assert!(seen.into_iter().all(|seen| seen));
 }

--- a/scenarios/clock/src/events.rs
+++ b/scenarios/clock/src/events.rs
@@ -1,5 +1,6 @@
 mod color_cycle;
 mod falling;
+pub(crate) mod meltdown;
 #[cfg(test)]
 mod tests;
 
@@ -11,6 +12,7 @@ use color_cycle::ColorCycle;
 pub use color_cycle::{COLOR_CYCLE_TICKS, DigitPalette};
 use falling::FallingEvent;
 pub use falling::{FALLING_TICKS, REFORMING_TICKS};
+use meltdown::{DRAINING_TICKS, MELTING_TICKS, MeltdownEvent};
 
 pub const FIXED_HZ: u32 = 60;
 pub const COOLDOWN_TICKS: u64 = 120;
@@ -37,6 +39,8 @@ pub enum EventPhase {
     Falling,
     Reforming,
     Cycling,
+    Melting,
+    Draining,
 }
 
 impl EventPhase {
@@ -45,6 +49,8 @@ impl EventPhase {
             Self::Falling => "falling",
             Self::Reforming => "reforming",
             Self::Cycling => "cycling",
+            Self::Melting => "melting",
+            Self::Draining => "draining",
         }
     }
 }
@@ -85,6 +91,12 @@ pub const EVENT_CATALOG: [EventDefinition; ClockEventKind::ALL.len()] = [
         duration_ticks: COLOR_CYCLE_TICKS,
         cooldown_ticks: 15 * 60,
     },
+    EventDefinition {
+        kind: ClockEventKind::Meltdown,
+        effect: EventEffect::DigitGeometry,
+        duration_ticks: MELTING_TICKS + DRAINING_TICKS + REFORMING_TICKS,
+        cooldown_ticks: 40 * 60,
+    },
 ];
 
 pub(super) struct EventContext<'a> {
@@ -98,6 +110,7 @@ pub(super) struct EventContext<'a> {
 pub(super) enum ActiveEvent {
     Falling(FallingEvent),
     ColorCycle(ColorCycle),
+    Meltdown(Box<MeltdownEvent>),
 }
 
 impl ActiveEvent {
@@ -105,6 +118,7 @@ impl ActiveEvent {
         match kind {
             ClockEventKind::Falling => Self::Falling(FallingEvent::new(context, seed)),
             ClockEventKind::ColorCycle => Self::ColorCycle(ColorCycle::default()),
+            ClockEventKind::Meltdown => Self::Meltdown(Box::new(MeltdownEvent::new(context, seed))),
         }
     }
 
@@ -112,6 +126,7 @@ impl ActiveEvent {
         match self {
             Self::Falling(_) => ClockEventKind::Falling,
             Self::ColorCycle(_) => ClockEventKind::ColorCycle,
+            Self::Meltdown(_) => ClockEventKind::Meltdown,
         }
     }
 
@@ -120,6 +135,7 @@ impl ActiveEvent {
         match self {
             Self::Falling(event) => event.step(context),
             Self::ColorCycle(event) => event.step(),
+            Self::Meltdown(event) => event.step(context),
         }
     }
 
@@ -127,6 +143,7 @@ impl ActiveEvent {
         match self {
             Self::Falling(event) => event.phase(),
             Self::ColorCycle(_) => EventPhase::Cycling,
+            Self::Meltdown(event) => event.phase(),
         }
     }
 
@@ -134,13 +151,14 @@ impl ActiveEvent {
         match self {
             Self::Falling(event) => event.phase_tick(),
             Self::ColorCycle(event) => event.tick,
+            Self::Meltdown(event) => event.phase_tick(),
         }
     }
 
     pub fn physics_counts(&self) -> (usize, usize) {
         match self {
             Self::Falling(event) => event.physics_counts(),
-            Self::ColorCycle(_) => (0, 0),
+            Self::ColorCycle(_) | Self::Meltdown(_) => (0, 0),
         }
     }
 
@@ -152,7 +170,10 @@ impl ActiveEvent {
     }
 
     pub fn holds_lit_segments(&self) -> bool {
-        self.phase() == EventPhase::Falling
+        matches!(
+            self.phase(),
+            EventPhase::Falling | EventPhase::Melting | EventPhase::Draining
+        )
     }
 }
 

--- a/scenarios/clock/src/events/meltdown.rs
+++ b/scenarios/clock/src/events/meltdown.rs
@@ -1,0 +1,233 @@
+//! Bounded, scenario-local melting: ballistic squares feed a conservative
+//! one-dimensional pool. This is a stylized drain current, not a fluid engine.
+//! No pairwise particle collisions, growing particle lists or extra Rapier solve.
+use engine_common::ClockMeltdownState;
+use engine_core::Vec2;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+use super::{EventContext, EventPhase, REFORMING_TICKS};
+use crate::{SegmentRepresentation, digits, layout::Layout};
+
+pub const MAX_MELTDOWN_CELLS: usize = 96;
+pub const WATER_COLUMNS: usize = 128;
+pub const MELTING_TICKS: u64 = 180;
+pub const DRAINING_TICKS: u64 = 240;
+const SIDE_COLUMNS: usize = WATER_COLUMNS / 2;
+const DT: f32 = 1.0 / 60.0;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct MeltCell {
+    pub position: Vec2,
+    velocity: Vec2,
+    pub angle: f32,
+    spin: f32,
+    release_tick: u64,
+}
+
+pub(crate) struct MeltdownEvent {
+    pub tick: u64,
+    pub cells: Vec<MeltCell>,
+    /// Each side has 64 columns ending exactly at the existing drain lip.
+    pub water: [f64; WATER_COLUMNS],
+    pub stream: f32,
+    initial_cells: usize,
+    drained: f64,
+    reclaimed: f64,
+}
+
+impl MeltdownEvent {
+    pub fn new(context: EventContext<'_>, seed: u64) -> Self {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut cells = Vec::with_capacity(MAX_MELTDOWN_CELLS);
+        for segment in context.segments.iter_mut() {
+            if segment.lit {
+                for cell in digits::cells(segment.id.kind) {
+                    assert!(cells.len() < MAX_MELTDOWN_CELLS);
+                    cells.push(MeltCell {
+                        position: context.layout.cell_center(segment.id, *cell),
+                        velocity: Vec2::new(
+                            rng.random_range(-0.8..0.8),
+                            rng.random_range(0.0..1.3),
+                        ) * context.layout.pitch,
+                        angle: 0.0,
+                        spin: rng.random_range(-2.5..2.5),
+                        release_tick: rng.random_range(0..60) + (8 - cell.y) as u64 * 3,
+                    });
+                }
+            }
+            segment.representation = SegmentRepresentation::Disintegrated;
+        }
+        Self {
+            tick: 0,
+            initial_cells: cells.len(),
+            cells,
+            water: [0.0; WATER_COLUMNS],
+            stream: 0.0,
+            drained: 0.0,
+            reclaimed: 0.0,
+        }
+    }
+
+    pub fn phase(&self) -> EventPhase {
+        if self.tick < MELTING_TICKS {
+            EventPhase::Melting
+        } else if self.tick < MELTING_TICKS + DRAINING_TICKS {
+            EventPhase::Draining
+        } else {
+            EventPhase::Reforming
+        }
+    }
+
+    pub fn phase_tick(&self) -> u64 {
+        self.tick
+            - match self.phase() {
+                EventPhase::Melting => 0,
+                EventPhase::Draining => MELTING_TICKS,
+                _ => MELTING_TICKS + DRAINING_TICKS,
+            }
+    }
+
+    pub fn step(&mut self, context: EventContext<'_>) -> bool {
+        self.tick += 1;
+        if self.tick < MELTING_TICKS + DRAINING_TICKS {
+            self.step_material(context.layout);
+        } else if self.tick == MELTING_TICKS + DRAINING_TICKS {
+            // Explicitly account for residual material instead of claiming it
+            // drained. Free the cell allocation before reforming the latest face.
+            self.reclaimed = self.water.iter().sum::<f64>() + self.cells.len() as f64;
+            self.water.fill(0.0);
+            self.cells = Vec::new();
+            self.stream = 0.0;
+            for segment in context.segments.iter_mut() {
+                segment.representation = SegmentRepresentation::Reforming {
+                    position: context.layout.segment_center(segment.id),
+                    angle: 0.0,
+                    was_lit: false,
+                };
+            }
+            digits::apply_snapshot(context.segments, context.display);
+        }
+        self.tick >= MELTING_TICKS + DRAINING_TICKS + REFORMING_TICKS
+    }
+
+    fn step_material(&mut self, layout: Layout) {
+        let mut deposited = [0.0; WATER_COLUMNS];
+        let mut newly_drained = 0.0;
+        let half = layout.pitch * 0.4;
+        self.cells.retain_mut(|cell| {
+            if self.tick <= cell.release_tick {
+                return true;
+            }
+            cell.velocity.y -= 400.0 * DT;
+            cell.position += cell.velocity * DT;
+            cell.angle += cell.spin * DT;
+            // Use the square's conservative rotating extent for side walls.
+            let extent = half * (cell.angle.sin().abs() + cell.angle.cos().abs());
+            let x = cell
+                .position
+                .x
+                .clamp(layout.bounds_min.x + extent, layout.bounds_max.x - extent);
+            if x != cell.position.x {
+                cell.position.x = x;
+                cell.velocity.x *= -0.35;
+            }
+            if cell.position.y - extent <= layout.floor_y
+                && cell.position.x.abs() + extent >= layout.drain_half_width()
+            {
+                // Spread one cell's volume over its footprint at first impact.
+                for offset in [-0.6, -0.2, 0.2, 0.6] {
+                    let x = cell.position.x + offset * half;
+                    if x.abs() < layout.drain_half_width() {
+                        newly_drained += 0.25;
+                    } else {
+                        deposited[Self::column_at(layout, x)] += 0.25;
+                    }
+                }
+                false
+            } else if cell.position.y + extent < layout.bounds_min.y {
+                newly_drained += 1.0;
+                false
+            } else {
+                true
+            }
+        });
+        for (water, added) in self.water.iter_mut().zip(deposited) {
+            *water += added;
+        }
+        // Two fixed conservative passes: diffuse toward lower neighboring
+        // columns, then advect 22% toward the drain. Outflows never exceed the
+        // donor's volume, even with a concentrated impact. Cost is O(128).
+        for _ in 0..2 {
+            let mut next = self.water;
+            for i in 0..WATER_COLUMNS - 1 {
+                if i == SIDE_COLUMNS - 1 {
+                    continue;
+                }
+                let flow = (self.water[i] - self.water[i + 1]) * 0.16;
+                next[i] -= flow;
+                next[i + 1] += flow;
+            }
+            self.water = next;
+            for i in 0..WATER_COLUMNS {
+                let flow = self.water[i] * 0.22;
+                next[i] -= flow;
+                if i == SIDE_COLUMNS - 1 || i == SIDE_COLUMNS {
+                    newly_drained += flow;
+                } else {
+                    next[if i < SIDE_COLUMNS { i + 1 } else { i - 1 }] += flow;
+                }
+            }
+            self.water = next;
+        }
+        self.drained += newly_drained;
+        self.stream = (self.stream * 0.84 + newly_drained as f32 * 0.8).min(1.0);
+    }
+
+    pub fn column_width(layout: Layout) -> f32 {
+        (layout.bounds_max.x - layout.drain_half_width()) / SIDE_COLUMNS as f32
+    }
+
+    pub fn column_left(layout: Layout, index: usize) -> f32 {
+        let width = Self::column_width(layout);
+        if index < SIDE_COLUMNS {
+            layout.bounds_min.x + index as f32 * width
+        } else {
+            layout.drain_half_width() + (index - SIDE_COLUMNS) as f32 * width
+        }
+    }
+
+    fn column_at(layout: Layout, x: f32) -> usize {
+        let origin = if x < 0.0 {
+            layout.bounds_min.x
+        } else {
+            layout.drain_half_width()
+        };
+        let local = ((x - origin) / Self::column_width(layout))
+            .clamp(0.0, (SIDE_COLUMNS - 1) as f32) as usize;
+        local + if x < 0.0 { 0 } else { SIDE_COLUMNS }
+    }
+
+    pub fn diagnostics(&self) -> ClockMeltdownState {
+        let waiting = self
+            .cells
+            .iter()
+            .filter(|cell| self.tick <= cell.release_tick)
+            .count();
+        ClockMeltdownState {
+            initial_cells: self.initial_cells,
+            waiting_cells: waiting,
+            airborne_cells: self.cells.len() - waiting,
+            water_columns: self
+                .water
+                .iter()
+                .filter(|volume| **volume > 0.000_001)
+                .count(),
+            pooled_microunits: (self.water.iter().sum::<f64>() * 1_000_000.0).round() as u64,
+            drained_microunits: (self.drained * 1_000_000.0).round() as u64,
+            reclaimed_microunits: (self.reclaimed * 1_000_000.0).round() as u64,
+        }
+    }
+}

--- a/scenarios/clock/src/events/meltdown/tests.rs
+++ b/scenarios/clock/src/events/meltdown/tests.rs
@@ -1,0 +1,217 @@
+use super::*;
+use crate::{ClockAction, ClockConfig, ClockReading, ClockScenario, ClockState};
+use engine_common::{ClockEventKind, ClockEventProfile, ClockSettings, ClockTimeFormat, Scenario};
+use std::time::Duration;
+
+fn ready(aspect: f32, seed: u64) -> ClockState {
+    let mut state = ClockScenario::init(
+        ClockConfig {
+            aspect_ratio: aspect,
+            event_profile: ClockEventProfile::Off,
+            ..ClockConfig::default()
+        },
+        seed,
+    );
+    ClockScenario::step(
+        &mut state,
+        &[
+            ClockAction::set_reading(ClockReading::new(8, 8, 0).unwrap()),
+            ClockAction::preview_event(ClockEventKind::Meltdown),
+        ],
+        Duration::ZERO,
+    );
+    state
+}
+
+fn tick(state: &mut ClockState) {
+    ClockScenario::step(state, &[], Duration::from_secs_f64(1.0 / 60.0));
+}
+
+fn assert_volume(state: &ClockState) {
+    let stats = state.meltdown_state().unwrap();
+    let accounted = ((stats.waiting_cells + stats.airborne_cells) as u64) * 1_000_000
+        + stats.pooled_microunits
+        + stats.drained_microunits
+        + stats.reclaimed_microunits;
+    assert!(
+        accounted.abs_diff(stats.initial_cells as u64 * 1_000_000) <= 1,
+        "{stats:?}"
+    );
+    assert!(stats.initial_cells <= MAX_MELTDOWN_CELLS);
+    assert!(stats.water_columns <= WATER_COLUMNS);
+    assert_eq!((state.body_count(), state.collider_count()), (0, 0));
+    let Some(crate::events::ActiveEvent::Meltdown(event)) = &state.active_event else {
+        panic!()
+    };
+    assert!(event.water.iter().all(|v| v.is_finite() && *v >= 0.0));
+    assert!(
+        event
+            .cells
+            .iter()
+            .all(|c| c.position.x.is_finite() && c.position.y.is_finite())
+    );
+}
+
+#[test]
+fn cells_pool_drain_and_reform_with_conserved_bounded_material_at_every_aspect() {
+    for aspect in [0.25, 0.75, 800.0 / 480.0, 4.0] {
+        for seed in [0, 42, 4242] {
+            let mut state = ready(aspect, seed);
+            let initial = state.meltdown_state().unwrap().initial_cells;
+            assert!(initial > 60);
+            let mut pooled = false;
+            let mut falling = false;
+            for _ in 0..MELTING_TICKS + DRAINING_TICKS {
+                assert_volume(&state);
+                let s = state.meltdown_state().unwrap();
+                pooled |= s.pooled_microunits > 1_000_000;
+                falling |= s.airborne_cells > 0;
+                tick(&mut state);
+            }
+            assert!(pooled && falling);
+            assert_eq!(state.event_phase(), Some(EventPhase::Reforming));
+            assert_volume(&state);
+            let stats = state.meltdown_state().unwrap();
+            assert_eq!(
+                (
+                    stats.waiting_cells,
+                    stats.airborne_cells,
+                    stats.water_columns
+                ),
+                (0, 0, 0)
+            );
+            assert!(
+                stats.drained_microunits > initial as u64 * 990_000,
+                "{aspect}: {stats:?}"
+            );
+            for _ in 0..REFORMING_TICKS {
+                tick(&mut state);
+            }
+            assert_eq!(state.meltdown_state(), None);
+            assert!(
+                state
+                    .segments()
+                    .iter()
+                    .all(|s| s.representation == SegmentRepresentation::Anchored)
+            );
+        }
+    }
+}
+
+#[test]
+fn pool_passes_are_symmetric_nonnegative_and_conservative() {
+    let mut state = ready(800.0 / 480.0, 0);
+    let Some(crate::events::ActiveEvent::Meltdown(event)) = &mut state.active_event else {
+        panic!()
+    };
+    event.cells.clear();
+    event.water[10] = 48.0;
+    event.water[WATER_COLUMNS - 11] = 48.0;
+    event.initial_cells = 96;
+    for _ in 0..300 {
+        event.step_material(Layout::new(800.0 / 480.0));
+        assert!(event.water.iter().all(|v| *v >= 0.0));
+        for i in 0..SIDE_COLUMNS {
+            assert!((event.water[i] - event.water[WATER_COLUMNS - 1 - i]).abs() < 1e-10);
+        }
+        assert!((event.water.iter().sum::<f64>() + event.drained - 96.0).abs() < 1e-9);
+    }
+    assert!(event.drained > 95.9);
+}
+
+#[test]
+fn pause_settings_time_corrections_and_resize_preserve_or_clean_the_right_state() {
+    let mut state = ready(800.0 / 480.0, 4);
+    for _ in 0..100 {
+        tick(&mut state);
+    }
+    let material = state.meltdown_state();
+    let frame = ClockScenario::render_frame(&state);
+    ClockScenario::step(&mut state, &[], Duration::ZERO);
+    assert_eq!(ClockScenario::render_frame(&state), frame);
+    let settings = ClockSettings {
+        time_format: ClockTimeFormat::TwelveHour,
+        event_profile: ClockEventProfile::Off,
+        ..state.settings()
+    };
+    ClockScenario::step(
+        &mut state,
+        &[
+            ClockAction::configure(settings),
+            ClockAction::set_reading(ClockReading::new(0, 1, 0).unwrap()),
+        ],
+        Duration::ZERO,
+    );
+    assert_eq!(state.meltdown_state(), material);
+    assert_eq!(state.phase_tick(), 100);
+    assert_eq!(state.display().digits, [Some(1), Some(2), Some(0), Some(1)]);
+    for _ in 100..MELTING_TICKS + DRAINING_TICKS + REFORMING_TICKS {
+        tick(&mut state);
+    }
+    let mut reference = ClockScenario::init(
+        ClockConfig {
+            time_format: ClockTimeFormat::TwelveHour,
+            event_profile: ClockEventProfile::Off,
+            ..ClockConfig::default()
+        },
+        4,
+    );
+    ClockScenario::step(
+        &mut reference,
+        &[ClockAction::set_reading(
+            ClockReading::new(0, 1, 0).unwrap(),
+        )],
+        Duration::ZERO,
+    );
+    assert_eq!(
+        ClockScenario::render_frame(&state),
+        ClockScenario::render_frame(&reference)
+    );
+    for elapsed in [20, 210, 450] {
+        ClockScenario::step(
+            &mut state,
+            &[ClockAction::preview_event(ClockEventKind::Meltdown)],
+            Duration::ZERO,
+        );
+        for _ in 0..elapsed {
+            tick(&mut state);
+        }
+        state.set_aspect_ratio(if state.aspect_ratio() == 1.0 {
+            0.75
+        } else {
+            1.0
+        });
+        assert_eq!(state.meltdown_state(), None);
+        assert_eq!(state.event_kind(), None);
+    }
+}
+
+#[test]
+fn repeated_previews_and_seeded_motion_are_identical_and_release_material() {
+    let mut a = ready(800.0 / 480.0, 42);
+    let mut b = ready(800.0 / 480.0, 42);
+    for cycle in 0..12 {
+        for kind in ClockEventKind::ALL {
+            for state in [&mut a, &mut b] {
+                ClockScenario::step(state, &[ClockAction::preview_event(kind)], Duration::ZERO);
+            }
+            for n in 0..(100 + cycle * 31) {
+                tick(&mut a);
+                tick(&mut b);
+                assert_eq!(a.meltdown_state(), b.meltdown_state());
+                if a.meltdown_state().is_some() {
+                    assert_volume(&a);
+                }
+                if n % 30 == 0 {
+                    assert_eq!(
+                        ClockScenario::render_frame(&a),
+                        ClockScenario::render_frame(&b)
+                    );
+                }
+            }
+            if kind != ClockEventKind::Meltdown {
+                assert_eq!(a.meltdown_state(), None);
+            }
+        }
+    }
+}

--- a/scenarios/clock/src/events/tests.rs
+++ b/scenarios/clock/src/events/tests.rs
@@ -45,6 +45,7 @@ fn automatic_selection_respects_enablement_and_each_events_reuse_delay() {
         let enabled = ClockEvents {
             falling: kind == ClockEventKind::Falling,
             color_cycle: kind == ClockEventKind::ColorCycle,
+            meltdown: kind == ClockEventKind::Meltdown,
         };
         let mut schedule = EventSchedule::new(ClockEventProfile::Demo, enabled, 2);
         let wait = schedule.next_event_tick.unwrap();
@@ -76,6 +77,7 @@ fn off_and_an_empty_enabled_set_never_schedule_automatic_events() {
             ClockEvents {
                 falling: false,
                 color_cycle: false,
+                meltdown: false,
             },
         ),
     ] {

--- a/scenarios/clock/src/lib.rs
+++ b/scenarios/clock/src/lib.rs
@@ -21,6 +21,7 @@ use engine_common::{
     Action, ClockEventKind, ClockEventProfile, ClockEvents, ClockSettings, ClockTimeFormat,
     Observation, RenderFrame, Scenario, StepResult, TickModel,
 };
+pub use events::meltdown::{DRAINING_TICKS, MAX_MELTDOWN_CELLS, MELTING_TICKS, WATER_COLUMNS};
 use events::{ActiveEvent, EventContext, EventSchedule};
 pub use events::{
     COLOR_CYCLE_TICKS, COOLDOWN_TICKS, DigitPalette, EVENT_CATALOG, EventDefinition, EventEffect,
@@ -92,8 +93,11 @@ impl ClockAction {
             ClockEventProfile::Calm => 1,
             ClockEventProfile::Demo => 2,
         });
-        payload
-            .push(u8::from(settings.events.falling) | (u8::from(settings.events.color_cycle) << 1));
+        payload.push(
+            u8::from(settings.events.falling)
+                | (u8::from(settings.events.color_cycle) << 1)
+                | (u8::from(settings.events.meltdown) << 2),
+        );
         Action::scenario(CLOCK_ACTION_CONFIGURE, payload)
     }
 
@@ -136,7 +140,7 @@ impl ClockAction {
                 .into_iter()
                 .find(|kind| *kind as u8 == payload[2])
                 .map(Self::PreviewEvent),
-            (CLOCK_ACTION_CONFIGURE, 5) if payload[4] <= 3 => {
+            (CLOCK_ACTION_CONFIGURE, 5) if payload[4] <= 7 => {
                 Some(Self::Configure(ClockSettings {
                     time_format: match payload[2] {
                         12 => ClockTimeFormat::TwelveHour,
@@ -152,6 +156,7 @@ impl ClockAction {
                     events: ClockEvents {
                         falling: payload[4] & 1 != 0,
                         color_cycle: payload[4] & 2 != 0,
+                        meltdown: payload[4] & 4 != 0,
                     },
                 }))
             }
@@ -298,6 +303,12 @@ impl ClockState {
         self.active_event
             .as_ref()
             .map_or(0, |event| event.physics_counts().1)
+    }
+    pub fn meltdown_state(&self) -> Option<engine_common::ClockMeltdownState> {
+        match self.active_event.as_ref()? {
+            ActiveEvent::Meltdown(event) => Some(event.diagnostics()),
+            _ => None,
+        }
     }
     pub fn can_trigger_event(&self) -> bool {
         self.reading.is_some() && self.lifecycle() == EventLifecycle::Idle

--- a/scenarios/clock/src/live_tests.rs
+++ b/scenarios/clock/src/live_tests.rs
@@ -26,13 +26,14 @@ fn settings_actions_round_trip_all_values_and_reject_malformed_payloads() {
             ClockEventProfile::Calm,
             ClockEventProfile::Demo,
         ] {
-            for bits in 0..4 {
+            for bits in 0..8 {
                 let settings = ClockSettings {
                     time_format,
                     event_profile,
                     events: ClockEvents {
                         falling: bits & 1 != 0,
                         color_cycle: bits & 2 != 0,
+                        meltdown: bits & 4 != 0,
                     },
                 };
                 assert_eq!(
@@ -48,7 +49,7 @@ fn settings_actions_round_trip_all_values_and_reject_malformed_payloads() {
         vec![2, 0, 24, 1, 3],
         vec![1, 0, 13, 1, 3],
         vec![1, 0, 24, 3, 3],
-        vec![1, 0, 24, 1, 4],
+        vec![1, 0, 24, 1, 8],
         vec![1, 0, 24, 1, 3, 0],
     ] {
         assert_eq!(
@@ -62,7 +63,7 @@ fn settings_actions_round_trip_all_values_and_reject_malformed_payloads() {
             Some(ClockAction::PreviewEvent(kind))
         );
     }
-    for payload in [vec![1, 0], vec![1, 0, 2], vec![2, 0, 0], vec![1, 0, 0, 0]] {
+    for payload in [vec![1, 0], vec![1, 0, 3], vec![2, 0, 0], vec![1, 0, 0, 0]] {
         assert_eq!(
             ClockAction::decode(&Action::scenario(CLOCK_ACTION_PREVIEW_EVENT, payload)),
             None
@@ -87,6 +88,7 @@ fn live_settings_preserve_falling_physics_and_reform_to_the_new_format() {
         events: ClockEvents {
             falling: false,
             color_cycle: false,
+            meltdown: false,
         },
     };
     ClockScenario::step(

--- a/scenarios/clock/src/render.rs
+++ b/scenarios/clock/src/render.rs
@@ -32,6 +32,9 @@ pub fn render_frame(state: &ClockState) -> RenderFrame {
     );
     render_floor(&mut frame, layout);
     render_segments(&mut frame, state, layout);
+    if let Some(crate::events::ActiveEvent::Meltdown(event)) = &state.active_event {
+        render_meltdown(&mut frame, event, layout);
+    }
     render_colon(&mut frame, state, layout);
     render_meridiem(&mut frame, state, layout);
     frame
@@ -84,6 +87,7 @@ fn render_segments(frame: &mut RenderFrame, state: &ClockState, layout: Layout) 
         let anchor = layout.segment_center(segment.id);
         let (position, angle, brightness) = match segment.representation {
             SegmentRepresentation::Anchored => (anchor, 0.0, f32::from(segment.lit)),
+            SegmentRepresentation::Disintegrated => (anchor, 0.0, 0.0),
             SegmentRepresentation::Rigid { position, angle } => (position, angle, 1.0),
             SegmentRepresentation::Reforming {
                 position,
@@ -113,6 +117,75 @@ fn render_segments(frame: &mut RenderFrame, state: &ClockState, layout: Layout) 
                     );
                 }
             }
+        }
+    }
+}
+
+fn render_meltdown(
+    frame: &mut RenderFrame,
+    event: &crate::events::meltdown::MeltdownEvent,
+    layout: Layout,
+) {
+    use crate::events::meltdown::MeltdownEvent;
+    let water_color = RenderColor::rgb(0.08, 0.55, 0.85);
+    let edge_color = RenderColor::rgb(0.36, 0.91, 1.0);
+    for cell in &event.cells {
+        render_square(
+            frame,
+            cell.position,
+            layout.pitch,
+            cell.angle,
+            1.0,
+            DigitPalette::default(),
+        );
+    }
+    let width = MeltdownEvent::column_width(layout);
+    let cell_area = (layout.pitch * 0.8).powi(2);
+    for (index, volume) in event.water.iter().enumerate() {
+        let height = *volume as f32 * cell_area / width;
+        if height < 0.25 {
+            continue;
+        }
+        let left = MeltdownEvent::column_left(layout, index);
+        let top = layout.floor_y + height;
+        frame.push_primitive(
+            ACTIVE_CELL_LAYER,
+            rectangle(
+                RenderPoint::new(left, layout.floor_y),
+                RenderPoint::new(left + width, top),
+                water_color,
+                None,
+            ),
+        );
+        frame.push_primitive(
+            ACTIVE_CELL_LAYER,
+            rectangle(
+                RenderPoint::new(left, top - height.min(1.8)),
+                RenderPoint::new(left + width, top),
+                edge_color,
+                None,
+            ),
+        );
+    }
+    // Bounded visual stream; it represents already-accounted drained volume.
+    // No extra particles are spawned and no water is reintroduced to the pool.
+    if event.stream > 0.005 {
+        let lip = layout.drain_half_width();
+        let thickness = layout.pitch * 0.35 * event.stream.sqrt();
+        for side in [-1.0, 1.0] {
+            let x = side * (lip - thickness * 0.5);
+            frame.push_primitive(
+                ACTIVE_CELL_LAYER,
+                rectangle(
+                    RenderPoint::new(x - thickness * 0.5, layout.bounds_min.y),
+                    RenderPoint::new(x + thickness * 0.5, layout.floor_y),
+                    RenderColor {
+                        a: event.stream.sqrt(),
+                        ..water_color
+                    },
+                    None,
+                ),
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements the Meltdown milestone of #19; the remaining Clock events stay open.

- Release illuminated digit cells with seeded delays, gravity, spin, and wall reflection. Floor contact turns cells into water that pools and drains through the center opening; the latest time reforms afterward.
- Keep the effect bounded to 96 cells and 128 water columns, with no Rapier bodies or growing particle lists. The conservative pool uses neighbor leveling and a stylized inward current, not a general fluid solver. Residual cleanup is accounted for separately from drainage.
- Integrate Meltdown with the shared scheduler, persisted launcher/live switches, controller navigation, and disabled-event previews. Preserve pause, time correction, resize, preview replacement, restart, and relaunch behavior.
- Add public material diagnostics, phase-aware CLI controls, rendering checks, documentation, and a reproducible release benchmark.

## Compatibility and scope

- Clock control schema advances to **4**; use matching client and CLI builds.
- Existing event IDs and saved switches retain their meanings. Missing Meltdown switches default to On; the Off profile still suppresses all automatic events.
- This PR contains only commit `96f9d95`. The Duck follow-up is separate and is not included.
- No Pi deployment or testing was performed for this slice; local playtesting was approved by the user.

## Validation

- `cargo test --locked --workspace --all-targets --quiet`: **869 passed**, with 15 display-dependent workflows ignored.
- All **five Clock UI workflows** passed when run explicitly on the local display, covering live settings, previews, pause/resume, restart/relaunch, and public state.
- Deterministic multi-aspect tests cover conservation, nonnegative water, more than 99% drainage before reform, latest-time recovery, and repeated cleanup.
- Raster checks at 800×480, 480×800, and 1280×720 verify visible water and a clean recovered face; the same draw lists reach vector presentation. Screenshot review and an 800×480 pointer test verify the settings layout.
- Strict Clippy passed for Clock/common/control/CLI; client Clippy completed with existing unrelated warnings. Formatting and diff checks passed.
- The 72-event desktop release benchmark reported step p95 0.0009 ms and draw-list p95 0.0042–0.0043 ms. These exclude rasterization, presentation, and host work and are not Pi/FPS measurements.

## Try it

Choose **Clock Controls → Preview Event: Meltdown → Preview & Resume**, or from idle Clock gameplay:

```sh
spacewars-cli clock trigger meltdown --json
spacewars-cli clock state --json
```
