### PR TITLE
Optimize Clock and shared software presentation performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           name: ui-functional-test-artifacts
           path: target/functional-test-artifacts
           if-no-files-found: ignore
-      - name: Test vendored LinuxKMS touch transforms
+      - name: Test vendored LinuxKMS input and software rendering
         run: cargo test --locked --manifest-path vendor/i-slint-backend-linuxkms/Cargo.toml --features renderer-software --lib
 
   spacewars-ai-regression:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,8 @@ dependencies = [
  "engine-core",
  "engine-nes",
  "gilrs",
+ "i-slint-backend-linuxkms",
+ "i-slint-core",
  "png 0.17.16",
  "scenario-clock",
  "scenario-falling",

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -32,6 +32,8 @@ gilrs = { workspace = true }
 png = { workspace = true }
 sha2 = { workspace = true }
 slint = { workspace = true }
+# Local, opt-in software-renderer observation hooks for the presentation lab.
+i-slint-core = { version = "=1.13.1", default-features = false, features = ["experimental", "software-renderer"] }
 tempfile = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
@@ -44,6 +46,10 @@ slint-build = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Public diagnostics from our existing vendored LinuxKMS backend, on its UI thread.
+i-slint-backend-linuxkms = { version = "=1.13.1", default-features = false, optional = true }
+
 [features]
 default = ["desktop"]
 desktop = [
@@ -55,6 +61,7 @@ desktop = [
     "slint/unstable-winit-030",
 ]
 pi-kiosk = [
+    "dep:i-slint-backend-linuxkms",
     "slint/backend-linuxkms",
     "slint/compat-1-2",
     "slint/software-renderer-systemfonts",

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -409,6 +409,8 @@ fn handle_request(
         },
         ControlCommand::Status => {
             let mut diagnostics = window.get_runtime_diagnostics().to_string();
+            #[cfg(all(target_os = "linux", feature = "pi-kiosk"))]
+            diagnostics.push_str(&i_slint_backend_linuxkms::profiling::diagnostics());
             let launch = window.get_launcher_diagnostics();
             if !launch.is_empty() {
                 diagnostics.push('\n');

--- a/crates/engine-client/src/keyboard_tests.rs
+++ b/crates/engine-client/src/keyboard_tests.rs
@@ -173,6 +173,59 @@ fn click(window: &MainWindow, x: f32, y: f32) {
 }
 
 #[test]
+fn recreated_launcher_buttons_do_not_retain_pressed_state_or_lose_shortcuts() {
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let window = MainWindow::new().unwrap();
+    window
+        .window()
+        .set_size(slint::LogicalSize::new(800.0, 480.0));
+    let input = Rc::new(RefCell::new(input::ClientInput::default()));
+    install_ui_navigation(&window);
+    install_keyboard_navigation(&window, Rc::clone(&input));
+    let starts = Rc::new(Cell::new(0));
+    let started = Rc::clone(&starts);
+    window.on_launcher_start_game(move || started.set(started.get() + 1));
+    window.show().unwrap();
+
+    for cycle in 0..3 {
+        window.set_launcher_visible(true);
+        window.set_launcher_focus_index(0);
+        slint::platform::update_timers_and_animations();
+        let position = slint::LogicalPosition::new(220.0, 278.0);
+        window.window().dispatch_event(WindowEvent::PointerPressed {
+            position,
+            button: slint::platform::PointerEventButton::Left,
+        });
+        // Remove the menu while its Start button has a pointer grab. A later
+        // release must not activate the old button or latch the recreated one.
+        window.set_launcher_visible(false);
+        slint::platform::update_timers_and_animations();
+        // This headless adapter has no render loop. Commit the conditional
+        // tree removal before testing input against the newly displayed tree.
+        window.window().take_snapshot().unwrap();
+        window
+            .window()
+            .dispatch_event(WindowEvent::PointerReleased {
+                position,
+                button: slint::platform::PointerEventButton::Left,
+            });
+        assert_eq!(starts.get(), cycle * 2);
+
+        window.set_launcher_visible(true);
+        click(&window, 220.0, 278.0);
+        assert_eq!(starts.get(), cycle * 2 + 1);
+        window.set_launcher_focus_index(0);
+        key(&window, Key::DownArrow);
+        assert_eq!(window.get_launcher_focus_index(), 1);
+        key(&window, Key::Return);
+        assert_eq!(starts.get(), cycle * 2 + 2);
+        window.set_launcher_visible(false);
+        key(&window, "p");
+        assert!(input.borrow_mut().take_pause_requested());
+    }
+}
+
+#[test]
 fn sound_keyboard_touch_and_menu_actions_share_persistent_controls() {
     slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
     let window = MainWindow::new().unwrap();

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -17,6 +17,7 @@ mod native_video;
 mod nes_audio;
 mod nes_realtime;
 mod nes_roms;
+mod presentation_probe;
 mod raster;
 mod render;
 mod settings;
@@ -25,6 +26,8 @@ mod sound_controls;
 mod ui_activation;
 mod ui_inventory;
 mod ui_navigation;
+#[cfg(test)]
+mod ui_render_tests;
 
 use std::cell::RefCell;
 use std::env;
@@ -69,6 +72,9 @@ type SharedNesRomCatalog = Rc<RefCell<nes_roms::NesRomCatalog>>;
 #[derive(Parser, Debug)]
 #[command(name = "engine-client", about = "Spacewars scenario host")]
 struct Args {
+    #[command(flatten)]
+    presentation: presentation_probe::Options,
+
     /// Scenario to load.
     #[arg(long)]
     scenario: Option<String>,
@@ -304,6 +310,16 @@ struct EffectiveLaunch {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
+
+    // This experiment must not load/write settings, open a control socket,
+    // initialize audio/input, or create a desktop/KMS display connection.
+    if args.presentation.benchmark_presentation {
+        return presentation_probe::run(
+            &args.presentation,
+            args.benchmark_width,
+            args.benchmark_height,
+        );
+    }
 
     let settings_path = settings_path_from_args(&args)?;
     let loaded_settings = settings::load_settings(&settings_path)?;
@@ -2221,6 +2237,7 @@ mod tests {
 
     fn base_args() -> Args {
         Args {
+            presentation: presentation_probe::Options::default(),
             scenario: None,
             rom: None,
             seed: None,

--- a/crates/engine-client/src/presentation_probe.rs
+++ b/crates/engine-client/src/presentation_probe.rs
@@ -1,0 +1,381 @@
+//! Fixed-image software presentation lab. No display, real-time simulation,
+//! input, settings, frame pacing, or scanout memory participates in these draws.
+
+use engine_common::{ClockEventProfile, Scenario};
+use i_slint_core::software_renderer::{
+    DRAW_DIAGNOSTIC_COUNT, DrawDiagnostic, DrawDiagnosticObserver, MinimalSoftwareWindow,
+    PhysicalRegion, PremultipliedRgbaColor, RepaintBufferType, SoftwareRenderer, TargetPixel,
+    TargetPixelBuffer,
+};
+use slint::platform::{Platform, PlatformError, WindowAdapter};
+use slint::{ComponentHandle, Image, PhysicalSize};
+use std::{
+    cell::RefCell,
+    hint::black_box,
+    rc::Rc,
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Default, clap::Args)]
+pub struct Options {
+    /// Compare frozen images in a bare window and the full UI; print CSV, without a display.
+    #[arg(long, conflicts_with_all = ["scenario", "rom", "benchmark", "benchmark_headless", "debug_render", "debug_triangles", "kiosk", "touch_test", "benchmark_report", "renderer", "raster_scale"])]
+    pub benchmark_presentation: bool,
+    /// Draws per measured block (each UI gets the same workload).
+    #[arg(long, default_value_t = 120, value_parser = clap::value_parser!(u32).range(1..=10000))]
+    presentation_frames: u32,
+    /// Paired blocks, alternating which UI runs first.
+    #[arg(long, default_value_t = 4, value_parser = clap::value_parser!(u32).range(1..=20))]
+    presentation_repeats: u32,
+    /// Time nested operations; off by default so instrumentation overhead can be compared.
+    #[arg(long)]
+    presentation_detail: bool,
+    /// Publish a fresh identical image before every draw, outside the draw timer.
+    #[arg(long)]
+    presentation_republish: bool,
+}
+
+slint::slint! {
+    export component ImageOnlyWindow inherits Window {
+        in property <image> frame;
+        in property <bool> native;
+        in property <int> crop-y;
+        in property <int> crop-width: frame.width;
+        in property <int> crop-height: frame.height;
+        background: #050514;
+        Image {
+            width: parent.width; height: parent.height;
+            source: root.frame;
+            source-clip-y: root.crop-y;
+            source-clip-width: root.crop-width;
+            source-clip-height: root.crop-height;
+            image-fit: root.native ? contain : fill;
+            image-rendering: pixelated;
+        }
+    }
+}
+
+struct ProbePlatform(Rc<RefCell<Vec<Rc<MinimalSoftwareWindow>>>>);
+impl Platform for ProbePlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        let window = MinimalSoftwareWindow::new(RepaintBufferType::NewBuffer);
+        self.0.borrow_mut().push(window.clone());
+        Ok(window)
+    }
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+struct Xrgb(u32);
+impl TargetPixel for Xrgb {
+    fn blend(&mut self, color: PremultipliedRgbaColor) {
+        let mut pixel = PremultipliedRgbaColor {
+            red: (self.0 >> 16) as u8,
+            green: (self.0 >> 8) as u8,
+            blue: self.0 as u8,
+            alpha: (self.0 >> 24) as u8,
+        };
+        pixel.blend(color);
+        self.0 = u32::from(pixel.alpha) << 24
+            | u32::from(pixel.red) << 16
+            | u32::from(pixel.green) << 8
+            | u32::from(pixel.blue);
+    }
+    fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        Self(0xff000000 | u32::from(r) << 16 | u32::from(g) << 8 | u32::from(b))
+    }
+    fn background() -> Self {
+        Self(0)
+    }
+}
+
+struct Buffer<'a> {
+    pixels: &'a mut [Xrgb],
+    stride: usize,
+    detail: bool,
+}
+impl TargetPixelBuffer for Buffer<'_> {
+    type TargetPixel = Xrgb;
+    fn line_slice(&mut self, y: usize) -> &mut [Xrgb] {
+        &mut self.pixels[y * self.stride..(y + 1) * self.stride]
+    }
+    fn num_lines(&self) -> usize {
+        self.pixels.len() / self.stride
+    }
+    fn diagnostic_observer(&self) -> Option<DrawDiagnosticObserver> {
+        self.detail.then_some(observe)
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct Measurement {
+    start: Option<Instant>,
+    depth: usize,
+    calls: u64,
+    elapsed: Duration,
+}
+thread_local! {
+    static MEASUREMENTS: RefCell<[Measurement; DRAW_DIAGNOSTIC_COUNT]> =
+        RefCell::new([Measurement::default(); DRAW_DIAGNOSTIC_COUNT]);
+}
+fn observe(operation: DrawDiagnostic, begin: bool) {
+    MEASUREMENTS.with(|measurements| {
+        let mut measurements = measurements.borrow_mut();
+        let m = &mut measurements[operation as usize];
+        if begin {
+            m.calls += 1;
+            if m.depth == 0 {
+                m.start = Some(Instant::now());
+            }
+            m.depth += 1;
+        } else {
+            assert!(m.depth > 0, "unbalanced diagnostic span");
+            m.depth -= 1;
+            if m.depth == 0 {
+                m.elapsed += m.start.take().unwrap().elapsed();
+            }
+        }
+    });
+}
+
+struct Fixture {
+    name: &'static str,
+    image: Image,
+    native: bool,
+    crop_y: i32,
+    crop_width: i32,
+    crop_height: i32,
+}
+
+fn fixtures() -> Vec<Fixture> {
+    let mut fixtures = vec![Fixture {
+        name: "background",
+        image: Image::default(),
+        native: false,
+        crop_y: 0,
+        crop_width: 0,
+        crop_height: 0,
+    }];
+    for (name, width, height) in [("clock-1024", 1024, 768), ("clock-2048", 2048, 1536)] {
+        let mut state = scenario_clock::ClockScenario::init(
+            scenario_clock::ClockConfig {
+                event_profile: ClockEventProfile::Off,
+                aspect_ratio: 4.0 / 3.0,
+                ..Default::default()
+            },
+            0,
+        );
+        scenario_clock::ClockScenario::step(
+            &mut state,
+            &[scenario_clock::ClockAction::set_reading(
+                scenario_clock::ClockReading::new(8, 8, 0).unwrap(),
+            )],
+            Duration::ZERO,
+        );
+        let image = crate::raster::RasterRenderer::new().image_from_frames_with_layout(
+            &[scenario_clock::ClockScenario::render_frame(&state)],
+            crate::render::Viewport::new(width as f32, height as f32),
+            crate::render::FrameLayout::EqualHorizontal,
+            Default::default(),
+        );
+        fixtures.push(Fixture {
+            name,
+            image,
+            native: false,
+            crop_y: 0,
+            crop_width: width,
+            crop_height: height,
+        });
+    }
+    // Boot the bundled, redistributable cartridge once, then freeze its title frame.
+    let mut falling = scenario_falling::FallingScenario::init(Default::default(), 0);
+    for _ in 0..180 {
+        scenario_falling::FallingScenario::step(
+            &mut falling,
+            &[],
+            Duration::from_secs_f64(1.0 / 60.0),
+        );
+    }
+    let video = falling.native_video_frame();
+    let crop = video.visible_crop;
+    let image = crate::native_video::NativeVideoRenderer::new()
+        .present(video)
+        .unwrap()
+        .image;
+    fixtures.push(Fixture {
+        name: "falling-256",
+        image,
+        native: true,
+        crop_y: crop.y as i32,
+        crop_width: crop.width as i32,
+        crop_height: crop.height as i32,
+    });
+    fixtures
+}
+
+fn fresh_image(image: &Image) -> Image {
+    image.to_rgb8().map_or_else(Image::default, |pixels| {
+        Image::from_rgb8(slint::SharedPixelBuffer::clone_from_slice(
+            pixels.as_bytes(),
+            pixels.width(),
+            pixels.height(),
+        ))
+    })
+}
+
+fn publish(
+    bare: &ImageOnlyWindow,
+    full: &crate::MainWindow,
+    fixture: &Fixture,
+    image: Image,
+    is_bare: bool,
+) {
+    if is_bare {
+        bare.set_frame(image);
+    } else if fixture.native {
+        full.set_native_video_frame(image);
+    } else {
+        full.set_raster_frame(image);
+    }
+}
+
+fn render(
+    window: &MinimalSoftwareWindow,
+    pixels: &mut [Xrgb],
+    width: usize,
+    detail: bool,
+) -> Duration {
+    let mut elapsed = Duration::ZERO;
+    assert!(window.draw_if_needed(|renderer: &SoftwareRenderer| {
+        let start = Instant::now();
+        let _: PhysicalRegion = renderer.render_into_buffer(&mut Buffer {
+            pixels,
+            stride: width,
+            detail,
+        });
+        elapsed = start.elapsed();
+    }));
+    elapsed
+}
+
+pub fn run(options: &Options, width: u32, height: u32) -> Result<(), Box<dyn std::error::Error>> {
+    if width > 2048 || height > 2048 {
+        return Err("presentation viewport must be at most 2048×2048".into());
+    }
+    let windows = Rc::new(RefCell::new(Vec::new()));
+    slint::platform::set_platform(Box::new(ProbePlatform(windows.clone())))?;
+    let bare = ImageOnlyWindow::new()?;
+    let full = crate::MainWindow::new()?;
+    bare.show()?;
+    full.show()?;
+    let windows = windows.borrow();
+    for window in windows.iter() {
+        window.set_size(PhysicalSize::new(width, height));
+    }
+    let mut pixels = [
+        vec![Xrgb::default(); (width * height) as usize],
+        vec![Xrgb::default(); (width * height) as usize],
+    ];
+    print!(
+        "fixture,ui,width,height,source_width,source_height,publication,detail,repeat,frames,draw_wall_ms,checksum"
+    );
+    for name in [
+        "render",
+        "prepare",
+        "dirty",
+        "items",
+        "image",
+        "texture",
+        "fallback",
+        "rectangle",
+        "text",
+        "path",
+        "background",
+    ] {
+        print!(",{name}_calls_per_frame,{name}_wall_ms");
+    }
+    println!();
+    for fixture in fixtures() {
+        bare.set_native(fixture.native);
+        bare.set_crop_y(fixture.crop_y);
+        bare.set_crop_width(fixture.crop_width);
+        bare.set_crop_height(fixture.crop_height);
+        // Falling has no gameplay HUD/button overlay. Keep that same shell for
+        // every source so both windows produce exactly the same visible pixels.
+        full.set_launcher_scenario("falling".into());
+        full.set_native_video_visible(fixture.native);
+        full.set_raster_visible(!fixture.native);
+        full.set_native_video_crop_y(fixture.crop_y);
+        full.set_native_video_crop_width(fixture.crop_width);
+        full.set_native_video_crop_height(fixture.crop_height);
+        for is_bare in [true, false] {
+            publish(&bare, &full, &fixture, fixture.image.clone(), is_bare);
+        }
+        for repeat in 0..options.presentation_repeats {
+            for index in if repeat % 2 == 0 { [0, 1] } else { [1, 0] } {
+                let window = &windows[index];
+                let mut elapsed = Duration::ZERO;
+                for frame in 0..options.presentation_frames + 10 {
+                    if frame == 10 {
+                        MEASUREMENTS.with(|m| {
+                            *m.borrow_mut() = [Measurement::default(); DRAW_DIAGNOSTIC_COUNT]
+                        });
+                    }
+                    if options.presentation_republish {
+                        publish(
+                            &bare,
+                            &full,
+                            &fixture,
+                            fresh_image(&fixture.image),
+                            index == 0,
+                        );
+                    }
+                    window.request_redraw();
+                    let sample = render(
+                        window,
+                        &mut pixels[index],
+                        width as usize,
+                        options.presentation_detail,
+                    );
+                    if frame >= 10 {
+                        elapsed += sample;
+                    }
+                    black_box(&pixels[index]);
+                }
+                let checksum = pixels[index].iter().fold(0xcbf29ce484222325u64, |h, p| {
+                    (h ^ u64::from(p.0)).wrapping_mul(0x100000001b3)
+                });
+                let frames = f64::from(options.presentation_frames);
+                print!(
+                    "{},{},{width},{height},{},{},{},{},{repeat},{},{:.6},{checksum:016x}",
+                    fixture.name,
+                    if index == 0 { "bare" } else { "full" },
+                    fixture.image.size().width,
+                    fixture.image.size().height,
+                    if options.presentation_republish {
+                        "replace"
+                    } else {
+                        "retained"
+                    },
+                    options.presentation_detail,
+                    options.presentation_frames,
+                    elapsed.as_secs_f64() * 1000.0 / frames
+                );
+                MEASUREMENTS.with(|m| {
+                    for measurement in m.borrow().iter() {
+                        assert_eq!(measurement.depth, 0);
+                        print!(
+                            ",{:.3},{:.6}",
+                            measurement.calls as f64 / frames,
+                            measurement.elapsed.as_secs_f64() * 1000.0 / frames
+                        );
+                    }
+                });
+                println!();
+            }
+            if pixels[0] != pixels[1] {
+                return Err(format!("{}: bare/full pixels differ", fixture.name).into());
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/engine-client/src/raster.rs
+++ b/crates/engine-client/src/raster.rs
@@ -33,6 +33,7 @@ const STARFIELD_CACHE_MIN_PRIMITIVES: usize = 128;
 const STARFIELD_CACHE_CELL_SIZE: f32 = 64.0;
 const STARFIELD_CACHE_MAX_ENTRIES: usize = 64;
 const BACKGROUND: Rgb8Pixel = Rgb8Pixel { r: 5, g: 5, b: 20 };
+const RGB_FILL_BLOCK_PIXELS: usize = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RasterOptions {
@@ -196,13 +197,26 @@ impl RasterRenderer {
             let starfield_cache = &mut self.starfield_cache;
             let pixels = self.buffers[buffer_index].make_mut_slice();
             let started = Instant::now();
-            clear_pixels(pixels);
+            let frame_viewport = Viewport::new(width as f32, height as f32);
+            let background = if frames.len() == 1 {
+                opaque_frame_background(&frames[0], frame_viewport)
+            } else {
+                None
+            };
+            fill_rgb_pixels(pixels, background.map_or(BACKGROUND, |(_, color)| color));
             timings.clear += started.elapsed();
             let mut canvas = Canvas::new(width, height, pixels);
 
             if frames.len() == 1 {
                 let started = Instant::now();
-                canvas.draw_frame(&frames[0], Viewport::new(width as f32, height as f32));
+                if let Some((background, _)) = background {
+                    // The clear already painted this first, full-frame primitive.
+                    canvas.draw_frame_filtered(&frames[0], frame_viewport, |_, primitive| {
+                        !std::ptr::eq(primitive, background)
+                    });
+                } else {
+                    canvas.draw_frame(&frames[0], frame_viewport);
+                }
                 timings.other_frames += started.elapsed();
             } else if layout == FrameLayout::SpacewarsLocalPlay && frames.len() >= 4 {
                 draw_spacewars_layout(
@@ -1165,7 +1179,74 @@ fn span_fill_mode_for_layer(layer_z: i32, color: RenderColor) -> SpanFillMode {
 }
 
 fn clear_pixels(pixels: &mut [Rgb8Pixel]) {
-    pixels.fill(BACKGROUND);
+    fill_rgb_pixels(pixels, BACKGROUND);
+}
+
+fn fill_rgb_pixels(pixels: &mut [Rgb8Pixel], color: Rgb8Pixel) {
+    // Rust's slice fill of three-byte RGB pixels currently compiles to scalar
+    // byte/halfword stores on both x86-64 and aarch64, even in release builds.
+    // Copying a small repeated pattern lets the compiler/libc use wide stores,
+    // without giving up Slint's opaque RGB image path or allocating per fill.
+    if pixels.len() <= RGB_FILL_BLOCK_PIXELS {
+        pixels.fill(color);
+        return;
+    }
+    let block = [color; RGB_FILL_BLOCK_PIXELS];
+    for chunk in pixels.chunks_mut(block.len()) {
+        chunk.copy_from_slice(&block[..chunk.len()]);
+    }
+}
+
+/// Fold a leading opaque background into the clear, only when its projected
+/// rectangle covers every pixel. Keep this conservative: no strokes, partial
+/// backgrounds, or multi-viewport frames. Layer storage need not be sorted.
+fn opaque_frame_background(
+    frame: &RenderFrame,
+    viewport: Viewport,
+) -> Option<(&RenderPrimitive, Rgb8Pixel)> {
+    let layer = frame
+        .layers
+        .iter()
+        .filter(|layer| !layer.primitives.is_empty())
+        .min_by_key(|layer| layer.z)?;
+    let primitive = layer.primitives.first()?;
+    let RenderPrimitive::Polygon(polygon) = primitive else {
+        return None;
+    };
+    let color = raster_color(polygon.fill?.color);
+    if !color.opaque || polygon.stroke.is_some() {
+        return None;
+    }
+    let [a, b, c, d] = polygon.points.as_slice() else {
+        return None;
+    };
+    let [a, b, c, d] = [a, b, c, d].map(|point| project(frame.camera, *point, viewport));
+    if ![a, b, c, d]
+        .iter()
+        .all(|point| point.x.is_finite() && point.y.is_finite())
+        || !((a.x == b.x && b.y == c.y && c.x == d.x && d.y == a.y)
+            || (a.y == b.y && b.x == c.x && c.y == d.y && d.x == a.x))
+    {
+        return None;
+    }
+    let min_x = a.x.min(c.x);
+    let max_x = a.x.max(c.x);
+    let min_y = a.y.min(c.y);
+    let max_y = a.y.max(c.y);
+    // Match the scan converter: inclusive floor/ceil x spans; y samples at
+    // pixel centers, including the top edge but excluding the bottom edge.
+    if min_x < max_x
+        && min_y < max_y
+        && min_x.floor() <= 0.0
+        && max_x.ceil() >= viewport.width - 1.0
+        && min_y <= 0.5
+        && max_y > viewport.height - 0.5
+        && primitive_visible(frame.camera, viewport, primitive)
+    {
+        Some((primitive, rgb_pixel(color.pixel)))
+    } else {
+        None
+    }
 }
 
 fn fill_circle_pixels(
@@ -1469,13 +1550,13 @@ fn fill_rect(
         let start = y as usize * width as usize + clip.min_x as usize;
         let end = y as usize * width as usize + clip.max_x as usize + 1;
         if color.opaque {
-            pixels[start..end].fill(rgb_pixel(color.pixel));
+            fill_rgb_pixels(&mut pixels[start..end], rgb_pixel(color.pixel));
         } else {
             match fill_mode {
                 SpanFillMode::BackgroundFastPath { blended_background }
                     if pixels[start..end].iter().all(|pixel| *pixel == BACKGROUND) =>
                 {
-                    pixels[start..end].fill(blended_background);
+                    fill_rgb_pixels(&mut pixels[start..end], blended_background);
                 }
                 _ => {
                     for pixel in &mut pixels[start..end] {
@@ -1511,13 +1592,13 @@ fn fill_span(
     let start = y as usize * width as usize + left as usize;
     let end = y as usize * width as usize + right as usize + 1;
     if color.opaque {
-        pixels[start..end].fill(rgb_pixel(color.pixel));
+        fill_rgb_pixels(&mut pixels[start..end], rgb_pixel(color.pixel));
     } else {
         match fill_mode {
             SpanFillMode::BackgroundFastPath { blended_background }
                 if pixels[start..end].iter().all(|pixel| *pixel == BACKGROUND) =>
             {
-                pixels[start..end].fill(blended_background);
+                fill_rgb_pixels(&mut pixels[start..end], blended_background);
             }
             _ => {
                 for pixel in &mut pixels[start..end] {
@@ -1582,8 +1663,232 @@ fn blend_channel(source: u8, destination: u8, alpha: u32, inverse_alpha: u32) ->
 mod tests {
     use super::*;
     use engine_common::{
-        Camera2, Fill, RenderCircle, RenderFrame, RenderLine, RenderPrimitive, Stroke,
+        Camera2, ClockEventKind, ClockEventProfile, Fill, RenderCircle, RenderFrame, RenderLine,
+        RenderPrimitive, Scenario, Stroke,
     };
+
+    #[test]
+    fn bulk_rgb_fill_matches_slice_fill_including_short_spans_and_tails() {
+        for length in (0..=RGB_FILL_BLOCK_PIXELS * 3 + 1).chain([2048, 4097, 65_537]) {
+            for color in [
+                BACKGROUND,
+                Rgb8Pixel { r: 0, g: 0, b: 0 },
+                Rgb8Pixel {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                },
+                Rgb8Pixel {
+                    r: 13,
+                    g: 127,
+                    b: 230,
+                },
+            ] {
+                // Offset spans also exercise unaligned starts and preserve guards.
+                for offset in 0..4 {
+                    let mut expected = vec![BACKGROUND; length + 6];
+                    let mut actual = expected.clone();
+                    expected[offset..offset + length].fill(color);
+                    fill_rgb_pixels(&mut actual[offset..offset + length], color);
+                    assert_eq!(actual, expected, "length={length}, offset={offset}");
+                }
+            }
+        }
+    }
+
+    fn rectangle_frame(viewport: Viewport, bounds: [f32; 4], color: RenderColor) -> RenderFrame {
+        let [left, top, right, bottom] = bounds;
+        let point =
+            |x: f32, y: f32| RenderPoint::new(x - viewport.width * 0.5, viewport.height * 0.5 - y);
+        let mut frame = RenderFrame::new(Camera2::new(RenderPoint::ZERO, viewport.height));
+        frame.push_primitive(
+            0,
+            RenderPrimitive::Polygon(RenderPolygon {
+                points: vec![
+                    point(left, top),
+                    point(right, top),
+                    point(right, bottom),
+                    point(left, bottom),
+                ],
+                fill: Some(Fill::new(color)),
+                stroke: None,
+            }),
+        );
+        frame
+    }
+
+    // Original clear-then-draw path, without background folding. Fill equivalence
+    // is checked independently above, so this also catches buffer-reuse trails.
+    fn reference_single_frame(frame: &RenderFrame, viewport: Viewport) -> Vec<Rgb8Pixel> {
+        let width = viewport.width as u32;
+        let height = viewport.height as u32;
+        let mut pixels = vec![BACKGROUND; width as usize * height as usize];
+        Canvas::new(width, height, &mut pixels).draw_frame(frame, viewport);
+        pixels
+    }
+
+    fn assert_frame_matches_reference(
+        renderer: &mut RasterRenderer,
+        frame: RenderFrame,
+        viewport: Viewport,
+    ) {
+        let expected = reference_single_frame(&frame, viewport);
+        let image = renderer.image_from_frames_with_layout(
+            &[frame],
+            viewport,
+            FrameLayout::EqualHorizontal,
+            RasterOptions::default(),
+        );
+        assert_eq!(image.to_rgb8().unwrap().as_slice(), expected);
+    }
+
+    #[test]
+    fn background_folding_matches_scan_coverage_in_either_winding() {
+        let viewport = Viewport::new(64.0, 64.0);
+        let mut renderer = RasterRenderer::new();
+        for (bounds, covers) in [
+            ([0.0, 0.0, 64.0, 64.0], true),
+            ([-8.0, -8.0, 72.0, 72.0], true),
+            ([0.75, 0.5, 62.25, 63.75], true),
+            ([1.0, 0.0, 64.0, 64.0], false),
+            ([0.0, 0.75, 64.0, 64.0], false),
+            ([0.0, 0.0, 62.0, 64.0], false),
+            ([0.0, 0.0, 64.0, 63.5], false),
+            ([32.0, 0.0, 32.0, 64.0], false),
+            ([0.0, 32.0, 64.0, 32.0], false),
+        ] {
+            for reversed in [false, true] {
+                for rotation in 0..4 {
+                    let mut frame = rectangle_frame(viewport, bounds, RenderColor::GREEN);
+                    let RenderPrimitive::Polygon(polygon) = &mut frame.layers[0].primitives[0]
+                    else {
+                        unreachable!()
+                    };
+                    if reversed {
+                        polygon.points.reverse();
+                    }
+                    polygon.points.rotate_left(rotation);
+                    assert_eq!(
+                        opaque_frame_background(&frame, viewport).is_some(),
+                        covers,
+                        "{bounds:?}"
+                    );
+                    assert_frame_matches_reference(&mut renderer, frame, viewport);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn background_folding_rejects_transparency_strokes_and_non_rectangles() {
+        let viewport = Viewport::new(64.0, 64.0);
+        let mut renderer = RasterRenderer::new();
+        for kind in 0..7 {
+            let mut frame = rectangle_frame(viewport, [-8.0, -8.0, 72.0, 72.0], RenderColor::RED);
+            let RenderPrimitive::Polygon(polygon) = &mut frame.layers[0].primitives[0] else {
+                unreachable!()
+            };
+            match kind {
+                0 => polygon.fill.as_mut().unwrap().color.a = 0.5,
+                1 => polygon.fill = None,
+                2 => polygon.stroke = Some(Stroke::new(RenderColor::GREEN, 2.0)),
+                3 => polygon.points[0].x += 1.0,
+                4 => polygon.points.swap(1, 2), // Bow tie, not a rectangle.
+                5 => {
+                    polygon.points.pop();
+                }
+                _ => polygon.points[0].x = f32::NAN,
+            }
+            assert!(
+                opaque_frame_background(&frame, viewport).is_none(),
+                "kind={kind}"
+            );
+            assert_frame_matches_reference(&mut renderer, frame, viewport);
+        }
+    }
+
+    #[test]
+    fn background_folding_respects_layer_order_and_resets_reused_buffers() {
+        let viewport = Viewport::new(64.0, 64.0);
+        let mut renderer = RasterRenderer::new();
+        for _ in 0..BUFFER_COUNT + 1 {
+            let mut frame = rectangle_frame(viewport, [0.0, 0.0, 64.0, 64.0], RenderColor::RED);
+            frame.layers[0].z = 3;
+            let mut overlay =
+                rectangle_frame(viewport, [9.0, 17.0, 32.0, 40.0], RenderColor::GREEN);
+            overlay.layers[0].z = 7;
+            frame.layers.insert(0, overlay.layers.remove(0));
+            frame.layers.insert(
+                0,
+                RenderLayer {
+                    z: -5,
+                    primitives: vec![],
+                },
+            );
+            assert!(opaque_frame_background(&frame, viewport).is_some());
+            assert_frame_matches_reference(&mut renderer, frame.clone(), viewport);
+            // At equal z the earlier stored partial rectangle must draw first.
+            frame.layers[1].z = 3;
+            assert!(opaque_frame_background(&frame, viewport).is_none());
+            assert_frame_matches_reference(&mut renderer, frame, viewport);
+            let empty = RenderFrame::new(Camera2::new(RenderPoint::ZERO, 64.0));
+            assert_frame_matches_reference(&mut renderer, empty, viewport);
+            let partial = rectangle_frame(viewport, [8.0, 8.0, 16.0, 16.0], RenderColor::GREEN);
+            assert_frame_matches_reference(&mut renderer, partial, viewport);
+        }
+    }
+
+    #[test]
+    fn all_clock_effects_match_original_background_rendering() {
+        use scenario_clock::{ClockAction, ClockConfig, ClockReading, ClockScenario};
+
+        let mut renderer = RasterRenderer::new();
+        // Include non-integral aspect/scaling and portrait buffers, with resize
+        // and repeated image-buffer reuse across active and recovered effects.
+        for (width, height) in [(160, 120), (213, 121), (96, 144)] {
+            let viewport = Viewport::new(width as f32, height as f32);
+            for event in ClockEventKind::ALL {
+                let mut state = ClockScenario::init(
+                    ClockConfig {
+                        aspect_ratio: viewport.aspect_ratio(),
+                        event_profile: ClockEventProfile::Off,
+                        ..Default::default()
+                    },
+                    7,
+                );
+                ClockScenario::step(
+                    &mut state,
+                    &[ClockAction::set_reading(
+                        ClockReading::new(8, 8, 8).unwrap(),
+                    )],
+                    Duration::ZERO,
+                );
+                let idle = ClockScenario::render_frame(&state);
+                assert!(opaque_frame_background(&idle, viewport).is_some());
+                assert_frame_matches_reference(&mut renderer, idle, viewport);
+                let duration = scenario_clock::EVENT_CATALOG[event as usize].duration_ticks;
+                for tick in 0..=duration + scenario_clock::COOLDOWN_TICKS {
+                    let actions = if tick == 0 {
+                        vec![ClockAction::preview_event(event)]
+                    } else {
+                        vec![]
+                    };
+                    ClockScenario::step(&mut state, &actions, Duration::from_nanos(16_666_667));
+                    if tick % 31 == 0
+                        || tick == duration
+                        || tick == duration + scenario_clock::COOLDOWN_TICKS
+                    {
+                        let frame = ClockScenario::render_frame(&state);
+                        assert!(
+                            opaque_frame_background(&frame, viewport).is_some(),
+                            "event={event:?}, tick={tick}"
+                        );
+                        assert_frame_matches_reference(&mut renderer, frame, viewport);
+                    }
+                }
+            }
+        }
+    }
 
     fn reference_blit_circle_with_opacity(
         destination: &mut [Rgb8Pixel],

--- a/crates/engine-client/src/ui_render_tests.rs
+++ b/crates/engine-client/src/ui_render_tests.rs
@@ -1,0 +1,183 @@
+//! Real menu trees must repaint correctly as panels are created and removed.
+use crate::MainWindow;
+use slint::platform::software_renderer::{MinimalSoftwareWindow, RepaintBufferType};
+use slint::platform::{Platform, PlatformError, WindowAdapter};
+use slint::{ComponentHandle, Image, PhysicalSize, Rgb8Pixel, SharedPixelBuffer};
+use std::{cell::RefCell, rc::Rc};
+
+struct TestPlatform(Rc<RefCell<Vec<Rc<MinimalSoftwareWindow>>>>);
+type MenuCase = (&'static str, fn(&MainWindow));
+
+impl Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        let mut windows = self.0.borrow_mut();
+        let mode = if windows.is_empty() {
+            RepaintBufferType::ReusedBuffer
+        } else {
+            RepaintBufferType::NewBuffer
+        };
+        let window = MinimalSoftwareWindow::new(mode);
+        windows.push(window.clone());
+        Ok(window)
+    }
+}
+
+fn reset_panels(ui: &MainWindow) {
+    ui.set_launcher_visible(false);
+    ui.set_launcher_settings_visible(false);
+    ui.set_launcher_controls_visible(false);
+    ui.set_ingame_menu_visible(false);
+    ui.set_ingame_controls_visible(false);
+    ui.set_ingame_clock_visible(false);
+    ui.set_game_over_visible(false);
+    ui.set_controller_disconnected_visible(false);
+    ui.set_scenario_error_text("".into());
+    ui.set_touch_test_visible(false);
+    ui.set_sound_visible(false);
+    ui.set_launcher_busy(false);
+    ui.set_spacewars_ui_visible(false);
+    ui.set_launcher_scenario("clock".into());
+}
+
+#[test]
+fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
+    let windows = Rc::new(RefCell::new(Vec::new()));
+    slint::platform::set_platform(Box::new(TestPlatform(windows.clone()))).unwrap();
+    let uis = [MainWindow::new().unwrap(), MainWindow::new().unwrap()];
+    let mut frame = SharedPixelBuffer::<Rgb8Pixel>::new(32, 24);
+    for (index, pixel) in frame.make_mut_slice().iter_mut().enumerate() {
+        *pixel = Rgb8Pixel::new((index % 32 * 7) as u8, (index / 32 * 9) as u8, 40);
+    }
+    for ui in &uis {
+        ui.set_raster_visible(true);
+        ui.set_raster_frame(Image::from_rgb8(frame.clone()));
+        ui.set_launcher_clock_time_format("12-hour".into());
+        ui.set_launcher_clock_event_profile("Off".into());
+        ui.set_launcher_settings_focus_index(10);
+        ui.set_ingame_clock_focus_index(4);
+        ui.set_clock_event_labels(Rc::new(slint::VecModel::from(vec!["Falling".into()])).into());
+        ui.set_scenario_controls_help("Move with the joystick. A selects. B goes back.".into());
+        ui.set_sound_volume_percent(5);
+        ui.set_p1_name("Player 1".into());
+        ui.set_p1_status("Ship Health: 80%".into());
+        ui.set_p1_status_fraction(0.8);
+        ui.set_p2_name("Rule Bot".into());
+        ui.set_p2_status("Pod Rebuild: 30%".into());
+        ui.set_p2_status_fraction(0.3);
+        ui.set_spacewars_message_text("Player 1 wins!".into());
+        ui.set_controller_disconnected_text("Player 2 controller disconnected".into());
+        ui.set_launcher_busy_title("Opening Clock".into());
+        ui.set_launcher_busy_detail("Preparing scenario".into());
+        ui.show().unwrap();
+    }
+    let windows = windows.borrow();
+    let cases: &[MenuCase] = &[
+        ("gameplay", |_| {}),
+        ("launcher", |ui| ui.set_launcher_visible(true)),
+        ("launcher-settings", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_launcher_settings_visible(true);
+        }),
+        ("launcher-controls", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_launcher_controls_visible(true);
+        }),
+        ("touch-test", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_launcher_controls_visible(true);
+            ui.set_touch_test_visible(true);
+        }),
+        ("launcher-sound", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_sound_visible(true);
+        }),
+        ("busy", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_launcher_busy(true);
+        }),
+        ("pause", |ui| ui.set_ingame_menu_visible(true)),
+        ("pause-controls", |ui| {
+            ui.set_ingame_menu_visible(true);
+            ui.set_ingame_controls_visible(true);
+        }),
+        ("pause-clock", |ui| {
+            ui.set_ingame_menu_visible(true);
+            ui.set_ingame_clock_visible(true);
+        }),
+        ("pause-sound", |ui| {
+            ui.set_ingame_menu_visible(true);
+            ui.set_sound_visible(true);
+        }),
+        ("disconnected", |ui| {
+            ui.set_controller_disconnected_visible(true)
+        }),
+        ("error", |ui| {
+            ui.set_scenario_error_text("Test error".into())
+        }),
+        ("spacewars-hud", |ui| {
+            ui.set_launcher_scenario("spacewars".into());
+            ui.set_spacewars_ui_visible(true);
+        }),
+        ("game-over", |ui| {
+            ui.set_launcher_scenario("spacewars".into());
+            ui.set_spacewars_ui_visible(true);
+            ui.set_game_over_visible(true);
+        }),
+        ("falling", |ui| ui.set_launcher_scenario("falling".into())),
+        ("gameplay-restored", |_| {}),
+    ];
+    // Keep both trees alive across transitions and a resize. The first buffer
+    // preserves old pixels; the reference repaints the entire window every time.
+    for (width, height) in [(800, 480), (480, 800)] {
+        for window in windows.iter() {
+            window.set_size(PhysicalSize::new(width, height));
+        }
+        let mut pixels = [
+            SharedPixelBuffer::<Rgb8Pixel>::new(width, height),
+            SharedPixelBuffer::<Rgb8Pixel>::new(width, height),
+        ];
+        for (name, configure) in cases {
+            for ui in &uis {
+                reset_panels(ui);
+                configure(ui);
+            }
+            slint::platform::update_timers_and_animations();
+            for index in 0..2 {
+                assert!(
+                    windows[index].draw_if_needed(|renderer| {
+                        renderer.render(pixels[index].make_mut_slice(), width as usize);
+                    }),
+                    "{name}: changing panels must invalidate the window"
+                );
+            }
+            assert!(
+                pixels[0].as_bytes() == pixels[1].as_bytes(),
+                "{name} at {width}×{height}: partial repaint left different pixels"
+            );
+            for ui in &uis {
+                assert_eq!(ui.get_launcher_clock_time_format(), "12-hour");
+                assert_eq!(ui.get_launcher_clock_event_profile(), "Off");
+                assert_eq!(ui.get_launcher_settings_focus_index(), 10);
+                assert_eq!(ui.get_ingame_clock_focus_index(), 4);
+                assert_eq!(ui.get_sound_volume_percent(), 5);
+            }
+            // Optional, local before/after visual comparison. No golden hashes
+            // in CI: system fonts can differ between machines.
+            if let Some(directory) = std::env::var_os("SPACEWARS_MENU_TEST_ARTIFACTS") {
+                let directory = std::path::PathBuf::from(directory);
+                std::fs::create_dir_all(&directory).unwrap();
+                let file =
+                    std::fs::File::create(directory.join(format!("{width}-{height}-{name}.png")))
+                        .unwrap();
+                let mut encoder = png::Encoder::new(file, width, height);
+                encoder.set_color(png::ColorType::Rgb);
+                encoder.set_depth(png::BitDepth::Eight);
+                encoder
+                    .write_header()
+                    .unwrap()
+                    .write_image_data(pixels[0].as_bytes())
+                    .unwrap();
+            }
+        }
+    }
+}

--- a/crates/engine-client/tests/presentation_probe.rs
+++ b/crates/engine-client/tests/presentation_probe.rs
@@ -1,0 +1,116 @@
+//! Frozen presentation experiments must work without devices and preserve data.
+use std::{collections::BTreeMap, fs, process::Command};
+
+fn run(detail: bool, republish: bool) -> Vec<BTreeMap<String, String>> {
+    let directory = tempfile::tempdir().unwrap();
+    let settings = directory.path().join("settings.toml");
+    // Intentionally malformed: the diagnostic must not even load or recover it.
+    fs::write(&settings, "not valid toml {{").unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_engine-client"));
+    command
+        .env_remove("DISPLAY")
+        .env_remove("WAYLAND_DISPLAY")
+        .env("SLINT_BACKEND", "nonexistent-backend")
+        .env(
+            "SPACEWARS_CONTROL_SOCKET",
+            directory.path().join("no-socket"),
+        )
+        .arg("--config-dir")
+        .arg(directory.path())
+        .args([
+            "--benchmark-presentation",
+            "--benchmark-width",
+            "128",
+            "--benchmark-height",
+            "96",
+            "--presentation-frames",
+            "2",
+            "--presentation-repeats",
+            "2",
+        ]);
+    if detail {
+        command.arg("--presentation-detail");
+    }
+    if republish {
+        command.arg("--presentation-republish");
+    }
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(settings).unwrap(), "not valid toml {{");
+    assert_eq!(fs::read_dir(directory.path()).unwrap().count(), 1);
+    let text = String::from_utf8(output.stdout).unwrap();
+    let mut lines = text.lines();
+    let columns: Vec<_> = lines.next().unwrap().split(',').collect();
+    let rows: Vec<BTreeMap<_, _>> = lines
+        .map(|line| {
+            let values: Vec<_> = line.split(',').collect();
+            assert_eq!(values.len(), columns.len());
+            columns
+                .iter()
+                .zip(values)
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect()
+        })
+        .collect();
+    assert_eq!(rows.len(), 16);
+    for pair in rows.chunks_exact(2) {
+        assert_eq!(pair[0]["fixture"], pair[1]["fixture"]);
+        assert_eq!(pair[0]["checksum"], pair[1]["checksum"]);
+        assert_ne!(pair[0]["ui"], pair[1]["ui"]);
+        for row in pair {
+            assert_eq!(row["frames"], "2");
+            assert_eq!(row["width"], "128");
+            assert_eq!(row["height"], "96");
+            assert_eq!(
+                row["render_calls_per_frame"],
+                if detail { "1.000" } else { "0.000" }
+            );
+            assert_eq!(row["detail"], detail.to_string());
+            assert_eq!(
+                row["publication"],
+                if republish { "replace" } else { "retained" }
+            );
+            for (key, value) in row {
+                if key.ends_with("_ms") || key.ends_with("_per_frame") {
+                    let value: f64 = value.parse().unwrap();
+                    assert!(value.is_finite() && value >= 0.0);
+                }
+            }
+        }
+    }
+    rows
+}
+
+#[test]
+fn frozen_bare_and_full_ui_match_without_settings_or_display() {
+    let plain = run(false, false);
+    let measured = run(true, false);
+    let published = run(true, true);
+    for ((plain, measured), published) in plain.iter().zip(&measured).zip(&published) {
+        assert_eq!(plain["checksum"], measured["checksum"]);
+        assert_eq!(plain["checksum"], published["checksum"]);
+    }
+}
+
+#[test]
+fn invalid_probe_limits_are_rejected_before_opening_a_display() {
+    for args in [
+        vec!["--presentation-frames", "0"],
+        vec!["--presentation-repeats", "21"],
+        vec!["--benchmark-width", "4096"],
+        vec!["--scenario", "clock"],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_engine-client"))
+            .env_remove("DISPLAY")
+            .env_remove("WAYLAND_DISPLAY")
+            .arg("--benchmark-presentation")
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+    }
+}

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -519,16 +519,14 @@ export component MainWindow inherits Window {
         }
     }
 
-    Rectangle {
-        visible: root.spacewars-ui-visible;
+    if root.spacewars-ui-visible: Rectangle {
         x: root.width / 2 - 1px;
         width: 2px;
         height: root.height;
         background: #59627388;
     }
 
-    PlayerStatusPanel {
-        visible: root.spacewars-ui-visible;
+    if root.spacewars-ui-visible: PlayerStatusPanel {
         x: 16px;
         y: 16px;
         width: root.width * 0.31;
@@ -539,8 +537,7 @@ export component MainWindow inherits Window {
         player-color: root.p1-color;
     }
 
-    PlayerStatusPanel {
-        visible: root.spacewars-ui-visible;
+    if root.spacewars-ui-visible: PlayerStatusPanel {
         x: root.width - self.width - 16px;
         y: 16px;
         width: root.width * 0.31;
@@ -552,8 +549,7 @@ export component MainWindow inherits Window {
         align-right: true;
     }
 
-    Rectangle {
-        visible: root.spacewars-ui-visible;
+    if root.spacewars-ui-visible: Rectangle {
         x: root.width * 0.37;
         y: root.height - self.height - 14px;
         width: root.width * 0.26;
@@ -658,8 +654,9 @@ export component MainWindow inherits Window {
         }
     }
 
-    MenuButton {
-        visible: root.launcher-scenario == "clock" && !root.launcher-visible && !root.ingame-menu-visible;
+    // Inactive panels must leave the item tree: visible:false still incurs
+    // software-renderer dirty-region/bounds work. Persistent state stays in root.
+    if root.launcher-scenario == "clock" && !root.launcher-visible && !root.ingame-menu-visible: MenuButton {
         x: parent.width - 178px;
         y: 12px;
         width: 166px;
@@ -668,8 +665,7 @@ export component MainWindow inherits Window {
         activated => { root.ingame-clock-open(); }
     }
 
-    Rectangle {
-        visible: root.ingame-menu-visible;
+    if root.ingame-menu-visible: Rectangle {
         width: parent.width;
         height: parent.height;
         background: #050514cc;
@@ -774,8 +770,7 @@ export component MainWindow inherits Window {
                 }
             }
 
-            Rectangle {
-                visible: root.ingame-controls-visible;
+            if root.ingame-controls-visible: Rectangle {
                 x: 24px;
                 y: 62px;
                 width: parent.width - 48px;
@@ -1018,8 +1013,7 @@ export component MainWindow inherits Window {
         }
     }
 
-    Rectangle {
-        visible: root.game-over-visible && !root.launcher-visible;
+    if root.game-over-visible && !root.launcher-visible: Rectangle {
         width: parent.width;
         height: parent.height;
         background: #050514c8;
@@ -1094,6 +1088,7 @@ export component MainWindow inherits Window {
         }
     }
 
+    // Keep keyboard focus/shortcuts alive even while the launcher tree is absent.
     launcher-shortcuts := FocusScope {
         width: parent.width;
         height: parent.height;
@@ -1156,8 +1151,7 @@ export component MainWindow inherits Window {
         }
 
 
-        Rectangle {
-            visible: root.launcher-visible;
+        if root.launcher-visible: Rectangle {
             width: parent.width;
             height: parent.height;
             background: #050514f4;
@@ -1200,8 +1194,7 @@ export component MainWindow inherits Window {
                     horizontal-alignment: right;
                 }
 
-                Rectangle {
-                    visible: !root.launcher-controls-visible && !root.launcher-settings-visible;
+                if !root.launcher-controls-visible && !root.launcher-settings-visible: Rectangle {
                     x: 24px;
                     y: 72px;
                     width: parent.width - 48px;
@@ -1343,8 +1336,7 @@ export component MainWindow inherits Window {
                     }
                 }
 
-                Rectangle {
-                    visible: root.launcher-settings-visible;
+                if root.launcher-settings-visible: Rectangle {
                     x: 24px;
                     y: 72px;
                     width: parent.width - 48px;
@@ -1764,8 +1756,7 @@ export component MainWindow inherits Window {
                     }
                 }
 
-                Rectangle {
-                    visible: root.launcher-controls-visible;
+                if root.launcher-controls-visible: Rectangle {
                     x: 24px;
                     y: 72px;
                     width: parent.width - 48px;
@@ -1851,8 +1842,7 @@ export component MainWindow inherits Window {
         }
     }
 
-    Rectangle {
-        visible: root.controller-disconnected-visible && !root.launcher-visible;
+    if root.controller-disconnected-visible && !root.launcher-visible: Rectangle {
         x: (parent.width - self.width) / 2;
         y: 20px;
         width: root.width < 552px ? root.width - 32px : 520px;
@@ -1874,8 +1864,7 @@ export component MainWindow inherits Window {
         }
     }
 
-    Rectangle {
-        visible: root.scenario-error-text != "" && !root.launcher-visible;
+    if root.scenario-error-text != "" && !root.launcher-visible: Rectangle {
         x: root.width * 0.15;
         y: root.controller-disconnected-visible ? 72px : 16px;
         width: root.width * 0.70;
@@ -1898,8 +1887,7 @@ export component MainWindow inherits Window {
         }
     }
 
-    Rectangle {
-        visible: root.touch-test-visible;
+    if root.touch-test-visible: Rectangle {
         width: parent.width;
         height: parent.height;
         background: #050514;

--- a/docs/clock-performance-lab.md
+++ b/docs/clock-performance-lab.md
@@ -69,6 +69,12 @@ report; consume columns by name, not numeric position:
 - `avg_step_ms` includes scripted actions and simulation. `avg_render_ms` is
   draw-list generation. `avg_present_ms` is CPU rasterization/image creation or
   vector scene conversion—not Slint drawing, GPU upload, composition or vsync.
+- `avg_raster_clear_ms` measures frame background initialization. When a single
+  frame starts with an opaque, unstroked rectangle covering every pixel, the
+  renderer paints that color directly and skips the redundant primitive.
+  `avg_raster_other_frames_ms` then covers the remaining Clock drawing. Compare
+  their sum as well as the individual stages across this optimization; work
+  was both accelerated and removed, not just moved between timing buckets.
 - `avg_total_ms` and total percentiles cover the same whole-frame CPU interval,
   including bookkeeping. Output/file I/O is outside that interval.
 - `max_scene_items` is the peak prepared scene item/primitive count in the row
@@ -193,6 +199,622 @@ the collecting checkout's ignored
 `target/clock-benchmarks/picade-20260910-TBMpiYaD/`. Future runs should keep their
 own report directories and binary hashes rather than overwriting this baseline.
 
+## Bulk RGB fills and background folding (2026-09-10)
+
+The raster renderer now copies a 256-pixel repeating RGB block for large fills,
+while keeping ordinary slice filling for short spans. This avoids the scalar
+byte/halfword stores emitted for three-byte RGB slice fills in the release
+desktop and ARM binaries. It retains the opaque RGB image format, reusable
+buffers, existing alpha rules, rendering cadence and raster-scale defaults.
+For a provably covering first rectangle, background initialization also replaces
+the previously separate clear and background polygon paint. Other frames keep
+the general clear-then-draw path; this is not Clock-specific rendering logic.
+
+A fresh before/after comparison used the same Picade, 1024×768 logical viewport,
+scales 1 and 2, all seven cases, three independent processes each, seed 7,
+two-second warm-up and 15 measured simulated seconds. The kiosk stayed at its
+launcher during both headless matrices. Both are optimized Yocto release builds:
+
+- Before: `93a854eb7bcb23be56ae9e64bda001e8a4e97840f25f7dccfbd54f5f7acbc77c`
+- After: `384050cdbca42776ee4c0d2407e1f4a71886dbe732669e6e3c241434b0ddff47`
+
+Median per-run mean CPU milliseconds per frame at **scale 2**:
+
+| Fixture | Before | After |
+| --- | ---: | ---: |
+| Idle | 12.382 | 5.374 |
+| Falling | 13.066 | 6.231 |
+| Color Cycle | 11.997 | 5.369 |
+| Meltdown | 12.819 | 5.872 |
+| Duck | 13.366 | 6.371 |
+| Marquee (Clock Wave) | 12.221 | 5.383 |
+| Digit Slide | 12.328 | 5.455 |
+
+Idle's stage breakdown (medians calculated independently, so rounded rows do
+not necessarily sum exactly to the whole-frame median):
+
+| CPU stage | Before | After |
+| --- | ---: | ---: |
+| Clear / background initialization | 4.779 | 3.058 |
+| Remaining Clock raster drawing | 7.535 | 2.251 |
+| Draw-list generation | 0.046 | 0.043 |
+| Scenario step | 0.004 | 0.004 |
+| Image handle creation | 0.001 | 0.001 |
+
+Thus the main gain is faster filling **and removal of an entire background
+paint**, not an eightfold whole-renderer speedup. Idle scale 1 fell from 3.672 to
+1.545 ms. The comparable desktop release idle scale-2 workload fell from 1.575
+to 0.344 ms; rerunning the original desktop binary afterward measured 1.567 ms.
+These remain CPU-only benchmarks, not displayed FPS.
+
+Repeating the original Pi binary after the new matrix measured 12.145 ms for
+idle scale 2 (three runs), versus the initial 12.382 ms. That small shift does
+not explain the drop to 5.374 ms. These confirmation reports are in
+`target/clock-benchmarks/fills-picade/before-check/`.
+
+A separate Pi fill probe, cycling three 9 MiB buffers with changing RGB colors,
+measured approximately 4.64 ms for slice fill and 2.88 ms for the chosen bulk
+copy. Block sizes from 64 to 4096 pixels and fixed-size copy loops all clustered
+around 2.86–2.90 ms; copying by repeatedly doubling the initialized prefix took
+4.32 ms. This suggests buffer writes/memory traffic deserve attention beyond
+loop sizing, but it is not a measurement of the Pi's peak memory bandwidth.
+Short spans have different tradeoffs and still leave room for improvement.
+
+The governor remained `ondemand`. Before endpoint temperatures were
+77.4–80.3°C; after endpoints were 72.1–79.4°C, with frequency snapshots spanning
+0.9–1.5 GHz in both matrices. These are not continuously controlled thermal or
+clock measurements. Keep that caveat for small differences between fixtures.
+
+Live Clock was also measured at scale 2, profile **Off**, 103 primitives, after
+the 120-callback timing window filled (ten samples one second apart):
+
+| Live metric | Before | After |
+| --- | ---: | ---: |
+| Host callbacks/sec | 37.55 | 45.51 |
+| Mean callback interval | 26.61 ms | 22.01 ms |
+| Mean measured callback work | 11.96 ms | 4.95 ms |
+| Mean CPU preparation | 11.85 ms | 4.86 ms |
+| Process/service CPU, fraction of one core | 99.2% | 99.1% |
+
+The live samples use local wall time, not identical frozen clock digits, and
+summarize overlapping rolling windows. CPU utilization comes from service CPU
+nanoseconds divided by elapsed `/proc/uptime` over each sampling interval.
+Host callback rate is not a scanout measurement. The approximately 17 ms now
+outside the measured callback includes the Slint/display/event-loop path, but
+is **not** a directly instrumented Slint rendering duration. The Pi uses
+`linuxkms-software`; that remaining work needs direct profiling before choosing
+the next presentation optimization. The renderer speedup has improved live
+throughput, but has not yet reduced total CPU utilization at this setting.
+Demo and the original event, message, scale and sound settings were restored.
+
+Raw matrices are retained in the collecting checkout under
+`target/clock-benchmarks/fills-picade/{before,after}/`, with matching desktop
+reports under `fills-desktop-before/`, `fills-desktop-after/`, and
+`fills-desktop-before-check/`. Each run directory includes the binary hash,
+per-run environment observations and original CSV stage timings.
+The same Picade directory retains `live-before.txt`, `live-after.txt`, and the
+isolated fill probe source/results; screenshots were taken outside timed runs.
+
+## Live LinuxKMS presentation profiling
+
+The Pi software backend adds bounded `kms_*` fields to the existing status
+response. Query it on a running kiosk, not in the headless benchmark:
+
+```sh
+ssh spacewars@picade.local 'spacewars-cli status'
+```
+
+These measurements cover work outside the host timer callback. They retain the
+last **120 completed event-loop iterations**, which are not necessarily 120
+draws or timer callbacks. The current in-flight iteration is excluded. Counters
+are also available as lifetime totals. No per-frame output or filesystem writes
+are performed; percentile sorting and text formatting happen only on a status
+request. Set `SPACEWARS_KMS_PROFILE=0` before application startup to disable the
+clocks and recording. Other backends do not publish these fields.
+
+| Stage | Scope |
+| --- | --- |
+| `loop` | Whole event-loop iteration, including blocking waits |
+| `timers` | Slint timer/animation updates, including the host's existing callback |
+| `callbacks` | Queued event-loop callbacks, including IPC/status requests |
+| `render` | Render-if-needed and presentation, inclusive of the stages below |
+| `map` / `unmap` | Mapping/unmapping the DRM backbuffer |
+| `draw` | Slint software rendering into the selected direct or RAM buffer |
+| `draw_generic` / `draw_rgb` | Whole draw classified by selected texture implementation, **included in `draw`** |
+| `background` | Solid window-background fill, **included in `draw`** |
+| `rgb_blit` | Eligible opaque RGB texture drawing, **included in `draw`** |
+| `copy` | Copying a completed RAM frame into the mapped display buffer, if enabled |
+| `flip_wait` | Waiting for the previous DRM page-flip event |
+| `submit` | Buffer rotation/bookkeeping and the DRM submission call |
+| `dispatch` | Event dispatch, input handling and blocking poll wait |
+
+Each stage exposes wall and **UI-thread CPU** total, mean, p95 and maximum
+milliseconds. Wall time includes descheduling and waits; CPU time does not.
+Statistics are per iteration in which that stage ran, summing repeated calls
+within an iteration. `_calls` counts calls; `_cpu_samples` counts active
+iterations with valid CPU readings. An unavailable CPU clock produces no CPU
+timing fields, rather than a misleading zero. A render-if-needed call can do no
+drawing: compare it with `kms_draws_window`.
+
+The stages are nested: do **not** add `loop` to its children, `render` to its
+children, `draw` to its implementation/background/blit timings, or `timers` to
+the host callback's existing timings. To account for the whole loop, use stage
+**totals from one window**, not averages with different denominators. The
+residual includes untimed setup
+and instrumentation overhead.
+The host's rolling callback window is separate, so its averages need not align
+exactly with this window.
+
+`kms_output_*`, `kms_pixel_format`, `kms_buffer_bytes` and `kms_buffer_age`
+describe the output and last rendered buffer, not the higher-resolution host
+raster image. `kms_dirty_pixels_window` sums Slint's reported dirty regions;
+compare with output pixels × draw count to identify full-screen repainting.
+`kms_flip_submissions_*` counts successful page-flip requests,
+`kms_flip_completions_*` counts observed completion events, and modesets and
+event-read errors have separate counters. Completions may lag submissions by a
+pending frame. None measures GPU work, scanout duration, or physical display
+latency. The Linux framebuffer fallback has no DRM map/flip stages.
+
+Profiler version 2 additionally reports `kms_buffer_mode` (`direct` or `ram`),
+`kms_shadow_bytes` (retained RAM pixel-storage capacity), and
+`kms_copy_bytes_{window,total}`. `draw` excludes the subsequent copy; use both
+when comparing paths. `background` measures only the solid Slint **window**
+background, not background-shaped scene items or the host's earlier raster
+clear. Non-solid brushes retain Slint's fallback and have no separate fill
+sample. Subtract background from draw totals to inspect the remaining scene
+rendering; that residual is not exclusively image conversion.
+
+### Picade findings (2026-09-10)
+
+The instrumented release was fast-deployed to `picade.local`, without rebooting:
+SHA-256 `6f13d9299c4a0556c6d27603af888bfd7917deeddcf80ae3c040e2bdd3056205`.
+The display is 1024×768, XRGB8888, with a 3 MiB mapped output buffer. A scale-2
+host raster image is separately 2048×1536 RGB (9 MiB).
+
+Clock used profile Off, 24-hour time and 103 primitives. Measurement order was
+raster 2, raster 1, vector, raster 1 again, then raster 2 twice more. Each group
+has ten status samples a second apart, except the final scale-2 group with five
+samples three seconds apart. The rolling windows were full before sampling;
+one-second-spaced windows overlap and are **not independent benchmark trials**.
+The final group spaces windows apart. Local clock digits were not frozen.
+
+Stage CPU totals are divided by draws in the same window, then averaged across
+samples. Values are milliseconds per draw, except the explicitly marked wait
+and utilization rows. Inclusive whole-loop time is not an additional cost:
+
+| Measurement | Raster 2, first | Raster 2, final | Raster 1, repeat | Vector |
+| --- | ---: | ---: | ---: | ---: |
+| Timer/host CPU work | 5.0 | 5.2 | 1.5 | 0.8 |
+| Slint software draw CPU | 16.5 | 14.4 | 14.3 | 11.1 |
+| Map + unmap + submission CPU | 0.26 | 0.25 | 0.23 | 0.21 |
+| Whole-loop CPU, inclusive | 21.8 | 19.9 | 16.2 | 12.3 |
+| Page-flip wait, **wall** ms | 0.02 | 0.07 | 0.35 | 4.36 |
+| Service CPU, % of one core | 99.3% | 99.0% | 96.9% | 73.7% |
+
+The initial native-scale draw was also 14.3 ms. The intermediate scale-2 repeat
+was 14.4 ms. Scale-2 drawing varied materially between launches, so do not treat
+the initial 2.2 ms difference from native scale as a stable supersampling cost.
+Temperature snapshots across these instrumented groups spanned 74.0–78.4°C.
+Raster samples reported 1.5 GHz; vector samples reported 1.1–1.5 GHz under the
+unchanged `ondemand` governor. These are snapshots, not continuous clocks or a
+thermally controlled comparison. They do not establish why the first scale-2
+group was slower.
+
+Findings:
+
+- The missing time is predominantly **CPU work inside Slint drawing**, not a
+  hidden frame-rate sleep. Timer + render + dispatch totals account for almost
+  all loop time. At scale 2, software drawing is about 72–76% of UI-thread CPU.
+- Page-flip waits barely block at scale 2. Vector mode has spare time to wait
+  for flips instead of spending the whole interval on CPU. There were no
+  recorded DRM event-read errors.
+- Every measured draw reported a full-screen dirty region. Buffer age was 3;
+  the current backend treats ages other than 1 or 2 as `NewBuffer`. Both this
+  buffer policy and publishing changed full-screen content matter when later
+  introducing partial updates. These measurements do not isolate their effects.
+- `/proc` samples in the later groups show roughly **768 minor faults/draw**,
+  matching the 768 4 KiB pages in the output buffer, and no major faults. This
+  is consistent with remapping it each frame. Those page faults happen on
+  access inside `draw`, not necessarily inside the short `map` call. However,
+  kernel time is only about 4–8% of process CPU in these groups: mapping/faults
+  alone are not a sufficient explanation for the whole cost.
+- The coarse `draw` bucket includes background painting, image sampling/format
+  conversion, scene traversal and mapped-buffer writes. It does **not** yet
+  identify which of those dominates. Vector rendering remains substantial, so
+  neither scaling nor copying the raster image explains everything by itself.
+
+These findings motivated the RAM-versus-mapped-output experiment below, with
+separate background-fill timing. Isolating opaque image drawing can then inform
+a measured bulk RGB-to-XRGB path or avoidance of redundant background painting,
+without assuming GPU acceleration, lower resolution, or timer changes are
+required. Keeping mappings alive is a separate smaller candidate; skipping
+unchanged frames will also matter for an idle clock.
+
+Immediately before deployment, the uninstrumented optimized build measured
+5.06 ms of host callback work, a 21.86 ms callback interval and 99.1% service
+CPU at scale 2. The initial instrumented group measured 4.94 ms, 21.98 ms and
+99.3%. This is a sanity check that profiling did not grossly change throughput,
+not a precise overhead measurement or a matched-digit performance comparison.
+The idle launcher also correctly reported no draws in its window and almost
+all elapsed time in blocking dispatch, with only about 0.09 ms CPU per loop.
+
+Raw status/CPU observations, binary hashes and collection/summary scripts are
+retained in `target/clock-benchmarks/kms-picade-20260910/` in the collecting
+checkout. The original raster renderer, scale 2, Demo, all effect toggles,
+message and 5% sound volume were restored, and a screenshot was checked outside
+the timed runs. No further rendering optimization was made in this profiling
+step.
+
+## RAM-backed output experiment (2026-09-10)
+
+The software backend can now render into a reusable, correctly aligned RAM
+buffer and copy the completed frame into scanout memory. **Direct rendering
+remains the default**: the measured RAM path did not recover its extra copy
+cost on Picade. This is an opt-in diagnostic path, not a claimed optimization:
+
+```sh
+SPACEWARS_KMS_BUFFER=ram SLINT_BACKEND=linuxkms-software engine-client ...
+SPACEWARS_KMS_BUFFER=direct SLINT_BACKEND=linuxkms-software engine-client ...
+```
+
+Set the variable before process startup; `status` reports the actual mode.
+Changing the environment of an SSH command does not change an already-running
+kiosk service. The default also leaves LinuxFB's existing RAM-buffer path alone.
+
+The comparison intentionally keeps the same pixels, resolution, pixel formats,
+scene rendering and page-flip scheduling. RAM mode forces `NewBuffer` rendering
+and copies the **entire frame** every draw, regardless of the target buffer's
+age. It does not claim that one shared RAM image is the previous contents of
+each of the three display buffers. This avoids stale pixels without introducing
+damage-history tracking or a partial-update optimization into the experiment.
+Direct mode keeps its existing buffer-age policy. Both paths fully repainted
+the screen in the measured gameplay windows.
+
+The shadow allocation is reused for matching sizes/formats and replaced when
+the pixel format changes. It adds 3 MiB on this 1024×768 XRGB8888 display; direct
+mode has no shadow pixel allocation. Copying is timed separately from drawing,
+while the solid window-background fill is timed within drawing. All other
+scene operations in this RAM comparison use Slint's existing fallback; it does
+not introduce custom texture sampling or alpha compositing.
+
+Backend tests compare both paths with Slint's original slice renderer, not just
+with each other: RGB and RGBA images, opacity, clipped/scaled images, rounded
+rectangles, borders and text; XRGB8888, ARGB8888 and RGB565 output; all four
+rotations; and growth/shrinkage of non-square windows. Guard pixels must remain
+untouched. Separate tests check buffer reuse, whole-frame copying into rotating
+targets, unsupported formats, the default/explicit mode choices, and byte/timing
+accounting. The Slint dev dependency in the backend's standalone manifest is for
+these headless UI fixtures; it does not add a new runtime renderer dependency.
+
+### Measured result: keep direct rendering
+
+Both paths were built as optimized Yocto releases and fast-deployed to the same
+Picade Pi 4, without rebooting or changing the display configuration:
+
+- RAM-default experimental binary SHA-256:
+  `b7b483739dc0f204f6e31819ce0c61b228cb7bc7124b3332f2780fbb46f37d50`.
+- Final direct-default binary SHA-256:
+  `89ebcf78f7495e316fc8fed687140a61b1b5118e90895a5e95222958766672d6`.
+
+Clock used Off, 24-hour time and 103 primitives. Each configuration had five
+status samples three seconds apart after at least five seconds of warm-up.
+Raw status was checked for actual buffer mode, renderer, raster scale, unpaused
+Clock, process identity and scenario revision; filenames alone are not evidence
+of the configuration. The collector now enforces these checks as well. Each
+sample summarizes up to 120 completed loops, with
+stage totals divided by draws in the same window. These are short live
+observations with rolling windows, not independent fixed-workload trials.
+
+| Rendering configuration | Direct draw CPU | RAM draw CPU | RAM copy CPU | RAM draw + copy CPU | Service CPU, direct / RAM |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Raster 2× | 16.85 ms | 15.48 ms | 2.18 ms | 17.66 ms | 99.1% / 99.3% |
+| Raster 1× | 14.22 ms | 12.96 ms | 2.31 ms | 15.27 ms | 96.4% / 98.6% |
+| Vector | 11.11 ms | 9.57 ms | 2.50 ms | 12.07 ms | 73.5% / 79.6% |
+
+CPU timings are per draw; service utilization is a percentage of one core.
+Direct mode has zero copy calls and zero retained shadow bytes. RAM mode copies
+3 MiB per draw. Background filling is **already included** in each draw column:
+it took 1.83–2.10 ms direct and 0.99–1.05 ms in RAM. Despite cheaper RAM drawing,
+the extra copy exceeded the saving in all three observed configurations.
+Observed flip-completion rates were approximately 44.7 / 43.1 per second at
+raster 2×, 60.0 / 57.7 at raster 1×, and 60.0 / 60.0 in vector mode
+(direct / RAM); these are not input-to-display latency measurements.
+
+Clock digits were not frozen, and temperature/frequency were not controlled.
+Across these groups temperature snapshots ranged from 72.5 to 78.9°C. Raster
+samples reported 1.5 GHz; vector samples reported 1.2–1.5 GHz under the unchanged
+governor. Earlier direct scale-2 runs varied from about 14.1 to 16.7 ms of draw
+CPU between launches; the final direct result above uses the same new fill
+instrumentation as RAM. Do not interpret small differences as universal or as
+a tightly isolated estimate of memory-cache effects. The useful conclusion is
+**no demonstrated net win from the extra RAM frame and copy**, so it is not
+enabled by default.
+
+The background accounts for only part of drawing: after subtracting it, RAM
+still spent roughly 8.5–14.5 ms per draw on the rest of Slint's scene work. Both
+paths still incurred about 768 minor faults per draw and no major faults, with
+kernel time only about 5–8.5% of process CPU. Moving writes into the copy stage
+does not eliminate the mapped-output cost, and neither faults nor the solid
+background alone explains the remaining time. The next experiment should
+isolate and optimize Slint's opaque RGB-image drawing path, comparing identical
+pixels at native and scaled sizes before changing production behavior. Vector
+cost also needs accounting; this result does not attribute all remaining time
+to image conversion.
+
+The six validated reports, collection/summary scripts, build/deployment logs,
+test results and restored status are retained in the collecting checkout under
+`target/clock-benchmarks/kms-ram-picade-20260910/`. The final direct-default build
+is deployed. Raster 2×, Demo, all six event toggles, 24-hour time, Clock wave,
+`SPACE WARS` and unmuted 5% volume were restored; no Pi 5 target was changed.
+
+## Opaque RGB blit experiment (2026-09-10)
+
+The next experiment specializes image drawing through Slint's existing
+`TargetPixelBuffer::draw_texture` hook in the **LinuxKMS software backend**. It
+does not change the scenario rasterizer, GPU backends, or the desktop Winit
+backend. It accepts only opaque RGB8 textures without tinting, tiling or
+rotation, with an exact 1:1 or 2:1 source-to-destination ratio on each axis.
+Source dimensions are limited to 4096 pixels per axis, with pixel-aligned,
+representable strides and coordinates, to preserve Slint's fixed-point limits.
+Other operations return to Slint's original renderer without writing pixels.
+
+For these integer ratios, Slint's fixed-point nearest-neighbor sampling reduces
+to fixed-size RGB chunks. The specialized loop converts them directly to the
+target pixel format, with no intermediate image or destination reads. It still
+honors source crop/stride, destination placement, clipping and partial damage.
+It does not skip background painting or change repaint/page-flip scheduling.
+The RAM-output experiment remains separate and opt-in.
+
+Set the texture implementation before application startup:
+
+```sh
+SPACEWARS_KMS_TEXTURE=generic SLINT_BACKEND=linuxkms-software engine-client ...
+SPACEWARS_KMS_TEXTURE=rgb SLINT_BACKEND=linuxkms-software engine-client ...
+SPACEWARS_KMS_TEXTURE=compare SLINT_BACKEND=linuxkms-software engine-client ...
+```
+
+`rgb` is the default, based on the paired Picade comparison below. `generic`
+provides a rollback/comparison without changing the other presentation work.
+
+Profiler version 4 reports the selected `kms_texture_mode`, handled
+`kms_rgb_blits_{window,total}`, written `kms_rgb_pixels_{window,total}`, and
+`kms_rgb_blit_*` timings. Blit time is **included in `draw`**, not additional to
+it. Rejected/fallback textures are not counted or timed as RGB blits. A handled
+texture with an empty clipped region can count as a blit with zero pixels.
+The mode alone does not prove a scene uses the fast path; check these counters.
+
+`compare` alternates generic and RGB-optimized **frames**, drawing each frame
+only once. It is a diagnostic mode, not a shipping default. This lets both paths
+run in the same process, with interleaved temperatures, frequency and scene
+content. Because the output ring has three buffers, each path visits all three.
+`kms_draw_generic_*` and `kms_draw_rgb_*` separately time the whole Slint draw;
+each is included in `draw`. Compare their per-active-iteration CPU means, or
+divide their CPU totals by their own valid sample counts, **not** by the total
+number of frames from both paths. In steady-state Clock there is one draw per
+active iteration. Clock digits still change, so this is not a frozen-scene
+microbenchmark; use Off and validate that no effect is active throughout.
+
+### Fixed-content benchmark and pixel tests
+
+A headless backend test compares generic and specialized drawing into the same
+1024×768 XRGB RAM buffer. Fixtures are a background-only window, a native-size
+RGB image, and a 2048×1536 image reduced by exactly two. It measures complete
+Slint draws (including the background), not the engine's rasterizer or DRM
+presentation. Each mode warms up for ten frames, then measures 100 frames, with
+four repeats and alternating mode order. Image content is fixed, profiling is
+inactive, and there are no pass/fail timing thresholds:
+
+```sh
+CARGO_PROFILE_RELEASE_LTO=fat CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
+  cargo test --release --locked \
+  --manifest-path vendor/i-slint-backend-linuxkms/Cargo.toml \
+  --features renderer-software --lib benchmark_opaque_rgb_presentation \
+  -- --ignored --nocapture
+```
+
+The first optimized desktop run measured roughly 0.025 ms for background-only
+drawing in either mode, 0.645 → 0.299 ms for the native image, and
+0.654 → 0.313 ms for the 2:1 image. These are RAM microbenchmark results, not
+claims about desktop application speed or Pi display performance.
+
+Correctness tests compare against Slint's original slice renderer. In addition
+to the earlier full-window matrix, 640 comparisons cover independent X/Y
+integer scales, source cropping with padded rows, negative destination offsets,
+clipping, output row padding/guards, both target pixel representations, all
+rotations, alpha images, opacity, tinting, tiling, fractional scales and sources
+beyond the fixed-point fast-path limit. They assert that eligible images
+actually use the specialized path and rejected images leave the buffer
+untouched before fallback. A separate eight-frame,
+two-renderer test compares partial redraws with overlapping and disjoint damage
+against the original renderer. Mode parsing and profiling counters have tests.
+
+### Paired Picade comparison
+
+The comparison release has SHA-256
+`65d7c019fe4e256231027bc0b5d49b116ff0eb07cc30c21b37c6fb0209aa210a`.
+Clock used Off, 24-hour time, 103 primitives and direct 1024×768 XRGB8888 output.
+Each configuration warmed up for five seconds, then collected six status samples
+three seconds apart. The same process alternated generic/RGB frames throughout;
+neither mode drew a second copy of the frame. The means below pool each mode's
+CPU totals and divide by that mode's valid CPU sample counts.
+
+| Clock presentation | Generic draw CPU | RGB-enabled draw CPU | Saving |
+| --- | ---: | ---: | ---: |
+| Raster 2×, 2048×1536 source | 16.53 ms | 14.85 ms | 1.68 ms / 10.2% |
+| Raster 1×, 1024×768 source | 14.93 ms | 11.39 ms | 3.54 ms / 23.7% |
+| Vector, no eligible RGB blits | 11.09 ms | 11.29 ms | No demonstrated gain |
+
+Each RGB-enabled raster frame handled one full-screen blit; generic frames
+handled none. Vector is a negative control: it does not use the fast path and
+its small difference is not evidence of an improvement. These are **whole Slint
+draw** savings, not equivalent percentages of total application CPU or latency.
+The alternating workload completed about 47 flips/s at raster 2× and 60 flips/s
+at raster 1×/vector; these are mixed-mode throughput figures, not pure RGB-mode
+performance.
+
+Earlier separate-process measurements varied enough to obscure the scale-2
+gain (generic draw 14.42 ms versus RGB 14.83 ms). That motivated the same-process
+comparison rather than selecting a favorable launch. Temperature snapshots
+ranged from approximately 72–76°C, and frequency snapshots from 1.3–1.5 GHz;
+the governor was not changed. Interleaving reduces launch/cache/thermal bias but
+does not freeze clock digits, control frequency, or turn rolling status windows
+into independent trials. Retain the raw reports when interpreting small changes.
+
+The specialized blit itself takes approximately 3.23 ms at scale 2 and 1.83 ms
+at scale 1. Independent RGB-only runs still leave about 8–10 ms of Slint drawing
+after subtracting both the timed window background and blit. This residual
+includes other scene rendering/setup; it is **not** measured image conversion
+or a demonstrated DRM wait. The optimization helps, but does not explain all
+of the remaining display cost.
+
+The final RGB-default release has SHA-256
+`a6c94e135ff2a6e82ce4041ba504df8d166db62ce737c8eebb01b48f2ed8f2c6`.
+A five-sample, three-second-spaced follow-up at raster 2× measured 14.78 ms draw
+CPU, 3.21 ms in the RGB blit, 1.82 ms in the window background, and 4.85 ms in the
+host callback. It still used about 99% of one core, with roughly 20.2 ms between
+frames (about 50 FPS). It handled one optimized blit per draw with no shadow
+buffer or copy. This verifies the deployed default, not another paired trial.
+
+### Falling as a comparison workload
+
+Falling was measured in the same comparison process, with the same display and
+six samples three seconds apart after warm-up. This is the **title screen**, not
+an active-gameplay benchmark. Sound was muted to avoid playing music during the
+measurement; the emulated APU and audio output thread remained active.
+
+Falling uses a separate NES runner thread and the native-video path, rather than
+Clock's scene generation and rasterization. Its 256×240 indexed framebuffer is
+expanded into a reused RGB8 buffer (180 KiB), cropped to 256×224, then displayed
+by Slint using aspect-preserving nearest-neighbor upscaling. Clock's scale-2
+source is 9 MiB. The launcher's raster/vector and raster-scale fields do **not**
+select Falling's native-video rendering path.
+
+| Falling title-screen measurement | Result |
+| --- | ---: |
+| Displayed page-flip completions | 60.0/s |
+| Reported emulated frames | 60.0/s |
+| Whole process CPU, one core = 100% | 154.6% |
+| UI/main thread CPU | 84.4% |
+| NES runner thread CPU | 68.7% |
+| Audio output thread CPU | 1.2% |
+| Slint draw CPU per draw | 13.05 ms |
+| Window background CPU, included in draw | 1.94 ms |
+| Queued callbacks CPU per draw, including video conversion/presentation | 0.66 ms |
+| Timer CPU per draw | 0.067 ms |
+| Page-flip wait wall time per draw | 2.48 ms |
+
+Process CPU uses systemd CPU-accounting deltas; thread CPU uses `/proc` task
+user/kernel tick deltas over the same collection interval. Stage values pool
+the backend windows and normalize by actual draw count, not event-loop count:
+native-video wakeups also produce loops without a draw. Callback time includes
+all queued work and is not an isolated measurement of palette expansion. The
+Clock-specific host callback fields are absent for this path, **not zero**.
+
+There were zero optimized RGB blits: fractional upscaling is deliberately left
+to Slint's original sampler. Generic/RGB-enabled draws measured 13.06/13.04 ms,
+consistent with both using the same fallback. Temperature snapshots were
+72–75°C and frequency snapshots 1.3–1.5 GHz. A screenshot taken outside the timed
+run verifies the title-screen workload, not physical scanout correctness.
+
+Falling therefore demonstrates that Clock's high-resolution rasterizer is not
+necessary for substantial UI CPU usage. Its emulation is additional parallel
+work, while software image scaling and the rest of Slint's scene drawing still
+consume most of the UI-thread budget. Further attribution inside the remaining
+draw work is needed before choosing the next optimization; this comparison does
+not establish that all of that time is scaling.
+
+Raw reports, collectors, pooled timing summaries, binary manifests, test/build
+logs and the Falling screenshot are retained in the collecting checkout under
+`target/clock-benchmarks/rgb-blit-picade-20260910/`. The RGB-default release was
+fast-deployed to Picade without a reboot. Clock Demo, raster 2×, all six effects,
+24-hour time, Clock wave, `SPACE WARS`, and unmuted 5% volume were restored.
+The Pi 5 target was not changed. Validation passed 930 workspace tests (20
+display-dependent tests skipped), 18 backend tests, and the explicitly run
+release presentation benchmark. The backend tests include the pixel-equivalence
+matrix and partial-damage checks described above.
+
+### Follow-up: attributing the remaining draw cost
+
+The [software presentation lab](presentation-performance-lab.md) adds nested
+draw attribution and identical frozen-image comparisons against a bare window.
+Its diagnostic Picade build measured **8.97 ms in dirty-region calculation**
+inside Clock's 14.85 ms draw, and 6.90 ms inside Falling's 13.26 ms draw. This
+accounts for much of the previously unattributed time above.
+
+The full UI also adds about 7 ms when drawing identical frozen pixels in RAM,
+including a background-only fixture. Quartering output pixel count does not
+remove that cost, nor does disabling the detailed timers. The next target is
+UI-tree/bounds bookkeeping, particularly inactive menus. No repaint-policy
+optimization has been made in this follow-up; see the lab for raw-report
+locations, controls, limitations and the next experiment.
+
+The subsequent conditional-panel experiment removes inactive menus and HUD
+subtrees from the application's item tree, while retaining settings and focus
+state in the root window. Live Clock dirty-region CPU falls to about 0.06 ms,
+whole draw CPU to 7.06 ms, and process CPU from 99% to 77% of one core while
+reaching 60 FPS instead of about 49. Falling also benefits. Rendering resolution
+and visual output are unchanged; 34 before/after menu PNGs and frozen-image
+checksums match. See the [conditional-panel results](presentation-performance-lab.md#conditional-panel-experiment-2026-09-10)
+for repeat runs, controls, thermal caveats and lifecycle coverage.
+
+## Final performance-batch checkpoint (2026-09-10)
+
+The complete matrix was rerun after all three optimizations: bulk RGB fills and
+background folding, the guarded LinuxKMS RGB blit, and conditional UI panels.
+The deployed Picade release is
+`8d9e714b108298e088991e71702a2dd287bddebe0d2813e0c44975f478bef98d`.
+The desktop release is
+`d97eccf57ee391e15e086064ed5319512876d657371d599165fbf8f86ab3e65a`.
+
+Each machine completed 42 independent runs and 37,800 measured frames: all
+seven cases, scales 1 and 2, three repeats, seed 7, 1024×768 viewport, Clock
+Wave, fixed 08:08, two simulated warm-up seconds and 15 measured seconds. The
+Pi kiosk stayed at its idle launcher; local build/test workloads started only
+after the desktop measurements finished. Every CSV contained the expected 900
+measured frames and matching fixture/dimension metadata. Event-active frame
+counts and maximum body counts agreed across repeats and both machines.
+
+Median per-run mean milliseconds per frame on Picade, compared with the
+initial baseline above:
+
+| Fixture | Initial 1× | Final 1× | Initial 2× | Final 2× |
+| --- | ---: | ---: | ---: | ---: |
+| Idle | 3.575 | 1.509 | 11.969 | 5.383 |
+| Falling | 3.950 | 1.954 | 12.853 | 6.199 |
+| Color Cycle | 3.574 | 1.558 | 12.137 | 5.401 |
+| Meltdown | 3.706 | 1.683 | 12.600 | 5.850 |
+| Duck | 4.087 | 1.877 | 13.538 | 6.433 |
+| Marquee (Clock Wave) | 3.693 | 1.513 | 12.228 | 5.452 |
+| Digit Slide | 3.666 | 1.565 | 12.326 | 5.479 |
+
+This confirms the earlier raster gains across the complete effect matrix:
+about **2.0–2.4× faster** than the initial baseline. Desktop final means range
+from 0.121–0.200 ms at 1× and 0.319–0.516 ms at 2×. These headless measurements
+cover stepping, scene construction and CPU raster preparation, including idle
+and recovery phases. They **exclude Slint display drawing and page flips**;
+the later presentation optimizations are validated by the separate frozen-image
+and live measurements above, not by these CSVs. This is not evidence that every
+active effect sustains 60 displayed FPS.
+
+Picade endpoint temperature readings were 74.5–77.4°C, with `ondemand` frequency
+snapshots of 0.9–1.5 GHz. This checkpoint did not rerun the initial binary or
+control frequency continuously; use the paired and baseline-recheck trials in
+the earlier sections for attribution, not small differences between this table
+and those trials.
+
+Raw CSVs, environment snapshots, binary metadata, the summary script and test
+logs are retained in this checkout under
+`target/clock-benchmarks/final-performance-picade-20260910/`. Picade was restored
+to unpaused Clock Demo, raster 2×, all six effects, 24-hour time, Clock Wave,
+`SPACE WARS`, and its original unmuted 5% volume. No new deployment, service
+restart, reboot, or Pi 5 change was needed for this checkpoint.
+
+Final validation passed 936 workspace/all-target tests, all 20 display-dependent
+UI functional tests under Xvfb, and 19 vendored LinuxKMS tests. The standalone
+backend's explicit timing benchmark remains opt-in. Rust 1.89 formatting,
+whitespace checks, and the strict NES/Falling CI Clippy check passed. Client
+Clippy completed with existing warnings; it is not a warning-free check.
+
 ## Regression coverage
 
 ```sh
@@ -206,3 +828,24 @@ physics bodies/colliders for Digit Slide, CSV alignment and dimensions, untouche
 settings, warm-up reset equivalence, bounded live samples and size-change reset.
 The CLI tests remove both display environment variables and assert no timing
 thresholds. Existing display-dependent Clock workflows cover the normal UI.
+
+Raster correctness tests (`cargo test --locked -p engine-client raster::tests`)
+compare bulk RGB fills against ordinary slice filling, including short spans,
+partial blocks and unaligned starts. Background folding is checked against the
+original clear-then-draw path, including partial/transparent backgrounds,
+strokes, winding, layer ordering, buffer reuse and resize. All six Clock effects
+are sampled through their active and recovered phases at landscape, portrait,
+and fractional-aspect viewports and must produce identical RGB pixels.
+
+The vendored backend's library tests cover bounded/completed windows, CPU-clock
+unavailability, counter semantics, repeated-stage aggregation, scope cleanup on
+early return, and disabled profiles. There are no machine-speed thresholds:
+
+```sh
+cargo test --locked --manifest-path vendor/i-slint-backend-linuxkms/Cargo.toml \
+  --features renderer-software --lib
+```
+
+This is also run by Linux CI and requires the Linux input/display development
+libraries listed in that job. The actual `pi-kiosk` build additionally needs
+libseat; the Yocto application recipe provides all target dependencies.

--- a/docs/presentation-performance-lab.md
+++ b/docs/presentation-performance-lab.md
@@ -1,0 +1,348 @@
+# Software presentation performance lab
+
+This lab separates software-renderer bookkeeping from pixel drawing. It builds
+on the [Clock measurements](clock-performance-lab.md), but also uses Falling's
+native-video image path. No graphics algorithm or repaint policy is changed by
+the diagnostic hooks.
+
+## Frozen-image comparison
+
+```sh
+cargo run --release --locked -p engine-client -- \
+  --benchmark-presentation --benchmark-width 1024 --benchmark-height 768 \
+  --presentation-frames 60 --presentation-repeats 4 --presentation-detail
+```
+
+The same command works on a deployed Pi using `engine-client` directly. It does
+not open a display connection, read/write settings, start input/audio workers,
+or bind the application's control socket. Leave the kiosk at its idle launcher
+while measuring on the Pi to avoid competing with an active scenario.
+
+Four fixed fixtures are drawn into ordinary XRGB8888 RAM:
+
+- Background only.
+- A 1024×768 Clock image fixed at 08:08:00, events Off.
+- The same Clock at 2048×1536, normally reduced to the output size.
+- Falling's 256×240 frame after 180 emulated frames, cropped to 256×224 and
+  enlarged using the native-video path's contain/pixelated settings.
+
+Fixture generation, including NES emulation, is completed before timed draws.
+The images remain frozen. One window contains only the image; the other is the
+real `MainWindow` type with its default UI models and menus inactive. In the
+baseline those menus remained in the tree; the conditional-panel optimization
+below removes them while inactive.
+It uses Falling's scenario label to suppress Clock's visible Controls button,
+so **both windows must produce exactly the same output pixels**. This tests the
+application shell, not a fully initialized live game's complete UI state.
+
+Both windows use Slint's generic software texture path, not the LinuxKMS RGB
+specialization. They force full repainting (`NewBuffer`), with no display pacing,
+DRM mappings, or page-flip waits. These are draw timings, **not application FPS**.
+Each block warms up with ten draws, then measures the requested frame count.
+The first window alternates between paired repeats. Completed buffers must be
+byte-for-byte equal; CSV rows include their checksums and dimensions.
+
+Experiments:
+
+```sh
+# Quarter the number of output pixels; keep source images unchanged.
+engine-client --benchmark-presentation --benchmark-width 512 --benchmark-height 384 \
+  --presentation-frames 60 --presentation-repeats 4 --presentation-detail
+
+# Publish a newly allocated but identical RGB image before each draw.
+engine-client --benchmark-presentation --benchmark-width 1024 --benchmark-height 768 \
+  --presentation-frames 60 --presentation-repeats 4 --presentation-detail \
+  --presentation-republish
+
+# Omit --presentation-detail to check the result without operation timestamps.
+engine-client --benchmark-presentation --benchmark-width 1024 --benchmark-height 768 \
+  --presentation-frames 60 --presentation-repeats 4
+```
+
+`--presentation-republish` excludes image allocation/copy/property assignment
+from the draw timer; their cache effects and deferred work can still affect the
+subsequent draw. It is not a measurement of total publication cost. With detail
+disabled, detailed CSV columns are zero/unmeasured, not evidence of free work.
+The viewport is bounded to 64–2048 pixels per axis, frames to 1–10000, and
+repeats to 1–20. Default output size is the shared benchmark default, 1280×720.
+
+## Live draw attribution
+
+LinuxKMS profiler version 5 adds `kms_draw_detail` and `kms_core_*` timings and
+call counts to `spacewars-cli status`. Detailed observation follows the existing
+profiler by default; set `SPACEWARS_KMS_DRAW_DETAIL=0` before application startup
+to disable these nested hooks, or `SPACEWARS_KMS_PROFILE=0` to disable all timing.
+Other display backends do not install this observer. The core hooks themselves
+are clock-free and optional; the backend owns CPU clocks and bounded storage.
+
+| Stage suffix | Scope |
+| --- | --- |
+| `render` | Complete Slint render call, inside the existing `draw` stage |
+| `prepare` | Buffer/window setup before dirty-region calculation |
+| `dirty` | Dirty-region calculation, including item bounds/cache processing |
+| `background` | Complete window-background fill |
+| `items` | Traversal and rendering of visible items, including operations below |
+| `image` | Image preparation and drawing, including texture work |
+| `texture` | Target texture operation, either accelerated or fallback |
+| `fallback` | Generic texture sampling/drawing; also includes internal glyph textures |
+| `rectangle` | Rectangle operations, including borders and gradients |
+| `text` | Text preparation and glyph drawing |
+| `path` | Path calls, even if the renderer does not support painting them |
+
+These stages are nested, not additive. For example, the existing RGB blit lies
+inside `core_texture`, which can lie inside `core_image` or `core_text`, then
+`core_items`. Use totals from the same completed-loop window, divided by actual
+draw count when reporting per-frame costs. Repeated operation calls are summed
+within each iteration. Recursive spans of the same kind are timed as their
+outermost span, avoiding double-counting that kind.
+
+The item operation counts indicate rendering calls, not dirty-tree visits or
+necessarily visible pixels. In particular, **zero text draw calls does not rule
+out text measurement while computing item bounds in `core_dirty`**. The dirty
+stage is not itself a measurement of font shaping or of one particular widget.
+
+## Baseline Picade results, 2026-09-10
+
+The release diagnostic build was fast-deployed to Picade's Pi 4, with its
+1024×768 XRGB8888 display, direct buffer mode and the existing RGB specialization
+enabled. No rendering algorithm or repaint-policy change was made for this
+experiment. The application SHA-256 is
+`63cd9037484f64abe53b05d0bec3777d9e49948d16a47c09e4d76240d4f584a8`.
+
+### Live Clock and Falling
+
+Each scenario warmed up for five seconds, then collected six status samples
+three seconds apart. Values pool stage CPU totals from the completed-loop
+windows and divide by the actual draw count. Clock used Off, 24-hour time,
+raster 2× and 103 primitives; Falling was at its title screen, with sound muted
+but emulation and audio workers still running.
+
+| CPU time per draw | Clock, raster 2× | Falling title screen |
+| --- | ---: | ---: |
+| Complete Slint draw | 14.85 ms | 13.26 ms |
+| Dirty-region calculation | **8.97 ms** | **6.90 ms** |
+| Window background | 1.82 ms | 1.95 ms |
+| Image preparation and drawing | 3.26 ms | 4.26 ms |
+| Visible text drawing | 0.47 ms | 0 calls |
+
+These rows are selected parts of the draw, not an exhaustive additive breakdown.
+Clock drew one image, one rectangle and one text item (the visible Clock
+Controls button). Falling drew one image, no rectangles and no text. Clock's
+optimized blit accounted for 3.24 ms inside image drawing; Falling used the
+generic texture sampler. Dirty-region work accounts for about 60% and 52% of
+their respective draw CPU costs.
+
+Clock still used about 99% of one core, with a 20.29 ms mean frame interval.
+Falling maintained about 60 page-flip completions/s and 60 emulated frames/s;
+its process used about 156% of one core, split chiefly between the UI thread
+(86%) and NES runner (68%). These are diagnostic-build observations, not gains
+from a new optimization. Temperature samples were 70–75°C; frequency samples
+were 1.4–1.5 GHz. Sampling does not hold the governor fixed.
+
+### Frozen pixels, bare window versus application shell
+
+At 1024×768, four paired repeats of 60 measured draws per window produced the
+following means. These are **wall times in ordinary RAM using the generic
+sampler**, not the live KMS CPU timings above.
+
+| Frozen fixture | Bare window | Full UI | Full UI dirty-region work |
+| --- | ---: | ---: | ---: |
+| Background only | 0.95 ms | 7.74 ms | 6.70 ms |
+| Clock, 1024×768 source | 5.50 ms | 12.56 ms | 6.95 ms |
+| Clock, 2048×1536 source | 5.81 ms | 12.88 ms | 6.90 ms |
+| Falling, 256×240 source | 4.68 ms | 11.77 ms | 6.88 ms |
+
+Every bare/full pair produced identical pixels. Neither window painted text or
+rectangles. The full UI adds roughly 6.7–7.1 ms even for an empty background;
+the main difference is dirty-region calculation, not additional visible drawing.
+
+The controls help narrow the cause:
+
+- Reducing output to 512×384 quarters the pixel count. Falling drops to
+  1.07 ms bare / 8.17 ms full, but full-UI dirty work remains 6.91 ms. The large
+  Clock source takes 1.65 / 8.71 ms, with 6.91 ms in dirty work.
+- Republishing identical images leaves the large Clock at 5.97 / 13.09 ms and
+  Falling at 4.78 / 11.98 ms. This does not explain the multi-millisecond UI gap;
+  remember that publication itself is outside the timer.
+- Disabling operation timestamps leaves the large Clock at 5.80 / 12.86 ms and
+  Falling at 4.68 / 11.78 ms. The gap is not an artifact of those timestamps.
+- The desktop reproduces approximately 1.0 ms of extra full-UI dirty work at
+  both output sizes. At 1024×768, Falling takes 0.58 / 1.62 ms. Its release
+  SHA-256 is
+  `05b61e305e1693c224b825b283d633a415914ef99ba22dfd65e3aeb23f7ff448`.
+
+These are small diagnostic runs, not controlled thermal trials or confidence
+intervals. Bare/full order alternates within a run; the different experiments
+run sequentially. The kiosk remained at the idle launcher during Pi probes.
+Before/after snapshots ranged from 65–75°C and 0.6–1.5 GHz, and do not establish
+the frequency during every draw. Treat small cross-run differences cautiously.
+
+### What to investigate next
+
+The evidence points to UI-tree bookkeeping, including inactive controls.
+In the vendored core, `PartialRenderer::compute_dirty_regions()` visits the
+item tree and computes bounds for uncached items. That path does not prune
+invisible subtrees. The uncached branch does not populate the rendering cache;
+items omitted from actual drawing can therefore repeat this work. Text bounds
+call `text_size()`. Many application menus use `visible` rather than conditional
+construction. See [the dirty-region traversal](../vendor/i-slint-core/item_rendering.rs)
+and [the application UI](../crates/engine-client/ui/main.slint).
+
+This is a source-backed explanation for the measured bucket, **not a measurement
+of which hidden widgets or text operations dominate it**. The probe intentionally
+uses default models and Falling's label, so it does not explain every difference
+between the 6.9 ms probe and 9.0 ms live Clock bucket.
+
+This motivated an experiment to remove inactive menu subtrees from the hot path and
+repeat the same pixel and timing comparisons. A narrower full-repaint fast path
+that avoids unnecessary dirty analysis is another candidate, but must preserve
+cache invalidation, visibility transitions, old-pixel damage, resizing, and
+buffer-age behavior. Neither optimization was part of the diagnostic baseline.
+There is no reason yet to change Clock's simulation or reduce its visual
+quality to address this particular cost.
+
+Raw CSV/JSON reports, collectors, summaries, build/deploy/test logs, binary
+hashes and restored-device state are retained in the collecting checkout under
+`target/clock-benchmarks/draw-detail-picade-20260910/`. After that collection,
+Clock Demo, raster 2×, all six effects, 24-hour time, Clock wave,
+`SPACE WARS`, and unmuted 5% volume were restored; the service did not crash or
+reboot during collection. Pi 5 was not changed.
+
+## Conditional-panel experiment, 2026-09-10
+
+The application UI now constructs launcher, pause, game-over, touch-test,
+notification and scenario-specific HUD panels only while they are needed.
+Launcher pages and the pause help panel are conditional too. Their settings,
+selection indices and callbacks remain on `MainWindow`; its keyboard focus
+scope remains alive even when the launcher is absent. No vendor rendering,
+repaint-policy, resolution, frame-rate target, or simulation changes were made
+for this optimization.
+
+The Pi release SHA-256 is
+`8d9e714b108298e088991e71702a2dd287bddebe0d2813e0c44975f478bef98d`;
+the desktop release SHA-256 is
+`d97eccf57ee391e15e086064ed5319512876d657371d599165fbf8f86ab3e65a`.
+Both use the same diagnostic hooks as the baseline above.
+
+### Frozen-pixel comparison
+
+The Pi ran the saved baseline and new binary in old/new/old/new order, with the
+kiosk idle at its launcher. Each process ran four paired blocks of 60 measured
+draws per window at 1024×768, after ten warm-up draws per block. The table pools
+the two runs of each binary. Every paired image and every before/after fixture
+checksum matches. These remain generic-sampler RAM **draw wall times**, not FPS.
+
+| Frozen fixture, full UI | Before | Conditional panels |
+| --- | ---: | ---: |
+| Background only | 7.62 ms | 0.96 ms |
+| Clock, 1024×768 source | 12.68 ms | 5.51 ms |
+| Clock, 2048×1536 source | 13.04 ms | 5.91 ms |
+| Falling, 256×240 source | 12.01 ms | 4.73 ms |
+
+Full-UI dirty calculation fell from approximately 6.6–7.1 ms to 0.01–0.02 ms.
+The new full-UI draw times closely match the bare window. The second baseline
+run still exhibits the original cost, ruling out a one-time warm-up explanation
+for its disappearance. Small pixel-drawing variations remain between runs.
+On the desktop, the large Clock fixture falls from 1.75 to 0.69 ms and Falling
+from 1.65 to 0.59 ms; full-UI dirty work falls from about 1.05 ms to 0.001 ms.
+
+### Live Picade comparison
+
+Clock was sampled immediately before and after the deployment using Off,
+24-hour time, raster 2×, 103 primitives, direct 1024×768 output and the RGB
+specialization. Both collections use six samples three seconds apart after
+five seconds of warm-up. Falling uses the earlier version-5 title-screen
+baseline above and a new collection with the same settings, muted sound, and
+sampling procedure. Stage CPU times pool totals and divide by draw count.
+
+| Live measurement | Before | Conditional panels |
+| --- | ---: | ---: |
+| Clock draw CPU per frame | 14.82 ms | 7.06 ms |
+| Clock dirty-region CPU per frame | 8.87 ms | 0.06 ms |
+| Clock displayed FPS | about 49 | 60 |
+| Clock process CPU, one core = 100% | 99% | 77% |
+| Falling draw CPU per frame | 13.26 ms | 6.76 ms |
+| Falling dirty-region CPU per frame | 6.90 ms | 0.04 ms |
+| Falling page-flip completions/s | about 60 | about 60 |
+| Falling process CPU, one core = 100% | 156% | 122% |
+
+The change removes the dominant UI-tree cost without changing the visible
+scene. Clock now reaches its 60 Hz target and spends time waiting for page
+flips. This is not a claim that Clock rendering is free: its host callback still
+takes about 5.25 ms, and the background and optimized image blit take about
+2.09 ms and 3.99 ms respectively. Falling still has a separate NES runner;
+its UI thread falls from about 86% to 47% of a core, while emulation remains
+roughly 68–74% across these samples.
+
+These are not fixed-frequency trials. Clock's before samples were 75–77°C at
+1.5 GHz; after samples were 71–73°C at 1.2–1.5 GHz. Different frame pacing,
+memory/cache behavior and governor decisions can affect the other buckets.
+The controlled, frozen-pixel comparisons support the large bookkeeping gain;
+the live numbers describe the resulting application behavior on this device.
+
+### Lifecycle verification and artifacts
+
+A new headless test opens and removes 17 UI states at landscape and portrait
+sizes, preserving the old framebuffer across transitions and resize. Each
+partial repaint must match a complete repaint, and root settings and selection
+state must survive panel removal. Its 34 PNGs were also byte-identical before
+and after this change on the same desktop. To retain them locally:
+
+```sh
+SPACEWARS_MENU_TEST_ARTIFACTS=/tmp/spacewars-menu-images \
+  cargo test --locked -p engine-client --bin engine-client ui_render_tests
+```
+
+A separate real Slint input test repeatedly removes a pressed launcher button,
+renders the changed tree, releases the pointer, and reopens the launcher. It
+checks that the removed button is not activated and that touch and keyboard
+shortcuts still work after reconstruction. Existing keyboard/touch tests pass.
+Picade's public UI API was also exercised through pause/help/Clock/sound,
+launcher settings/help/touch-test, and Clock → Falling → Clock. A follow-up
+after these menu cycles still measured about 7.08 ms Clock draw CPU at 60 FPS.
+
+Initial validation passed 934 workspace tests (20 display-dependent tests
+skipped), 19 backend tests (one explicit benchmark skipped), formatting and
+whitespace checks. The new tests run headlessly. The final checkpoint below
+also ran the display-dependent tests under an isolated Xvfb server.
+
+Reports, collectors, summaries, menu PNG pairs, build/deploy/test logs and device
+state are retained under
+`target/clock-benchmarks/menu-pruning-picade-20260910/`. The optimized release
+remains deployed to Picade; Clock Demo and the original display/effect/audio
+settings were restored. No reboot, OS update, or Pi 5 deployment was performed.
+
+## Validation
+
+```sh
+cargo test --locked --workspace --all-targets
+xvfb-run -a -s "-screen 0 1280x1024x24" \
+  cargo test --locked -p engine-client --test ui_control_functional -- \
+  --ignored --test-threads=1
+cargo test --locked -p engine-client --test presentation_probe
+cargo test --locked --manifest-path vendor/i-slint-backend-linuxkms/Cargo.toml \
+  --features renderer-software --lib
+```
+
+Black-box tests run with no display and an invalid backend name, preserve an
+intentionally malformed settings file, assert that no extra files/socket are
+created, compare both windows and publication modes, check CSV columns/call
+counts, and reject invalid limits. They have no machine-speed thresholds.
+Backend tests verify balanced nested accounting and distinguish generic
+fallbacks from the RGB fast path without changing pixels. The standalone backend
+tests now use the same locally patched core as the application so the observer
+API and existing core fixes are exercised together.
+
+The final performance batch passed **936 workspace/all-target tests**, all
+**20 display-dependent UI functional tests**, and **19 backend tests**, using
+Rust 1.89. The backend's explicit timing benchmark remains opt-in and was not
+part of this final correctness run. Xvfb was extracted into a temporary directory
+and used without a system install or changes to the workstation's active display.
+Formatting and whitespace checks passed. Client Clippy completes with existing
+warnings; the CI NES/Falling `-D warnings` check passed. Release builds on desktop
+and Pi, and the Picade fast deployment, were validated in the preceding experiment.
+
+The [final Clock matrix](clock-performance-lab.md#final-performance-batch-checkpoint-2026-09-10)
+records all seven effects on both machines after the combined changes. Final
+matrix and test logs are retained under
+`target/clock-benchmarks/final-performance-picade-20260910/`.

--- a/vendor/i-slint-backend-linuxkms/Cargo.lock
+++ b/vendor/i-slint-backend-linuxkms/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -78,6 +78,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "serde",
+ "unty",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,13 +96,13 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn",
 ]
@@ -110,19 +120,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
-name = "block2"
-version = "0.5.1"
+name = "borsh"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
- "objc2 0.5.2",
+ "bytes",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -151,6 +168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "calloop"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -213,7 +236,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -232,6 +255,22 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
+name = "codemap"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24"
+
+[[package]]
+name = "codemap-diagnostic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc20770be05b566a963bf91505e60412c4a2d016d1ef95c5512823bb085a8122"
+dependencies = [
+ "codemap",
+ "termcolor",
+]
 
 [[package]]
 name = "color_quant"
@@ -331,6 +370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,20 +456,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.4",
- "objc2 0.6.2",
+ "objc2",
 ]
 
 [[package]]
-name = "drm"
-version = "0.12.0"
+name = "displaydoc"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "bitflags 2.9.4",
- "bytemuck",
- "drm-ffi 0.8.0",
- "drm-fourcc",
- "rustix 0.38.44",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -435,19 +478,9 @@ checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
  "bitflags 2.9.4",
  "bytemuck",
- "drm-ffi 0.9.0",
+ "drm-ffi",
  "drm-fourcc",
  "libc",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "drm-ffi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53"
-dependencies = [
- "drm-sys 0.7.0",
  "rustix 0.38.44",
 ]
 
@@ -457,7 +490,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e41459d99a9b529845f6d2c909eb9adf3b6d2f82635ae40be8de0601726e8b"
 dependencies = [
- "drm-sys 0.8.0",
+ "drm-sys",
  "rustix 0.38.44",
 ]
 
@@ -466,16 +499,6 @@ name = "drm-fourcc"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
-
-[[package]]
-name = "drm-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986"
-dependencies = [
- "libc",
- "linux-raw-sys 0.6.5",
-]
 
 [[package]]
 name = "drm-sys"
@@ -489,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "dwrote"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c93d234bac0cdd0e2ac08bc8a5133f8df2169e95b262dfcea5e5cb7855672f"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
 dependencies = [
  "lazy_static",
  "libc",
@@ -520,7 +543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -576,21 +599,20 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -649,7 +671,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
  "ttf-parser 0.21.1",
 ]
 
@@ -681,13 +703,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "gbm"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
 dependencies = [
  "bitflags 2.9.4",
- "drm 0.14.1",
+ "drm",
  "drm-fourcc",
  "gbm-sys",
  "libc",
@@ -754,10 +785,10 @@ dependencies = [
  "glutin_egl_sys",
  "glutin_wgl_sys",
  "libloading",
- "objc2 0.6.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
  "once_cell",
  "raw-window-handle",
  "windows-sys 0.52.0",
@@ -784,14 +815,21 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -803,6 +841,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -834,7 +878,7 @@ version = "1.13.1"
 dependencies = [
  "bytemuck",
  "calloop",
- "drm 0.14.1",
+ "drm",
  "gbm",
  "glutin",
  "i-slint-common",
@@ -846,8 +890,21 @@ dependencies = [
  "memmap2",
  "nix",
  "raw-window-handle",
+ "slint",
  "vulkano",
  "xkbcommon",
+]
+
+[[package]]
+name = "i-slint-backend-selector"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5c1525cd7a659b609600a7df79bb7d90092730d5c4de4f378f39ab9a023993"
+dependencies = [
+ "cfg-if",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
 ]
 
 [[package]]
@@ -864,10 +921,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "i-slint-core"
+name = "i-slint-compiler"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d10fc4c25a22e757784acf7da950223762477329f01d73e1c9cfa0749bf51a"
+checksum = "8e7e35548ed4f437f7fcb7c2bb11bbd0f45c8271d1900b47b688e4eed89482d0"
+dependencies = [
+ "by_address",
+ "codemap",
+ "codemap-diagnostic",
+ "derive_more",
+ "i-slint-common",
+ "itertools 0.14.0",
+ "linked_hash_set",
+ "lyon_extra",
+ "lyon_path",
+ "num_enum",
+ "proc-macro2",
+ "quote",
+ "rowan",
+ "smol_str",
+ "strum",
+ "typed-index-collections",
+ "url",
+]
+
+[[package]]
+name = "i-slint-core"
+version = "1.13.1"
 dependencies = [
  "auto_enums",
  "bitflags 2.9.4",
@@ -969,12 +1049,12 @@ dependencies = [
  "i-slint-core",
  "i-slint-core-macros",
  "lyon_path",
- "objc2 0.6.2",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
- "objc2-metal 0.3.1",
- "objc2-quartz-core 0.3.1",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
  "pin-weak",
  "raw-window-handle",
  "raw-window-metal",
@@ -1015,6 +1095,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "image"
 version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,18 +1229,18 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgref"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1110,16 +1292,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "js-sys"
-version = "0.3.78"
+name = "jni-sys"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1161,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1183,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "libseat"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23a245bbd5790c690791c4fe6eefafe4c75851226288a71cb657601135aa00c"
+checksum = "6656c69b6e0366ffb83faa232f3e4fda5fc91161722d140f2c95ce2e90b1ef31"
 dependencies = [
  "errno",
  "libseat-sys",
@@ -1194,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "libseat-sys"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134621e50557e8698a96ccff3eadbc6f4b449d5d12f8aa48fcef8d40b4b02725"
+checksum = "e8a484fa48be5f62a8d3ffed767779d0ab808cfead91de98ef4362d469097dfb"
 dependencies = [
  "pkg-config",
 ]
@@ -1209,6 +1428,21 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1230,6 +1464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,9 +1487,9 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.16.1"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "lyon_algorithms"
@@ -1343,6 +1583,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.9.4",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,19 +1639,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
+name = "num_enum"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
 
 [[package]]
-name = "objc2"
-version = "0.5.2"
+name = "num_enum_derive"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "objc-sys",
- "objc2-encode",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1406,20 +1676,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
  "bitflags 2.9.4",
- "objc2 0.6.2",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.9.4",
  "dispatch2",
- "objc2 0.6.2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.9.4",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -1430,74 +1713,48 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.9.4",
- "block2",
- "libc",
- "objc2 0.5.2",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
-name = "objc2-foundation"
-version = "0.3.1"
+name = "objc2-io-surface"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.9.4",
- "objc2 0.6.2",
+ "objc2",
  "objc2-core-foundation",
 ]
 
 [[package]]
 name = "objc2-metal"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.9.4",
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f246c183239540aab1782457b35ab2040d4259175bd1d0c58e46ada7b47a874"
-dependencies = [
- "bitflags 2.9.4",
- "objc2 0.6.2",
- "objc2-foundation 0.3.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-quartz-core"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.9.4",
- "block2",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal 0.2.2",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ffb6a0cd5f182dc964334388560b12a57f7b74b3e2dec5e2722aa2dfb2ccd5"
-dependencies = [
- "bitflags 2.9.4",
- "objc2 0.6.2",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
- "objc2-metal 0.3.1",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1534,6 +1791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1827,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pin-weak"
@@ -1627,6 +1896,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1912,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -1662,9 +1949,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1681,10 +1968,10 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "objc2 0.6.2",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.1",
- "objc2-quartz-core 0.3.1",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -1698,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1710,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1721,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resvg"
@@ -1752,6 +2039,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,9 +2058,15 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1795,7 +2100,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1848,18 +2153,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1957,6 +2272,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db491c0d4152a069911a0fbdaca959691bf0b9d7110d98a7ed1c8e59b79ab30"
 
 [[package]]
+name = "slint"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f467a64a49620e41807016dc1d519ba0ebb9d1322f734853059f93b8c3f3d2bd"
+dependencies = [
+ "const-field-offset",
+ "i-slint-backend-selector",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "num-traits",
+ "once_cell",
+ "pin-weak",
+ "slint-macros",
+ "unicode-segmentation",
+ "vtable",
+]
+
+[[package]]
+name = "slint-macros"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11f55a603d8bb037f0831d4f4e91a560cfe93d93ddf2f992aa375b620f4bca3"
+dependencies = [
+ "i-slint-compiler",
+ "proc-macro2",
+ "quote",
+ "spin_on",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,27 +2317,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "softbuffer"
-version = "0.4.6"
+name = "smol_str"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "softbuffer"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
- "cfg_aliases",
- "core-graphics",
- "drm 0.12.0",
- "foreign-types",
+ "drm",
  "js-sys",
- "log",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
+ "ndk",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
- "rustix 0.38.44",
+ "rustix 1.1.2",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin_on"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2"
+dependencies = [
+ "pin-utils",
 ]
 
 [[package]]
@@ -2053,6 +2417,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sys-locale"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,14 +2438,29 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -2128,6 +2518,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,8 +2550,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2164,6 +2564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,9 +2581,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -2213,6 +2643,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
+]
+
+[[package]]
+name = "typed-index-collections"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd393dbd1e7b23e0cab7396570309b4068aa504e9dac2cd41d827583b4e9ab7"
+dependencies = [
+ "bincode",
+ "serde",
 ]
 
 [[package]]
@@ -2288,6 +2728,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "usvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2771,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -2383,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2395,24 +2859,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2420,31 +2870,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2481,6 +2931,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2539,8 +2998,8 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -2570,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2592,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2609,9 +3068,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
@@ -2693,16 +3152,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2738,17 +3197,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
  "windows_i686_gnullvm 0.53.0",
  "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
 ]
@@ -2860,9 +3319,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2902,9 +3361,18 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -2919,10 +3387,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "1.5.1"
+name = "writeable"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.2",
@@ -2947,15 +3421,112 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zune-core"

--- a/vendor/i-slint-backend-linuxkms/Cargo.toml
+++ b/vendor/i-slint-backend-linuxkms/Cargo.toml
@@ -58,6 +58,7 @@ renderer-skia-vulkan = [
 ]
 renderer-software = [
     "i-slint-core/software-renderer-systemfonts",
+    "i-slint-core/experimental",
     "drm",
     "dep:bytemuck",
     "dep:memmap2",
@@ -66,6 +67,14 @@ renderer-software = [
 [lib]
 name = "i_slint_backend_linuxkms"
 path = "lib.rs"
+
+[dev-dependencies.slint]
+version = "=1.13.1"
+default-features = false
+features = ["std", "compat-1-2"]
+
+[patch.crates-io]
+i-slint-core = { path = "../i-slint-core" }
 
 [dependencies.i-slint-common]
 version = "=1.13.1"
@@ -141,6 +150,7 @@ version = "0.30.1"
 features = [
     "fs",
     "ioctl",
+    "time",
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies.raw-window-handle]

--- a/vendor/i-slint-backend-linuxkms/Cargo.toml.orig
+++ b/vendor/i-slint-backend-linuxkms/Cargo.toml.orig
@@ -20,7 +20,7 @@ renderer-skia = ["renderer-skia-opengl"]
 renderer-skia-vulkan = ["i-slint-renderer-skia/vulkan", "vulkano", "drm", "dep:memmap2"]
 renderer-skia-opengl = ["i-slint-renderer-skia/opengl", "drm", "gbm", "glutin", "raw-window-handle", "dep:memmap2"]
 renderer-femtovg = ["i-slint-renderer-femtovg/opengl", "drm", "gbm", "glutin", "raw-window-handle"]
-renderer-software = ["i-slint-core/software-renderer-systemfonts", "drm", "dep:bytemuck", "dep:memmap2"]
+renderer-software = ["i-slint-core/software-renderer-systemfonts", "i-slint-core/experimental", "drm", "dep:bytemuck", "dep:memmap2"]
 libseat = ["dep:libseat"]
 
 #default = ["renderer-skia", "renderer-femtovg"]
@@ -37,7 +37,7 @@ input = { workspace = true, default-features = true }
 xkbcommon = { version = "0.8.0" }
 calloop = { version = "0.14.1" }
 libseat = { version = "0.2.1", optional = true, default-features = false }
-nix = { version = "0.30.1", features = ["fs", "ioctl"] }
+nix = { version = "0.30.1", features = ["fs", "ioctl", "time"] }
 vulkano = { version = "0.35.0", optional = true, default-features = false }
 drm = { version = "0.14.0", optional = true }
 gbm = { version = "0.18.0", optional = true, default-features = false, features = ["drm-support"] }
@@ -45,6 +45,12 @@ glutin = { workspace = true, optional = true, default-features = false, features
 raw-window-handle = { version = "0.6.2", optional = true }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 memmap2 = { version = "0.9.4", optional = true }
+
+[dev-dependencies]
+slint = { version = "=1.13.1", default-features = false, features = ["std", "compat-1-2"] }
+
+[patch.crates-io]
+i-slint-core = { path = "../i-slint-core" }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/vendor/i-slint-backend-linuxkms/calloop_backend.rs
+++ b/vendor/i-slint-backend-linuxkms/calloop_backend.rs
@@ -17,6 +17,7 @@ use calloop::EventLoop;
 use i_slint_core::platform::PlatformError;
 
 use crate::fullscreenwindowadapter::FullscreenWindowAdapter;
+use crate::profiling::{Scope, Stage};
 use crate::BackendBuilder;
 
 #[cfg(not(any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32")))]
@@ -248,18 +249,27 @@ impl i_slint_core::platform::Platform for Backend {
         quit_loop.store(false, std::sync::atomic::Ordering::Release);
 
         while !quit_loop.load(std::sync::atomic::Ordering::Acquire) {
-            i_slint_core::platform::update_timers_and_animations();
+            let _loop_profile = Scope::new(Stage::Loop);
+            {
+                let _timers = Scope::new(Stage::Timers);
+                i_slint_core::platform::update_timers_and_animations();
+            }
 
             // Only after updating the animation tick, invoke callbacks from invoke_from_event_loop(). They
             // might set animated properties, which requires an up-to-date start time.
-            for callback in callbacks_to_invoke_per_iteration.take().into_iter() {
-                callback();
+            {
+                let _callbacks = Scope::new(Stage::Callbacks);
+                for callback in callbacks_to_invoke_per_iteration.take().into_iter() {
+                    callback();
+                }
             }
 
             if let Some(adapter) = self.window.borrow().as_ref() {
+                let _render = Scope::new(Stage::Render);
                 adapter.clone().render_if_needed(mouse_position_property.as_ref())?;
             };
 
+            let _dispatch = Scope::new(Stage::Dispatch);
             let next_timeout = i_slint_core::platform::duration_until_next_timer_update();
             event_loop
                 .dispatch(next_timeout, &mut loop_data)

--- a/vendor/i-slint-backend-linuxkms/display/swdisplay/dumbbuffer.rs
+++ b/vendor/i-slint-backend-linuxkms/display/swdisplay/dumbbuffer.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::drmoutput::DrmOutput;
+use crate::profiling::{Scope, Stage};
 use drm::control::Device;
 use i_slint_core::platform::PlatformError;
 
@@ -77,11 +78,18 @@ impl super::SoftwareBufferDisplay for DumbBufferDisplay {
         let mut back_buffer = self.back_buffer.borrow_mut();
         let age = back_buffer.age;
         let format = back_buffer.format;
-        self.drm_output
-            .drm_device
-            .map_dumb_buffer(&mut back_buffer.buffer_handle)
-            .map_err(|e| PlatformError::Other(format!("Error mapping dumb buffer: {e}").into()))
-            .and_then(|mut buffer| callback(buffer.as_mut(), age, format))
+        let mut buffer = {
+            let _map = Scope::new(Stage::Map);
+            self.drm_output.drm_device.map_dumb_buffer(&mut back_buffer.buffer_handle).map_err(
+                |e| PlatformError::Other(format!("Error mapping dumb buffer: {e}").into()),
+            )?
+        };
+        let result = callback(buffer.as_mut(), age, format);
+        {
+            let _unmap = Scope::new(Stage::Unmap);
+            drop(buffer);
+        }
+        result
     }
 
     fn as_presenter(self: Arc<Self>) -> Arc<dyn crate::display::Presenter> {
@@ -91,8 +99,12 @@ impl super::SoftwareBufferDisplay for DumbBufferDisplay {
 
 impl crate::display::Presenter for DumbBufferDisplay {
     fn present(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.drm_output.wait_for_page_flip();
+        {
+            let _wait = Scope::new(Stage::FlipWait);
+            self.drm_output.wait_for_page_flip();
+        }
 
+        let _submit = Scope::new(Stage::Submit);
         self.back_buffer.swap(&self.front_buffer);
         self.front_buffer.swap(&self.in_flight_buffer);
 

--- a/vendor/i-slint-backend-linuxkms/drmoutput.rs
+++ b/vendor/i-slint-backend-linuxkms/drmoutput.rs
@@ -5,6 +5,7 @@ use std::cell::{Cell, RefCell};
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::rc::Rc;
 
+use crate::profiling::{self, Counter};
 use crate::DeviceOpener;
 use drm::buffer::Buffer;
 use drm::control::Device;
@@ -209,6 +210,7 @@ impl DrmOutput {
             self.drm_device
                 .page_flip(self.crtc, framebuffer_handle, drm::control::PageFlipFlags::EVENT, None)
                 .map_err(|e| format!("Error presenting framebuffer on screen: {e}"))?;
+            profiling::count(Counter::FlipSubmissions);
 
             *self.page_flip_state.borrow_mut() =
                 PageFlipState::WaitingForPageFlip { _buffer_to_keep_alive_until_flip: last_buffer };
@@ -223,6 +225,7 @@ impl DrmOutput {
                 )
                 .map_err(|e| format!("Error presenting framebuffer on screen: {e}"))?;
             *self.page_flip_state.borrow_mut() = PageFlipState::InitialBufferPosted;
+            profiling::count(Counter::Modesets);
         }
 
         Ok(())
@@ -240,6 +243,7 @@ impl DrmOutput {
 
         loop {
             let Ok(mut event_it) = self.drm_device.receive_events() else {
+                profiling::count(Counter::FlipReadErrors);
                 return;
             };
 
@@ -247,6 +251,7 @@ impl DrmOutput {
                 if let PageFlipState::WaitingForPageFlip { .. } =
                     self.page_flip_state.replace(PageFlipState::ReadyForNextBuffer)
                 {
+                    profiling::count(Counter::FlipCompletions);
                     return;
                 }
             }

--- a/vendor/i-slint-backend-linuxkms/lib.rs
+++ b/vendor/i-slint-backend-linuxkms/lib.rs
@@ -21,6 +21,9 @@ mod drmoutput;
 mod display;
 
 #[cfg(target_os = "linux")]
+pub mod profiling;
+
+#[cfg(target_os = "linux")]
 mod renderer {
     use i_slint_core::platform::PlatformError;
 

--- a/vendor/i-slint-backend-linuxkms/profiling.rs
+++ b/vendor/i-slint-backend-linuxkms/profiling.rs
@@ -1,0 +1,615 @@
+// Copyright © Space-Wars contributors
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Local, bounded LinuxKMS software-presentation diagnostics. These measure CPU
+//! rendering and DRM calls, not GPU execution or verified physical scanouts.
+//! Read on the UI thread. Set SPACEWARS_KMS_PROFILE=0 before startup to disable.
+
+use nix::time::{clock_gettime, ClockId};
+use std::{
+    cell::RefCell,
+    collections::VecDeque,
+    fmt::Write,
+    time::{Duration, Instant},
+};
+
+const SAMPLE_LIMIT: usize = 120;
+const STAGE_COUNT: usize = 26;
+const COUNTER_COUNT: usize = 8;
+
+#[derive(Clone, Copy)]
+pub(crate) enum Stage {
+    Loop,
+    Timers,
+    Callbacks,
+    Render,
+    Dispatch,
+    Map,
+    Draw,
+    Unmap,
+    FlipWait,
+    Submit,
+    Background,
+    Copy,
+    RgbBlit,
+    DrawGeneric,
+    DrawRgb,
+    CoreRender,
+    CorePrepare,
+    CoreDirty,
+    CoreItems,
+    CoreImage,
+    CoreTexture,
+    CoreFallback,
+    CoreRectangle,
+    CoreText,
+    CorePath,
+    CoreBackground,
+}
+
+const STAGES: [(Stage, &str); STAGE_COUNT] = [
+    (Stage::Loop, "loop"),
+    (Stage::Timers, "timers"),
+    (Stage::Callbacks, "callbacks"),
+    (Stage::Render, "render"),
+    (Stage::Dispatch, "dispatch"),
+    (Stage::Map, "map"),
+    (Stage::Draw, "draw"),
+    (Stage::Unmap, "unmap"),
+    (Stage::FlipWait, "flip_wait"),
+    (Stage::Submit, "submit"),
+    (Stage::Background, "background"),
+    (Stage::Copy, "copy"),
+    (Stage::RgbBlit, "rgb_blit"),
+    (Stage::DrawGeneric, "draw_generic"),
+    (Stage::DrawRgb, "draw_rgb"),
+    (Stage::CoreRender, "core_render"),
+    (Stage::CorePrepare, "core_prepare"),
+    (Stage::CoreDirty, "core_dirty"),
+    (Stage::CoreItems, "core_items"),
+    (Stage::CoreImage, "core_image"),
+    (Stage::CoreTexture, "core_texture"),
+    (Stage::CoreFallback, "core_fallback"),
+    (Stage::CoreRectangle, "core_rectangle"),
+    (Stage::CoreText, "core_text"),
+    (Stage::CorePath, "core_path"),
+    (Stage::CoreBackground, "core_background"),
+];
+
+#[derive(Clone, Copy)]
+pub(crate) enum Counter {
+    Draws,
+    FlipSubmissions,
+    FlipCompletions,
+    Modesets,
+    FlipReadErrors,
+    CopyBytes,
+    RgbBlits,
+    RgbPixels,
+}
+
+const COUNTERS: [&str; COUNTER_COUNT] = [
+    "draws",
+    "flip_submissions",
+    "flip_completions",
+    "modesets",
+    "flip_read_errors",
+    "copy_bytes",
+    "rgb_blits",
+    "rgb_pixels",
+];
+
+#[derive(Clone, Copy)]
+struct Stamp {
+    wall: Instant,
+    cpu: Option<Duration>,
+}
+
+impl Stamp {
+    fn now() -> Self {
+        let wall = Instant::now();
+        let cpu = clock_gettime(ClockId::CLOCK_THREAD_CPUTIME_ID).ok().and_then(|time| {
+            Some(Duration::new(time.tv_sec().try_into().ok()?, time.tv_nsec().try_into().ok()?))
+        });
+        Self { wall, cpu }
+    }
+
+    fn elapsed(self) -> Elapsed {
+        let end = Self::now();
+        Elapsed {
+            wall: end.wall.duration_since(self.wall),
+            cpu: self.cpu.zip(end.cpu).and_then(|(start, end)| end.checked_sub(start)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct Elapsed {
+    wall: Duration,
+    cpu: Option<Duration>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct StageSample {
+    calls: u64,
+    elapsed: Elapsed,
+}
+
+impl StageSample {
+    fn add(&mut self, elapsed: Elapsed) {
+        self.elapsed.cpu = if self.calls == 0 {
+            elapsed.cpu
+        } else {
+            self.elapsed.cpu.zip(elapsed.cpu).map(|(a, b)| a + b)
+        };
+        self.elapsed.wall += elapsed.wall;
+        self.calls += 1;
+    }
+}
+
+#[derive(Clone, Default)]
+struct LoopSample {
+    stages: [StageSample; STAGE_COUNT],
+    counters: [u64; COUNTER_COUNT],
+    dirty_pixels: u64,
+}
+
+struct Profile {
+    active: bool,
+    enabled: bool,
+    size: (u32, u32),
+    format: &'static str,
+    buffer_bytes: usize,
+    buffer_age: u8,
+    buffer_mode: &'static str,
+    shadow_bytes: usize,
+    texture_mode: &'static str,
+    draw_detail: bool,
+    current: Option<LoopSample>,
+    samples: VecDeque<LoopSample>,
+    loops_total: u64,
+    counters_total: [u64; COUNTER_COUNT],
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Self {
+            active: false,
+            enabled: false,
+            size: (0, 0),
+            format: "unknown",
+            buffer_bytes: 0,
+            buffer_age: 0,
+            buffer_mode: "unknown",
+            shadow_bytes: 0,
+            texture_mode: "unknown",
+            draw_detail: false,
+            current: None,
+            samples: VecDeque::new(),
+            loops_total: 0,
+            counters_total: [0; COUNTER_COUNT],
+        }
+    }
+}
+
+impl Profile {
+    fn record(&mut self, stage: Stage, elapsed: Elapsed) {
+        if let Some(sample) = &mut self.current {
+            sample.stages[stage as usize].add(elapsed);
+        }
+    }
+
+    fn finish_loop(&mut self, elapsed: Elapsed) {
+        self.record(Stage::Loop, elapsed);
+        if let Some(sample) = self.current.take() {
+            self.loops_total += 1;
+            if self.samples.len() == SAMPLE_LIMIT {
+                self.samples.pop_front();
+            }
+            self.samples.push_back(sample);
+        }
+    }
+
+    fn count(&mut self, counter: Counter) {
+        self.add(counter, 1);
+    }
+
+    fn add(&mut self, counter: Counter, amount: u64) {
+        if !self.enabled {
+            return;
+        }
+        self.counters_total[counter as usize] += amount;
+        if let Some(sample) = &mut self.current {
+            sample.counters[counter as usize] += amount;
+        }
+    }
+
+    fn diagnostics(&self) -> String {
+        if !self.active {
+            return String::new();
+        }
+        let mut text = format!(
+            "\nkms_profile_version=5\nkms_profile_enabled={}\nkms_loop_samples={}\nkms_loops_total={}\nkms_output_width={}\nkms_output_height={}\nkms_pixel_format={}\nkms_buffer_bytes={}\nkms_buffer_age={}\nkms_buffer_mode={}\nkms_shadow_bytes={}\nkms_texture_mode={}\nkms_draw_detail={}",
+            self.enabled, self.samples.len(), self.loops_total, self.size.0, self.size.1,
+            self.format, self.buffer_bytes, self.buffer_age, self.buffer_mode, self.shadow_bytes, self.texture_mode, self.draw_detail,
+        );
+        let window_wall = self
+            .samples
+            .iter()
+            .map(|s| s.stages[Stage::Loop as usize].elapsed.wall)
+            .sum::<Duration>();
+        let _ = write!(
+            text,
+            "\nkms_window_wall_ms={:.3}\nkms_dirty_pixels_window={}",
+            millis(window_wall),
+            self.samples.iter().map(|s| s.dirty_pixels).sum::<u64>()
+        );
+        for (index, name) in COUNTERS.iter().enumerate() {
+            let count = self.samples.iter().map(|s| s.counters[index]).sum::<u64>();
+            let _ = write!(
+                text,
+                "\nkms_{name}_total={}\nkms_{name}_window={count}",
+                self.counters_total[index]
+            );
+        }
+        for (stage, name) in STAGES {
+            let samples: Vec<_> = self
+                .samples
+                .iter()
+                .map(|s| s.stages[stage as usize])
+                .filter(|s| s.calls > 0)
+                .collect();
+            let calls = samples.iter().map(|s| s.calls).sum::<u64>();
+            let cpu_samples = samples.iter().filter(|s| s.elapsed.cpu.is_some()).count();
+            let _ =
+                write!(text, "\nkms_{name}_calls={calls}\nkms_{name}_cpu_samples={cpu_samples}");
+            if samples.is_empty() {
+                continue;
+            }
+            let wall: Vec<_> = samples.iter().map(|s| s.elapsed.wall).collect();
+            append_stats(&mut text, name, "wall", wall);
+            let cpu: Vec<_> = samples.iter().filter_map(|s| s.elapsed.cpu).collect();
+            if !cpu.is_empty() {
+                append_stats(&mut text, name, "cpu", cpu);
+            }
+        }
+        text
+    }
+}
+
+fn millis(time: Duration) -> f64 {
+    time.as_secs_f64() * 1000.0
+}
+
+fn append_stats(text: &mut String, stage: &str, clock: &str, mut values: Vec<Duration>) {
+    values.sort_unstable();
+    let total = values.iter().copied().sum::<Duration>();
+    let p95 = (values.len() * 95).div_ceil(100) - 1;
+    let _ = write!(text,
+        "\nkms_{stage}_{clock}_total_ms={:.3}\nkms_{stage}_{clock}_avg_ms={:.3}\nkms_{stage}_{clock}_p95_ms={:.3}\nkms_{stage}_{clock}_max_ms={:.3}",
+        millis(total), millis(total) / values.len() as f64, millis(values[p95]), millis(*values.last().unwrap()));
+}
+
+thread_local! { static PROFILE: RefCell<Profile> = RefCell::new(Profile::default()); }
+
+pub(crate) fn activate(size: (u32, u32)) {
+    PROFILE.with(|profile| {
+        *profile.borrow_mut() = Profile {
+            active: true,
+            enabled: std::env::var_os("SPACEWARS_KMS_PROFILE").as_deref()
+                != Some(std::ffi::OsStr::new("0")),
+            draw_detail: std::env::var_os("SPACEWARS_KMS_DRAW_DETAIL").as_deref()
+                != Some(std::ffi::OsStr::new("0")),
+            size,
+            samples: VecDeque::with_capacity(SAMPLE_LIMIT),
+            ..Profile::default()
+        };
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn activate_for_test(size: (u32, u32)) {
+    PROFILE.with(|profile| {
+        *profile.borrow_mut() =
+            Profile { active: true, enabled: true, draw_detail: true, size, ..Profile::default() };
+    });
+}
+
+/// Snapshot completed loop iterations on the UI thread. Formatting/sorting is
+/// only done on request, never in the rendering hot path. Empty on other renderers.
+pub fn diagnostics() -> String {
+    PROFILE.with(|profile| profile.borrow().diagnostics())
+}
+
+pub(crate) struct Scope {
+    stage: Stage,
+    start: Option<Stamp>,
+}
+
+impl Scope {
+    pub(crate) fn new(stage: Stage) -> Self {
+        let enabled = PROFILE.with(|p| p.borrow().enabled);
+        let start = enabled.then(Stamp::now);
+        if matches!(stage, Stage::Loop) && enabled {
+            PROFILE.with(|p| p.borrow_mut().current = Some(LoopSample::default()));
+        }
+        Self { stage, start }
+    }
+}
+
+impl Drop for Scope {
+    fn drop(&mut self) {
+        if let Some(start) = self.start {
+            let elapsed = start.elapsed();
+            PROFILE.with(|p| {
+                let mut profile = p.borrow_mut();
+                if matches!(self.stage, Stage::Loop) {
+                    profile.finish_loop(elapsed);
+                } else {
+                    profile.record(self.stage, elapsed);
+                }
+            });
+        }
+    }
+}
+
+pub(crate) fn count(counter: Counter) {
+    PROFILE.with(|p| p.borrow_mut().count(counter));
+}
+
+pub(crate) fn copied(bytes: usize) {
+    PROFILE.with(|p| p.borrow_mut().add(Counter::CopyBytes, bytes as u64));
+}
+
+pub(crate) fn rgb_blit(pixels: usize) {
+    PROFILE.with(|p| {
+        let mut p = p.borrow_mut();
+        p.count(Counter::RgbBlits);
+        p.add(Counter::RgbPixels, pixels as u64);
+    });
+}
+
+pub(crate) fn texture_mode(mode: &'static str) {
+    PROFILE.with(|p| p.borrow_mut().texture_mode = mode);
+}
+
+#[cfg(feature = "renderer-software")]
+pub(crate) fn draw_observer() -> Option<i_slint_core::software_renderer::DrawDiagnosticObserver> {
+    PROFILE.with(|p| (p.borrow().enabled && p.borrow().draw_detail).then_some(draw_event as _))
+}
+
+#[cfg(feature = "renderer-software")]
+fn draw_event(operation: i_slint_core::software_renderer::DrawDiagnostic, begin: bool) {
+    use i_slint_core::software_renderer::{DrawDiagnostic as D, DRAW_DIAGNOSTIC_COUNT};
+    // Fixed storage. Nested instances of the same operation are timed as one
+    // outer span, avoiding double-counting recursive rendering.
+    #[derive(Clone, Copy, Default)]
+    struct Active {
+        start: Option<Stamp>,
+        depth: usize,
+    }
+    thread_local! {
+        static ACTIVE: RefCell<[Active; DRAW_DIAGNOSTIC_COUNT]> =
+            RefCell::new([Active::default(); DRAW_DIAGNOSTIC_COUNT]);
+    }
+    let stage = match operation {
+        D::Render => Stage::CoreRender,
+        D::Prepare => Stage::CorePrepare,
+        D::DirtyRegion => Stage::CoreDirty,
+        D::Items => Stage::CoreItems,
+        D::Image => Stage::CoreImage,
+        D::Texture => Stage::CoreTexture,
+        D::TextureFallback => Stage::CoreFallback,
+        D::Rectangle => Stage::CoreRectangle,
+        D::Text => Stage::CoreText,
+        D::Path => Stage::CorePath,
+        D::Background => Stage::CoreBackground,
+    };
+    ACTIVE.with(|active| {
+        let mut active = active.borrow_mut();
+        let active = &mut active[operation as usize];
+        if begin {
+            if active.depth == 0 {
+                active.start = Some(Stamp::now());
+            }
+            active.depth += 1;
+        } else if active.depth > 0 {
+            active.depth -= 1;
+            if active.depth == 0 {
+                if let Some(start) = active.start.take() {
+                    let elapsed = start.elapsed();
+                    PROFILE.with(|p| p.borrow_mut().record(stage, elapsed));
+                }
+            }
+        }
+    });
+}
+
+pub(crate) fn render_target(mode: &'static str, shadow_bytes: usize) {
+    PROFILE.with(|p| {
+        let mut p = p.borrow_mut();
+        p.buffer_mode = mode;
+        p.shadow_bytes = shadow_bytes;
+    });
+}
+
+pub(crate) fn buffer(age: u8, bytes: usize, format: &'static str, dirty_pixels: u64) {
+    PROFILE.with(|p| {
+        let mut p = p.borrow_mut();
+        if !p.enabled {
+            return;
+        }
+        p.buffer_age = age;
+        p.buffer_bytes = bytes;
+        p.format = format;
+        if let Some(sample) = &mut p.current {
+            sample.dirty_pixels += dirty_pixels;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn elapsed(wall: u64, cpu: Option<u64>) -> Elapsed {
+        Elapsed { wall: Duration::from_millis(wall), cpu: cpu.map(Duration::from_millis) }
+    }
+
+    #[test]
+    fn completed_windows_are_bounded_and_do_not_mix_inflight_work() {
+        let mut p = Profile { active: true, enabled: true, ..Profile::default() };
+        for i in 0..150 {
+            p.current = Some(LoopSample::default());
+            p.record(Stage::Draw, elapsed(i, Some(2)));
+            p.count(Counter::Draws);
+            p.finish_loop(elapsed(i + 5, Some(3)));
+        }
+        assert_eq!(p.samples.len(), SAMPLE_LIMIT);
+        p.current = Some(LoopSample::default());
+        p.record(Stage::Draw, elapsed(9999, None));
+        let text = p.diagnostics();
+        assert!(text.contains("kms_draw_wall_avg_ms=89.500"));
+        assert!(text.contains("kms_draw_wall_p95_ms=143.000"));
+        assert!(text.contains("kms_draw_cpu_avg_ms=2.000"));
+        assert!(text.contains("kms_draws_total=150\nkms_draws_window=120"));
+        assert!(text.contains("kms_loops_total=150"));
+    }
+
+    #[test]
+    fn idle_loops_waits_and_missing_cpu_clocks_are_explicit() {
+        let mut p = Profile { active: true, enabled: true, ..Profile::default() };
+        p.current = Some(LoopSample::default());
+        p.record(Stage::Draw, elapsed(4, None));
+        p.count(Counter::Draws);
+        p.finish_loop(elapsed(10, None));
+        p.current = Some(LoopSample::default());
+        p.record(Stage::Dispatch, elapsed(50, Some(0)));
+        p.finish_loop(elapsed(50, Some(0)));
+        let text = p.diagnostics();
+        assert!(text.contains("kms_window_wall_ms=60.000"));
+        assert!(text.contains("kms_draw_calls=1\nkms_draw_cpu_samples=0"));
+        assert!(!text.contains("kms_draw_cpu_avg_ms"));
+        assert!(text.contains("kms_dispatch_wall_avg_ms=50.000"));
+        assert!(text.contains("kms_dispatch_cpu_avg_ms=0.000"));
+    }
+
+    #[test]
+    fn counters_distinguish_initial_modesets_submissions_and_completions() {
+        let mut p = Profile { active: true, enabled: true, ..Profile::default() };
+        p.current = Some(LoopSample::default());
+        p.count(Counter::Modesets);
+        p.count(Counter::FlipSubmissions);
+        p.count(Counter::FlipSubmissions);
+        p.count(Counter::FlipCompletions);
+        p.count(Counter::FlipReadErrors);
+        p.finish_loop(elapsed(1, Some(1)));
+        let text = p.diagnostics();
+        assert!(text.contains("kms_modesets_window=1"));
+        assert!(text.contains("kms_flip_submissions_window=2"));
+        assert!(text.contains("kms_flip_completions_window=1"));
+        assert!(text.contains("kms_flip_read_errors_window=1"));
+    }
+
+    #[test]
+    fn copy_accounting_records_bytes_and_keeps_background_nested_in_draw() {
+        let mut p = Profile { active: true, enabled: true, ..Profile::default() };
+        p.current = Some(LoopSample::default());
+        p.record(Stage::Background, elapsed(2, Some(2)));
+        p.record(Stage::Draw, elapsed(5, Some(5)));
+        p.record(Stage::Copy, elapsed(1, Some(1)));
+        p.add(Counter::CopyBytes, 3 * 1024 * 1024);
+        p.finish_loop(elapsed(7, Some(6)));
+        let text = p.diagnostics();
+        assert!(text.contains("kms_background_cpu_avg_ms=2.000"));
+        assert!(text.contains("kms_draw_cpu_avg_ms=5.000"));
+        assert!(text.contains("kms_copy_cpu_avg_ms=1.000"));
+        assert!(text.contains("kms_copy_bytes_window=3145728"));
+    }
+
+    #[test]
+    fn rgb_blit_accounting_is_nested_in_draw_and_counts_only_handled_pixels() {
+        let mut p =
+            Profile { active: true, enabled: true, texture_mode: "rgb", ..Profile::default() };
+        p.current = Some(LoopSample::default());
+        p.record(Stage::RgbBlit, elapsed(1, Some(1)));
+        p.record(Stage::Draw, elapsed(4, Some(4)));
+        p.count(Counter::RgbBlits);
+        p.add(Counter::RgbPixels, 1024 * 768);
+        p.finish_loop(elapsed(6, Some(6)));
+        let text = p.diagnostics();
+        assert!(text.contains("kms_profile_version=5"));
+        assert!(text.contains("kms_texture_mode=rgb"));
+        assert!(text.contains("kms_rgb_blit_cpu_avg_ms=1.000"));
+        assert!(text.contains("kms_draw_cpu_avg_ms=4.000"));
+        assert!(text.contains("kms_rgb_blits_window=1"));
+        assert!(text.contains("kms_rgb_pixels_window=786432"));
+        assert!(text.contains("kms_copy_bytes_window=0"));
+    }
+
+    #[test]
+    fn disabled_and_uninitialized_profiles_do_not_report_measurements() {
+        let mut p = Profile::default();
+        assert!(p.diagnostics().is_empty());
+        p.active = true;
+        p.count(Counter::Draws);
+        let text = p.diagnostics();
+        assert!(text.contains("kms_profile_enabled=false"));
+        assert!(text.contains("kms_draws_total=0"));
+        assert!(!text.contains("kms_draw_wall_avg_ms"));
+    }
+
+    #[test]
+    fn scopes_commit_completed_work_on_early_return() {
+        PROFILE.with(|p| {
+            *p.borrow_mut() = Profile { active: true, enabled: true, ..Profile::default() };
+        });
+        let render = || -> Result<(), ()> {
+            let _iteration = Scope::new(Stage::Loop);
+            let _render = Scope::new(Stage::Render);
+            {
+                let _draw = Scope::new(Stage::Draw);
+                count(Counter::Draws);
+                buffer(3, 4096, "XRGB8888", 1024);
+            }
+            assert!(diagnostics().contains("kms_loop_samples=0"));
+            Err(())
+        };
+        assert_eq!(render(), Err(()));
+        PROFILE.with(|p| {
+            let p = p.borrow();
+            assert!(p.current.is_none());
+            assert_eq!(p.samples.len(), 1);
+            let sample = &p.samples[0];
+            for stage in [Stage::Loop, Stage::Render, Stage::Draw] {
+                assert_eq!(sample.stages[stage as usize].calls, 1);
+            }
+            assert_eq!(sample.dirty_pixels, 1024);
+            assert_eq!(p.buffer_age, 3);
+            assert_eq!(p.buffer_bytes, 4096);
+            assert_eq!(p.format, "XRGB8888");
+        });
+        PROFILE.with(|p| *p.borrow_mut() = Profile::default());
+        {
+            let _iteration = Scope::new(Stage::Loop);
+            let _draw = Scope::new(Stage::Draw);
+            count(Counter::Draws);
+        }
+        assert!(diagnostics().is_empty());
+    }
+
+    #[test]
+    fn repeated_stages_sum_within_a_loop_and_preserve_unknown_cpu() {
+        let mut sample = StageSample::default();
+        sample.add(elapsed(3, Some(2)));
+        sample.add(elapsed(5, Some(4)));
+        assert_eq!(sample.calls, 2);
+        assert_eq!(sample.elapsed.wall, Duration::from_millis(8));
+        assert_eq!(sample.elapsed.cpu, Some(Duration::from_millis(6)));
+        sample.add(elapsed(1, None));
+        sample.add(elapsed(1, Some(1)));
+        assert_eq!(sample.calls, 4);
+        assert_eq!(sample.elapsed.wall, Duration::from_millis(10));
+        assert_eq!(sample.elapsed.cpu, None);
+    }
+}

--- a/vendor/i-slint-backend-linuxkms/renderer/sw.rs
+++ b/vendor/i-slint-backend-linuxkms/renderer/sw.rs
@@ -6,16 +6,22 @@
 use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
-use i_slint_core::software_renderer::{PremultipliedRgbaColor, RepaintBufferType, TargetPixel};
+use i_slint_core::software_renderer::{PremultipliedRgbaColor, TargetPixel};
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::display::RenderingRotation;
+use crate::profiling::{self, Counter};
+
+mod buffer;
+use buffer::{BufferMode, OutputBuffer, TextureMode};
 
 pub struct SoftwareRendererAdapter {
     renderer: SoftwareRenderer,
     display: Arc<dyn crate::display::swdisplay::SoftwareBufferDisplay>,
     presenter: Arc<dyn crate::display::Presenter>,
     size: PhysicalWindowSize,
+    output_buffer: RefCell<OutputBuffer>,
 }
 
 const SOFTWARE_RENDER_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = &[
@@ -113,15 +119,22 @@ impl SoftwareRendererAdapter {
 
         let (width, height) = display.size();
         let size = i_slint_core::api::PhysicalSize::new(width, height);
+        profiling::activate((width, height));
+        let mode = BufferMode::parse(std::env::var("SPACEWARS_KMS_BUFFER").ok().as_deref())?;
+        let texture_mode =
+            TextureMode::parse(std::env::var("SPACEWARS_KMS_TEXTURE").ok().as_deref())?;
+        profiling::render_target(mode.name(), 0);
+        profiling::texture_mode(texture_mode.name());
 
         let renderer = Box::new(Self {
             renderer: SoftwareRenderer::new(),
             display: display.clone(),
             presenter: display.as_presenter(),
             size,
+            output_buffer: RefCell::new(OutputBuffer::new(mode, texture_mode)),
         });
 
-        eprintln!("Using Software renderer");
+        eprintln!("Using Software renderer ({} buffer)", mode.name());
 
         Ok(renderer)
     }
@@ -138,12 +151,6 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SoftwareRendererAdap
         _draw_mouse_cursor_callback: &dyn Fn(&mut dyn i_slint_core::item_rendering::ItemRenderer),
     ) -> Result<(), PlatformError> {
         self.display.map_back_buffer(&mut |pixels, age, format| {
-            self.renderer.set_repaint_buffer_type(match age {
-                1 => RepaintBufferType::ReusedBuffer,
-                2 => RepaintBufferType::SwappedBuffers,
-                _ => RepaintBufferType::NewBuffer,
-            });
-
             self.renderer.set_rendering_rotation(match rotation {
                 RenderingRotation::NoRotation => {
                     i_slint_core::software_renderer::RenderingRotation::NoRotation
@@ -159,24 +166,28 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SoftwareRendererAdap
                 }
             });
 
-            match format {
-                drm::buffer::DrmFourcc::Xrgb8888 | drm::buffer::DrmFourcc::Argb8888 => {
-                    let buffer: &mut [DumbBufferPixelXrgb888] =
-                        bytemuck::cast_slice_mut(pixels.as_mut());
-                    self.renderer.render(buffer, self.size.width as usize);
-                }
-                drm::buffer::DrmFourcc::Rgb565 => {
-                    let buffer: &mut [i_slint_core::software_renderer::Rgb565Pixel] =
-                        bytemuck::cast_slice_mut(pixels.as_mut());
-                    self.renderer.render(buffer, self.size.width as usize);
-                }
-                _ => {
-                    return Err(format!(
-                        "Unsupported frame buffer format {format} used with software renderer"
-                    )
-                    .into())
-                }
-            }
+            let dirty_region = self.output_buffer.borrow_mut().render(
+                &self.renderer,
+                pixels,
+                self.size.width as usize,
+                age,
+                format,
+            )?;
+            profiling::count(Counter::Draws);
+            profiling::buffer(
+                age,
+                pixels.len(),
+                match format {
+                    drm::buffer::DrmFourcc::Xrgb8888 => "XRGB8888",
+                    drm::buffer::DrmFourcc::Argb8888 => "ARGB8888",
+                    drm::buffer::DrmFourcc::Rgb565 => "RGB565",
+                    _ => "unknown",
+                },
+                dirty_region
+                    .iter()
+                    .map(|(_, size)| u64::from(size.width) * u64::from(size.height))
+                    .sum(),
+            );
 
             Ok(())
         })?;

--- a/vendor/i-slint-backend-linuxkms/renderer/sw/buffer.rs
+++ b/vendor/i-slint-backend-linuxkms/renderer/sw/buffer.rs
@@ -1,0 +1,232 @@
+// Copyright © Space-Wars contributors
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Keep pixel rendering separate from scanout memory access. The shadow path
+//! deliberately repaints and copies the whole frame; it does not assume that a
+//! triple-buffered display target contains the previous frame's pixels.
+
+use super::{DumbBufferPixelXrgb888, SoftwareRenderer};
+use crate::profiling::{self, Scope, Stage};
+use drm::buffer::DrmFourcc;
+use i_slint_core::platform::PlatformError;
+use i_slint_core::software_renderer::{
+    DrawTextureArgs, PhysicalRegion, RepaintBufferType, Rgb565Pixel, TargetPixel, TargetPixelBuffer,
+};
+use i_slint_core::Brush;
+
+mod texture;
+pub(super) use texture::TextureMode;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BufferMode {
+    Direct,
+    Ram,
+}
+
+impl BufferMode {
+    pub(super) fn parse(value: Option<&str>) -> Result<Self, PlatformError> {
+        match value {
+            // Picade measurements favor direct rendering once the extra copy is
+            // counted. Retain RAM as an opt-in experiment, not a default cost.
+            None | Some("direct") => Ok(Self::Direct),
+            Some("ram") => Ok(Self::Ram),
+            Some(_) => Err("SPACEWARS_KMS_BUFFER must be 'direct' or 'ram'".into()),
+        }
+    }
+
+    pub(super) fn name(self) -> &'static str {
+        match self {
+            Self::Direct => "direct",
+            Self::Ram => "ram",
+        }
+    }
+}
+
+enum ShadowPixels {
+    Empty,
+    Xrgb(Vec<DumbBufferPixelXrgb888>),
+    Rgb565(Vec<Rgb565Pixel>),
+}
+
+pub(super) struct OutputBuffer {
+    mode: BufferMode,
+    texture_mode: TextureMode,
+    compare_next_rgb: bool,
+    shadow: ShadowPixels,
+}
+
+impl OutputBuffer {
+    pub(super) fn new(mode: BufferMode, texture_mode: TextureMode) -> Self {
+        Self { mode, texture_mode, compare_next_rgb: false, shadow: ShadowPixels::Empty }
+    }
+
+    pub(super) fn render(
+        &mut self,
+        renderer: &SoftwareRenderer,
+        pixels: &mut [u8],
+        stride: usize,
+        age: u8,
+        format: DrmFourcc,
+    ) -> Result<PhysicalRegion, PlatformError> {
+        let texture_mode = if self.texture_mode == TextureMode::Compare {
+            let selected =
+                if self.compare_next_rgb { TextureMode::Rgb } else { TextureMode::Generic };
+            self.compare_next_rgb = !self.compare_next_rgb;
+            selected
+        } else {
+            self.texture_mode
+        };
+        let region = match format {
+            DrmFourcc::Xrgb8888 | DrmFourcc::Argb8888 => {
+                if self.mode == BufferMode::Ram && !matches!(self.shadow, ShadowPixels::Xrgb(_)) {
+                    self.shadow = ShadowPixels::Xrgb(Vec::new());
+                }
+                let shadow = match &mut self.shadow {
+                    ShadowPixels::Xrgb(pixels) => Some(pixels),
+                    _ => None,
+                };
+                render_pixels(
+                    renderer,
+                    bytemuck::cast_slice_mut::<_, DumbBufferPixelXrgb888>(pixels),
+                    stride,
+                    age,
+                    shadow,
+                    texture_mode,
+                )
+            }
+            DrmFourcc::Rgb565 => {
+                if self.mode == BufferMode::Ram && !matches!(self.shadow, ShadowPixels::Rgb565(_)) {
+                    self.shadow = ShadowPixels::Rgb565(Vec::new());
+                }
+                let shadow = match &mut self.shadow {
+                    ShadowPixels::Rgb565(pixels) => Some(pixels),
+                    _ => None,
+                };
+                render_pixels(
+                    renderer,
+                    bytemuck::cast_slice_mut::<_, Rgb565Pixel>(pixels),
+                    stride,
+                    age,
+                    shadow,
+                    texture_mode,
+                )
+            }
+            _ => {
+                return Err(format!(
+                    "Unsupported frame buffer format {format} used with software renderer"
+                )
+                .into())
+            }
+        };
+        let bytes = match &self.shadow {
+            ShadowPixels::Empty => 0,
+            ShadowPixels::Xrgb(pixels) => pixels.capacity() * size_of::<DumbBufferPixelXrgb888>(),
+            ShadowPixels::Rgb565(pixels) => pixels.capacity() * size_of::<Rgb565Pixel>(),
+        };
+        profiling::render_target(self.mode.name(), bytes);
+        Ok(region)
+    }
+}
+
+fn render_pixels<P: TargetPixel>(
+    renderer: &SoftwareRenderer,
+    output: &mut [P],
+    stride: usize,
+    age: u8,
+    shadow: Option<&mut Vec<P>>,
+    texture_mode: TextureMode,
+) -> PhysicalRegion {
+    if let Some(shadow) = shadow {
+        // A persistent RAM buffer is not the display buffer described by `age`.
+        // Force a complete repaint for now: the experiment changes memory access,
+        // not dirty-region policy. Resize/format changes cannot retain stale pixels.
+        shadow.resize_with(output.len(), P::background);
+        renderer.set_repaint_buffer_type(RepaintBufferType::NewBuffer);
+        let region = draw(renderer, shadow, stride, texture_mode);
+        {
+            let _copy = Scope::new(Stage::Copy);
+            output.copy_from_slice(shadow);
+        }
+        profiling::copied(std::mem::size_of_val(output));
+        region
+    } else {
+        renderer.set_repaint_buffer_type(match age {
+            1 => RepaintBufferType::ReusedBuffer,
+            2 => RepaintBufferType::SwappedBuffers,
+            _ => RepaintBufferType::NewBuffer,
+        });
+        draw(renderer, output, stride, texture_mode)
+    }
+}
+
+fn draw<P: TargetPixel>(
+    renderer: &SoftwareRenderer,
+    pixels: &mut [P],
+    stride: usize,
+    texture_mode: TextureMode,
+) -> PhysicalRegion {
+    let _draw = Scope::new(Stage::Draw);
+    let _implementation = Scope::new(match texture_mode {
+        TextureMode::Generic => Stage::DrawGeneric,
+        TextureMode::Rgb => Stage::DrawRgb,
+        TextureMode::Compare => unreachable!("comparison mode is resolved before drawing"),
+    });
+    renderer.render_into_buffer(&mut TimedPixelBuffer { pixels, stride, texture_mode })
+}
+
+/// Keep unsupported scene operations on Slint's fallback. Background fill and
+/// eligible RGB image blits are timed within the outer Draw measurement.
+struct TimedPixelBuffer<'a, P> {
+    pixels: &'a mut [P],
+    stride: usize,
+    texture_mode: TextureMode,
+}
+
+impl<P: TargetPixel> TargetPixelBuffer for TimedPixelBuffer<'_, P> {
+    type TargetPixel = P;
+
+    fn line_slice(&mut self, line: usize) -> &mut [P] {
+        &mut self.pixels[line * self.stride..(line + 1) * self.stride]
+    }
+
+    fn num_lines(&self) -> usize {
+        self.pixels.len() / self.stride
+    }
+
+    fn diagnostic_observer(
+        &self,
+    ) -> Option<i_slint_core::software_renderer::DrawDiagnosticObserver> {
+        profiling::draw_observer()
+    }
+
+    fn draw_texture(&mut self, args: &DrawTextureArgs, clip: &PhysicalRegion) -> bool {
+        if self.texture_mode == TextureMode::Generic {
+            return false;
+        }
+        texture::draw_rgb(args, clip, self.pixels, self.stride)
+    }
+
+    fn fill_background(&mut self, brush: &Brush, region: &PhysicalRegion) -> bool {
+        if !matches!(brush, Brush::SolidColor(_)) {
+            return false;
+        }
+        let _background = Scope::new(Stage::Background);
+        let mut color = P::background();
+        color.blend(brush.color().into());
+        for (position, size) in region.iter() {
+            let left = (i64::from(position.x)).clamp(0, self.stride as i64) as usize;
+            let right = (i64::from(position.x) + i64::from(size.width)).clamp(0, self.stride as i64)
+                as usize;
+            let top = (i64::from(position.y)).clamp(0, self.num_lines() as i64) as usize;
+            let bottom = (i64::from(position.y) + i64::from(size.height))
+                .clamp(0, self.num_lines() as i64) as usize;
+            for line in top..bottom {
+                self.line_slice(line)[left..right].fill(color);
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/vendor/i-slint-backend-linuxkms/renderer/sw/buffer/tests.rs
+++ b/vendor/i-slint-backend-linuxkms/renderer/sw/buffer/tests.rs
@@ -1,0 +1,223 @@
+// Copyright © Space-Wars contributors
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use super::*;
+use i_slint_core::software_renderer::{MinimalSoftwareWindow, RenderingRotation};
+use slint::platform::{Platform, WindowAdapter};
+use slint::{ComponentHandle, PhysicalSize};
+use std::{cell::RefCell, rc::Rc};
+
+mod texture;
+
+thread_local! {
+    static WINDOW: RefCell<Option<Rc<MinimalSoftwareWindow>>> = const { RefCell::new(None) };
+}
+
+struct TestPlatform;
+
+impl Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        WINDOW.with(|window| {
+            Ok(window.borrow().as_ref().expect("test window initialized").clone()
+                as Rc<dyn WindowAdapter>)
+        })
+    }
+}
+
+slint::slint! {
+    export component BufferTestWindow inherits Window {
+        in property <image> texture;
+        in property <color> window-background: #123456;
+        in property <int> frame;
+        background: root.window-background;
+        Rectangle {
+            x: -4px; y: 3px; width: parent.width - 5px; height: parent.height - 7px;
+            clip: true;
+            background: #b46321a0;
+            Image {
+                x: (root.frame * 7 - 9) * 1px; y: 2px;
+                width: parent.width + 7px; height: parent.height - 1px;
+                source: root.texture;
+                opacity: root.frame == 2 ? 0.45 : 1;
+            }
+        }
+        Rectangle {
+            x: parent.width / 3; y: parent.height / 4;
+            width: parent.width / 2; height: parent.height / 2;
+            background: #2040b080;
+            border-color: #eeddaa;
+            border-width: 2px;
+            border-radius: 5px;
+        }
+        Text { x: 1px; y: 2px; text: "12:34"; font-size: 12px; color: #eeeeee; }
+    }
+}
+
+fn texture(alpha: bool) -> slint::Image {
+    if alpha {
+        let mut image = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::new(13, 7);
+        for (i, pixel) in image.make_mut_slice().iter_mut().enumerate() {
+            *pixel = slint::Rgba8Pixel::new(
+                (i * 19) as u8,
+                (i * 47) as u8,
+                (i * 71) as u8,
+                (i * 29) as u8,
+            );
+        }
+        slint::Image::from_rgba8(image)
+    } else {
+        let mut image = slint::SharedPixelBuffer::<slint::Rgb8Pixel>::new(13, 7);
+        for (i, pixel) in image.make_mut_slice().iter_mut().enumerate() {
+            *pixel = slint::Rgb8Pixel::new((i * 19) as u8, (i * 47) as u8, (i * 71) as u8);
+        }
+        slint::Image::from_rgb8(image)
+    }
+}
+
+fn check_pixels<P: TargetPixel + bytemuck::Pod>(
+    renderer: &SoftwareRenderer,
+    shadow: &mut OutputBuffer,
+    size: (usize, usize),
+    rotation: RenderingRotation,
+    format: DrmFourcc,
+    frame: usize,
+) {
+    let (width, height) = size;
+    let stride = match rotation {
+        RenderingRotation::Rotate90 | RenderingRotation::Rotate270 => height,
+        _ => width,
+    };
+    renderer.set_rendering_rotation(rotation);
+    let count = width * height;
+    let guard = P::from_rgb(79, 127, 193);
+    let mut expected = vec![guard; count + 2];
+    let mut direct = expected.clone();
+    let mut copied = expected.clone();
+
+    // The oracle is Slint's original, unwrapped slice renderer, including its
+    // background-fill implementation. It does not exercise our timing wrapper.
+    renderer.set_repaint_buffer_type(RepaintBufferType::NewBuffer);
+    renderer.render(&mut expected[1..count + 1], stride);
+    OutputBuffer::new(BufferMode::Direct, TextureMode::Rgb)
+        .render(renderer, bytemuck::cast_slice_mut(&mut direct[1..count + 1]), stride, 3, format)
+        .unwrap();
+    let region = shadow
+        .render(
+            renderer,
+            bytemuck::cast_slice_mut(&mut copied[1..count + 1]),
+            stride,
+            (frame % 4) as u8,
+            format,
+        )
+        .unwrap();
+    assert_eq!(
+        bytemuck::cast_slice::<_, u8>(&expected),
+        bytemuck::cast_slice::<_, u8>(&direct),
+        "direct wrapper: {format:?}, {size:?}, {rotation:?}, frame {frame}"
+    );
+    assert_eq!(
+        bytemuck::cast_slice::<_, u8>(&expected),
+        bytemuck::cast_slice::<_, u8>(&copied),
+        "RAM + copy: {format:?}, {size:?}, {rotation:?}, frame {frame}"
+    );
+    assert_eq!(
+        region.iter().map(|(_, size)| size.width as usize * size.height as usize).sum::<usize>(),
+        count,
+        "RAM mode deliberately repaints the full frame"
+    );
+}
+
+#[test]
+fn direct_and_shadow_match_original_renderer_for_formats_rotations_alpha_and_resize() {
+    let window = MinimalSoftwareWindow::new(RepaintBufferType::NewBuffer);
+    WINDOW.with(|slot| *slot.borrow_mut() = Some(window.clone()));
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let ui = BufferTestWindow::new().unwrap();
+    ui.show().unwrap();
+    let mut shadow = OutputBuffer::new(BufferMode::Ram, TextureMode::Rgb);
+    for format in [DrmFourcc::Xrgb8888, DrmFourcc::Argb8888, DrmFourcc::Rgb565] {
+        for size in [(48, 32), (73, 41), (39, 27)] {
+            window.set_size(PhysicalSize::new(size.0 as u32, size.1 as u32));
+            for rotation in [
+                RenderingRotation::NoRotation,
+                RenderingRotation::Rotate90,
+                RenderingRotation::Rotate180,
+                RenderingRotation::Rotate270,
+            ] {
+                for frame in 0..4 {
+                    ui.set_frame(frame as i32);
+                    ui.set_texture(texture(frame % 2 == 1));
+                    ui.set_window_background(slint::Color::from_argb_u8(
+                        if frame == 3 { 120 } else { 255 },
+                        12,
+                        (31 * frame) as u8,
+                        73,
+                    ));
+                    ui.window().request_redraw();
+                    assert!(window.draw_if_needed(|renderer| {
+                        if format != DrmFourcc::Rgb565 {
+                            check_pixels::<DumbBufferPixelXrgb888>(
+                                renderer,
+                                &mut shadow,
+                                size,
+                                rotation,
+                                format,
+                                frame,
+                            );
+                        } else {
+                            check_pixels::<Rgb565Pixel>(
+                                renderer,
+                                &mut shadow,
+                                size,
+                                rotation,
+                                DrmFourcc::Rgb565,
+                                frame,
+                            );
+                        }
+                    }));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ram_is_opt_in_and_invalid_modes_are_rejected() {
+    assert_eq!(BufferMode::parse(None).unwrap(), BufferMode::Direct);
+    assert_eq!(BufferMode::parse(Some("direct")).unwrap(), BufferMode::Direct);
+    assert_eq!(BufferMode::parse(Some("ram")).unwrap(), BufferMode::Ram);
+    assert!(BufferMode::parse(Some("invalid")).is_err());
+}
+
+#[test]
+fn unsupported_format_does_not_change_output_or_allocate_a_shadow() {
+    let renderer = SoftwareRenderer::new();
+    let mut buffer = OutputBuffer::new(BufferMode::Ram, TextureMode::Rgb);
+    let mut output = [42_u8; 64];
+    assert!(buffer.render(&renderer, &mut output, 4, 0, DrmFourcc::C8).is_err());
+    assert_eq!(output, [42_u8; 64]);
+    assert!(matches!(buffer.shadow, ShadowPixels::Empty));
+}
+
+#[test]
+fn same_size_frames_reuse_storage_and_copy_whole_frames_to_rotating_targets() {
+    let renderer = SoftwareRenderer::new();
+    let mut shadow = vec![DumbBufferPixelXrgb888(0xff123456); 64];
+    let address = shadow.as_ptr();
+    // With no window attached, Slint leaves the shadow untouched. This isolates
+    // the copy/reuse lifecycle from scene rendering (covered above).
+    let mut targets = [
+        vec![DumbBufferPixelXrgb888(0); 64],
+        vec![DumbBufferPixelXrgb888(1); 64],
+        vec![DumbBufferPixelXrgb888(2); 64],
+    ];
+    for index in 0..9 {
+        let target = &mut targets[index % 3];
+        for pixel in &mut shadow {
+            pixel.0 = 0xff123456 + index as u32;
+        }
+        render_pixels(&renderer, target, 8, 3, Some(&mut shadow), TextureMode::Rgb);
+        assert_eq!(shadow.as_ptr(), address);
+        assert!(target.iter().all(|pixel| pixel.0 == 0xff123456 + index as u32));
+    }
+}

--- a/vendor/i-slint-backend-linuxkms/renderer/sw/buffer/tests/texture.rs
+++ b/vendor/i-slint-backend-linuxkms/renderer/sw/buffer/tests/texture.rs
@@ -1,0 +1,387 @@
+use super::*;
+
+slint::slint! {
+    export component TextureWindow inherits Window {
+        in property <image> texture;
+        in property <length> image-width: self.width;
+        in property <length> image-height: self.height;
+        in property <length> image-x;
+        in property <length> image-y;
+        in property <float> image-opacity: 1;
+        in property <color> tint: transparent;
+        in property <bool> clipped;
+        in property <int> crop-x;
+        in property <int> crop-y;
+        in property <int> crop-width: root.texture.width;
+        in property <int> crop-height: root.texture.height;
+        in property <bool> tiled;
+        in property <bool> overlay;
+        in property <length> overlay-x: 8px;
+        background: #152b40;
+        Rectangle {
+            width: root.clipped ? parent.width - 7px : parent.width;
+            height: root.clipped ? parent.height - 5px : parent.height;
+            clip: root.clipped;
+            Image {
+                x: root.image-x; y: root.image-y;
+                width: root.image-width; height: root.image-height;
+                source: root.texture;
+                image-fit: fill;
+                horizontal-tiling: root.tiled ? repeat : none;
+                vertical-tiling: root.tiled ? repeat : none;
+                source-clip-x: root.crop-x;
+                source-clip-y: root.crop-y;
+                source-clip-width: root.crop-width;
+                source-clip-height: root.crop-height;
+                opacity: root.image-opacity;
+                colorize: root.tint;
+            }
+        }
+        if root.overlay : Rectangle {
+            x: root.overlay-x; y: 4px; width: 13px; height: 9px;
+            background: #ee771188; border-color: #ddaaff; border-width: 1px;
+        }
+    }
+}
+
+fn window() -> Rc<MinimalSoftwareWindow> {
+    let window = MinimalSoftwareWindow::new(RepaintBufferType::NewBuffer);
+    WINDOW.with(|slot| *slot.borrow_mut() = Some(window.clone()));
+    window
+}
+
+fn rgb_texture(width: u32, height: u32, alpha: bool) -> slint::Image {
+    if alpha {
+        let mut buffer = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::new(width, height);
+        for (i, p) in buffer.make_mut_slice().iter_mut().enumerate() {
+            *p = slint::Rgba8Pixel::new(
+                (i * 19) as u8,
+                (i * 47) as u8,
+                (i * 71) as u8,
+                (i * 29) as u8,
+            );
+        }
+        slint::Image::from_rgba8(buffer)
+    } else {
+        let mut buffer = slint::SharedPixelBuffer::<slint::Rgb8Pixel>::new(width, height);
+        for (i, p) in buffer.make_mut_slice().iter_mut().enumerate() {
+            *p = slint::Rgb8Pixel::new((i * 19) as u8, (i * 47) as u8, (i * 71) as u8);
+        }
+        slint::Image::from_rgb8(buffer)
+    }
+}
+
+struct CheckedBuffer<'a, P> {
+    pixels: &'a mut [P],
+    stride: usize,
+    hits: usize,
+}
+
+impl<P: TargetPixel + bytemuck::Pod> TargetPixelBuffer for CheckedBuffer<'_, P> {
+    type TargetPixel = P;
+    fn line_slice(&mut self, y: usize) -> &mut [P] {
+        &mut self.pixels[y * self.stride..(y + 1) * self.stride]
+    }
+    fn num_lines(&self) -> usize {
+        self.pixels.len() / self.stride
+    }
+    fn draw_texture(&mut self, args: &DrawTextureArgs, clip: &PhysicalRegion) -> bool {
+        let before = bytemuck::cast_slice::<_, u8>(self.pixels).to_vec();
+        let handled = super::super::texture::draw_rgb(args, clip, self.pixels, self.stride);
+        if handled {
+            self.hits += 1;
+        } else {
+            assert_eq!(
+                before,
+                bytemuck::cast_slice::<_, u8>(self.pixels),
+                "fallback must not write"
+            );
+        }
+        handled
+    }
+}
+
+fn compare<P: TargetPixel + bytemuck::Pod>(
+    renderer: &SoftwareRenderer,
+    size: (usize, usize),
+    rotation: RenderingRotation,
+) -> usize {
+    renderer.set_rendering_rotation(rotation);
+    let (width, height) = match rotation {
+        RenderingRotation::Rotate90 | RenderingRotation::Rotate270 => (size.1, size.0),
+        _ => size,
+    };
+    // Row padding and end guards must be identical, including for cropped sources
+    // whose byte stride exceeds their visible width.
+    let stride = width + 5;
+    let count = stride * height;
+    let mut original = vec![P::from_rgb(93, 137, 191); count + 2];
+    let mut fast = original.clone();
+    renderer.render(&mut original[1..count + 1], stride);
+    let hits = {
+        let mut buffer = CheckedBuffer { pixels: &mut fast[1..count + 1], stride, hits: 0 };
+        renderer.render_into_buffer(&mut buffer);
+        buffer.hits
+    };
+    assert_eq!(bytemuck::cast_slice::<_, u8>(&original), bytemuck::cast_slice::<_, u8>(&fast));
+    hits
+}
+
+#[test]
+fn rgb_blits_match_original_for_scaling_cropping_clipping_formats_and_fallbacks() {
+    let window = window();
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let ui = TextureWindow::new().unwrap();
+    ui.show().unwrap();
+    for size in [(71, 53), (53, 31)] {
+        window.set_size(PhysicalSize::new(size.0 as u32, size.1 as u32));
+        for (width, height, sx, sy) in
+            [(41, 29, 1, 1), (41, 29, 2, 2), (41, 29, 2, 1), (41, 29, 1, 2), (4200, 29, 2, 1)]
+        {
+            for variant in 0..8 {
+                // Native/scaled, cropped/padded, opacity, RGBA, tint, tiling,
+                // fractional sampling, and magnification.
+                let crop = variant == 1;
+                let source_w = width * sx;
+                let source_h = height * sy;
+                ui.set_texture(rgb_texture(
+                    source_w + u32::from(crop) * 8,
+                    source_h + u32::from(crop) * 6,
+                    variant == 3,
+                ));
+                ui.set_crop_x(if crop { 3 } else { 0 });
+                ui.set_crop_y(if crop { 2 } else { 0 });
+                ui.set_crop_width(source_w as i32);
+                ui.set_crop_height(source_h as i32);
+                ui.set_image_width(if variant == 6 {
+                    width as f32 + 3.0
+                } else if variant == 7 {
+                    source_w as f32 * 2.0
+                } else {
+                    width as f32
+                });
+                ui.set_image_height(height as f32);
+                ui.set_image_x(if crop && width > 4096 {
+                    -3000.0
+                } else if crop {
+                    -9.0
+                } else {
+                    size.0 as f32 - 30.0
+                });
+                ui.set_image_y(if crop { -5.0 } else { 3.0 });
+                ui.set_clipped(true);
+                ui.set_overlay(true);
+                ui.set_image_opacity(if variant == 2 { 0.45 } else { 1.0 });
+                ui.set_tint(if variant == 4 {
+                    slint::Color::from_rgb_u8(41, 211, 71)
+                } else {
+                    slint::Color::default()
+                });
+                ui.set_tiled(variant == 5);
+                for rotation in [
+                    RenderingRotation::NoRotation,
+                    RenderingRotation::Rotate90,
+                    RenderingRotation::Rotate180,
+                    RenderingRotation::Rotate270,
+                ] {
+                    ui.window().request_redraw();
+                    assert!(window.draw_if_needed(|renderer| {
+                        let xrgb_hits = compare::<DumbBufferPixelXrgb888>(renderer, size, rotation);
+                        let rgb565_hits = compare::<Rgb565Pixel>(renderer, size, rotation);
+                        let expected = usize::from(
+                            variant <= 1
+                                && source_w <= 4096
+                                && rotation == RenderingRotation::NoRotation,
+                        );
+                        assert_eq!(xrgb_hits, expected, "variant {variant}, rotation {rotation:?}");
+                        assert_eq!(rgb565_hits, expected);
+                    }));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn rgb_blits_preserve_partial_damage_and_pixels_outside_dirty_regions() {
+    let original_window = window();
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let original_ui = TextureWindow::new().unwrap();
+    original_ui.show().unwrap();
+    let fast_window = window();
+    let fast_ui = TextureWindow::new().unwrap();
+    fast_ui.show().unwrap();
+    for (window, ui) in [(&original_window, &original_ui), (&fast_window, &fast_ui)] {
+        window.set_size(PhysicalSize::new(97, 61));
+        ui.set_texture(rgb_texture(194, 122, false));
+        ui.set_overlay(true);
+    }
+    let mut original = vec![DumbBufferPixelXrgb888(0x12345678); 97 * 61];
+    let mut fast = original.clone();
+    for (frame, x) in [4.0, 11.0, 72.0, 8.0, 70.0, 12.0, 74.0, 6.0].into_iter().enumerate() {
+        for ui in [&original_ui, &fast_ui] {
+            ui.set_overlay_x(x);
+            ui.window().request_redraw();
+        }
+        assert!(original_window.draw_if_needed(|renderer| {
+            renderer.render(&mut original, 97);
+            renderer.set_repaint_buffer_type(RepaintBufferType::ReusedBuffer);
+        }));
+        assert!(fast_window.draw_if_needed(|renderer| {
+            let mut buffer = CheckedBuffer { pixels: &mut fast, stride: 97, hits: 0 };
+            let region = renderer.render_into_buffer(&mut buffer);
+            assert!(buffer.hits > 0);
+            if frame > 1 {
+                let area: u32 = region.iter().map(|(_, s)| s.width * s.height).sum();
+                assert!(area > 0 && area < 97 * 61, "expected partial damage, got {area}");
+            }
+            renderer.set_repaint_buffer_type(RepaintBufferType::ReusedBuffer);
+        }));
+        assert_eq!(
+            bytemuck::cast_slice::<_, u8>(&original),
+            bytemuck::cast_slice::<_, u8>(&fast),
+            "frame {frame}"
+        );
+    }
+}
+
+#[test]
+fn texture_mode_selection_is_explicit() {
+    assert_eq!(TextureMode::parse(None).unwrap(), TextureMode::Rgb);
+    assert_eq!(TextureMode::parse(Some("rgb")).unwrap(), TextureMode::Rgb);
+    assert_eq!(TextureMode::parse(Some("generic")).unwrap(), TextureMode::Generic);
+    assert_eq!(TextureMode::parse(Some("compare")).unwrap(), TextureMode::Compare);
+    assert!(TextureMode::parse(Some("other")).is_err());
+}
+
+#[test]
+fn detailed_draw_spans_balance_and_distinguish_fallback_from_rgb() {
+    use crate::profiling::{self, Scope, Stage};
+    let window = window();
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let ui = TextureWindow::new().unwrap();
+    ui.show().unwrap();
+    window.set_size(PhysicalSize::new(64, 32));
+    ui.set_texture(rgb_texture(64, 32, false));
+    ui.set_overlay(true);
+    let mut previous = None;
+    for mode in [TextureMode::Generic, TextureMode::Rgb] {
+        profiling::activate_for_test((64, 32));
+        let mut output = OutputBuffer::new(BufferMode::Direct, mode);
+        let mut pixels = vec![DumbBufferPixelXrgb888(0); 64 * 32];
+        ui.window().request_redraw();
+        {
+            let _iteration = Scope::new(Stage::Loop);
+            assert!(window.draw_if_needed(|renderer| {
+                output
+                    .render(
+                        renderer,
+                        bytemuck::cast_slice_mut(&mut pixels),
+                        64,
+                        3,
+                        DrmFourcc::Xrgb8888,
+                    )
+                    .unwrap();
+            }));
+        }
+        let status = profiling::diagnostics();
+        for phase in ["render", "prepare", "dirty", "items", "image", "texture"] {
+            assert!(status.contains(&format!("kms_core_{phase}_calls=1\n")), "{status}");
+        }
+        let fallbacks = usize::from(mode == TextureMode::Generic);
+        assert!(status.contains(&format!("kms_core_fallback_calls={fallbacks}\n")));
+        let bytes = bytemuck::cast_slice::<_, u8>(&pixels).to_vec();
+        if let Some(previous) = previous {
+            assert_eq!(bytes, previous);
+        }
+        previous = Some(bytes);
+    }
+}
+
+#[test]
+fn comparison_alternates_once_per_frame_with_separate_draw_accounting() {
+    use crate::profiling::{self, Scope, Stage};
+    profiling::activate_for_test((8, 8));
+    profiling::texture_mode("compare");
+    let renderer = SoftwareRenderer::new();
+    let mut output = OutputBuffer::new(BufferMode::Direct, TextureMode::Compare);
+    let mut pixels = vec![DumbBufferPixelXrgb888(0); 64];
+    for frame in 0..6 {
+        let _loop = Scope::new(Stage::Loop);
+        output
+            .render(&renderer, bytemuck::cast_slice_mut(&mut pixels), 8, 3, DrmFourcc::Xrgb8888)
+            .unwrap();
+        assert_eq!(output.compare_next_rgb, frame % 2 == 0);
+    }
+    let status = profiling::diagnostics();
+    assert!(status.contains("kms_texture_mode=compare"));
+    assert!(status.contains("kms_draw_calls=6\n"));
+    assert!(status.contains("kms_draw_generic_calls=3\n"));
+    assert!(status.contains("kms_draw_rgb_calls=3\n"));
+}
+
+/// Fixed-content RAM benchmark for Slint drawing, not DRM presentation or the
+/// host's scene rasterizer. No pass/fail timing thresholds. Run explicitly with
+/// --release --ignored --nocapture; regular CI still runs pixel equivalence.
+#[test]
+#[ignore = "explicit presentation microbenchmark; no timing assertions"]
+fn benchmark_opaque_rgb_presentation() {
+    use std::{hint::black_box, time::Instant};
+    let window = window();
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let ui = TextureWindow::new().unwrap();
+    ui.show().unwrap();
+    window.set_size(PhysicalSize::new(1024, 768));
+    let mut pixels = vec![DumbBufferPixelXrgb888(0); 1024 * 768];
+    println!("fixture,mode,repeat,frames,wall_ms_per_frame");
+    for (fixture, scale) in [("background", 0), ("rgb-native", 1), ("rgb-downscale2", 2)] {
+        ui.set_texture(if scale == 0 {
+            slint::Image::default()
+        } else {
+            rgb_texture(1024 * scale, 768 * scale, false)
+        });
+        ui.window().request_redraw();
+        assert!(window.draw_if_needed(|renderer| {
+            for repeat in 0..4 {
+                let modes = if repeat % 2 == 0 {
+                    [TextureMode::Generic, TextureMode::Rgb]
+                } else {
+                    [TextureMode::Rgb, TextureMode::Generic]
+                };
+                for mode in modes {
+                    let mut output = OutputBuffer::new(BufferMode::Direct, mode);
+                    let frames = 100;
+                    for _ in 0..10 {
+                        output
+                            .render(
+                                renderer,
+                                bytemuck::cast_slice_mut(&mut pixels),
+                                1024,
+                                3,
+                                DrmFourcc::Xrgb8888,
+                            )
+                            .unwrap();
+                    }
+                    let start = Instant::now();
+                    for _ in 0..frames {
+                        output
+                            .render(
+                                renderer,
+                                bytemuck::cast_slice_mut(&mut pixels),
+                                1024,
+                                3,
+                                DrmFourcc::Xrgb8888,
+                            )
+                            .unwrap();
+                        black_box(&pixels);
+                    }
+                    println!(
+                        "{fixture},{},{repeat},{frames},{:.6}",
+                        mode.name(),
+                        start.elapsed().as_secs_f64() * 1000.0 / f64::from(frames)
+                    );
+                }
+            }
+        }));
+    }
+}

--- a/vendor/i-slint-backend-linuxkms/renderer/sw/buffer/texture.rs
+++ b/vendor/i-slint-backend-linuxkms/renderer/sw/buffer/texture.rs
@@ -1,0 +1,136 @@
+// Copyright © Space-Wars contributors
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use crate::profiling::{self, Scope, Stage};
+use i_slint_core::platform::PlatformError;
+use i_slint_core::software_renderer::{
+    DrawTextureArgs, PhysicalRegion, RenderingRotation, TargetPixel, TexturePixelFormat,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in super::super) enum TextureMode {
+    Generic,
+    Rgb,
+    Compare,
+}
+
+impl TextureMode {
+    pub(in super::super) fn parse(value: Option<&str>) -> Result<Self, PlatformError> {
+        match value {
+            // The same-process Picade comparison favors the specialized path.
+            // Keep generic and alternating-frame modes for reproducible checks.
+            None | Some("rgb") => Ok(Self::Rgb),
+            Some("generic") => Ok(Self::Generic),
+            Some("compare") => Ok(Self::Compare),
+            Some(_) => Err("SPACEWARS_KMS_TEXTURE must be 'generic', 'rgb' or 'compare'".into()),
+        }
+    }
+
+    pub(in super::super) fn name(self) -> &'static str {
+        match self {
+            Self::Generic => "generic",
+            Self::Rgb => "rgb",
+            Self::Compare => "compare",
+        }
+    }
+}
+
+/// Only handle exact 1:1 / 2:1 source-to-destination sampling. Slint's generic
+/// renderer uses fixed-point nearest-neighbor sampling; integer steps and
+/// offsets produce exactly the same pixels without per-pixel tiling arithmetic.
+/// Reject everything else before touching the destination.
+pub(super) fn draw_rgb<P: TargetPixel>(
+    args: &DrawTextureArgs,
+    clip: &PhysicalRegion,
+    pixels: &mut [P],
+    stride: usize,
+) -> bool {
+    if args.alpha != 255
+        || args.colorize.is_some()
+        || args.tiling.is_some()
+        || args.rotation != RenderingRotation::NoRotation
+        || args.dst_width == 0
+        || args.dst_height == 0
+        || stride == 0
+    {
+        return false;
+    }
+    let source = args.source();
+    // Slint stores clipped source offsets in unsigned 12.4 fixed point. Limit
+    // the source extent so every offset this path handles is representable;
+    // otherwise the generic path can reject geometry that we would draw.
+    if source.pixel_format != TexturePixelFormat::Rgb
+        || source.width > 4096
+        || source.height > 4096
+        || source.byte_stride % 3 != 0
+        || source.byte_stride / 3 > u16::MAX as usize
+    {
+        return false;
+    }
+    let step = |src: usize, dst: usize| {
+        if src == dst {
+            Some(1)
+        } else if dst.checked_mul(2) == Some(src) {
+            Some(2)
+        } else {
+            None
+        }
+    };
+    let Some(step_x) = step(source.width as usize, args.dst_width) else { return false };
+    let Some(step_y) = step(source.height as usize, args.dst_height) else { return false };
+
+    let Some(row_bytes) = (source.width as usize).checked_mul(3) else { return false };
+    let source_end = (source.height as usize - 1)
+        .checked_mul(source.byte_stride)
+        .and_then(|last_row| last_row.checked_add(row_bytes));
+    if source.byte_stride < row_bytes || source_end.is_none_or(|end| end > source.data.len()) {
+        return false;
+    }
+    let Some(right) = args.dst_x.checked_add_unsigned(args.dst_width) else { return false };
+    let Some(bottom) = args.dst_y.checked_add_unsigned(args.dst_height) else { return false };
+    // Slint's software scene uses i16 geometry.
+    // Keep conversions lossless and leave unusually large requests to Slint.
+    if [args.dst_x, args.dst_y, right, bottom].iter().any(|&n| i16::try_from(n).is_err()) {
+        return false;
+    }
+
+    let _blit = Scope::new(Stage::RgbBlit);
+    let mut written = 0;
+    for (position, size) in clip.iter() {
+        let left = i64::from(position.x).max(args.dst_x as i64).max(0);
+        let top = i64::from(position.y).max(args.dst_y as i64).max(0);
+        let right =
+            (i64::from(position.x) + i64::from(size.width)).min(right as i64).min(stride as i64);
+        let bottom = (i64::from(position.y) + i64::from(size.height))
+            .min(bottom as i64)
+            .min((pixels.len() / stride) as i64);
+        if left >= right || top >= bottom {
+            continue;
+        }
+        let count = (right - left) as usize;
+        let src_x = (left - args.dst_x as i64) as usize * step_x * 3;
+        for y in top..bottom {
+            let src_y = (y - args.dst_y as i64) as usize * step_y;
+            let start = src_y * source.byte_stride + src_x;
+            let row = &source.data[start..start + count * step_x * 3];
+            let out = &mut pixels
+                [y as usize * stride + left as usize..y as usize * stride + right as usize];
+            // Constant-size chunks let LLVM vectorize format conversion. No
+            // destination reads, intermediate image or unsafe code.
+            if step_x == 1 {
+                rgb_row::<P, 3>(row, out);
+            } else {
+                rgb_row::<P, 6>(row, out);
+            }
+        }
+        written += count * (bottom - top) as usize;
+    }
+    profiling::rgb_blit(written);
+    true
+}
+
+fn rgb_row<P: TargetPixel, const BYTES: usize>(source: &[u8], output: &mut [P]) {
+    for (rgb, pixel) in source.chunks_exact(BYTES).zip(output) {
+        *pixel = P::from_rgb(rgb[0], rgb[1], rgb[2]);
+    }
+}

--- a/vendor/i-slint-core/software_renderer.rs
+++ b/vendor/i-slint-core/software_renderer.rs
@@ -7,6 +7,7 @@
 
 #![warn(missing_docs)]
 
+mod diagnostics;
 mod draw_functions;
 mod fixed;
 mod fonts;
@@ -380,6 +381,10 @@ fn region_line_ranges(
 mod target_pixel_buffer;
 
 #[cfg(feature = "experimental")]
+pub use diagnostics::{DrawDiagnostic, DrawDiagnosticObserver, DRAW_DIAGNOSTIC_COUNT};
+use diagnostics::{DrawDiagnostic as Diagnostic, Span as DiagnosticSpan};
+
+#[cfg(feature = "experimental")]
 pub use target_pixel_buffer::{
     DrawRectangleArgs, DrawTextureArgs, TargetPixelBuffer, TexturePixelFormat,
 };
@@ -518,6 +523,9 @@ impl SoftwareRenderer {
         &self,
         buffer: &mut impl target_pixel_buffer::TargetPixelBuffer,
     ) -> PhysicalRegion {
+        let observer = buffer.diagnostic_observer();
+        let _render_span = DiagnosticSpan::new(observer, Diagnostic::Render);
+        let prepare_span = DiagnosticSpan::new(observer, Diagnostic::Prepare);
         let pixels_per_line = buffer.line_slice(0).len();
         let num_lines = buffer.num_lines();
         let buffer_pixel_count = num_lines * pixels_per_line;
@@ -563,9 +571,11 @@ impl SoftwareRenderer {
         );
         let mut renderer = self.partial_rendering_state.create_partial_renderer(buffer_renderer);
         let window_adapter = renderer.window_adapter.clone();
+        drop(prepare_span);
 
         window_inner
             .draw_contents(|components| {
+                let dirty_span = DiagnosticSpan::new(observer, Diagnostic::DirtyRegion);
                 let logical_size = (size.cast() / factor).cast();
 
                 let dirty_region_of_existing_buffer = match self.repaint_buffer_type.get() {
@@ -605,6 +615,8 @@ impl SoftwareRenderer {
                 drop(i);
 
                 renderer.actual_renderer.processor.dirty_region = dirty_region.clone();
+                drop(dirty_span);
+                let background_span = DiagnosticSpan::new(observer, Diagnostic::Background);
                 if !renderer
                     .actual_renderer
                     .processor
@@ -622,6 +634,8 @@ impl SoftwareRenderer {
                     );
                 }
 
+                drop(background_span);
+                let items_span = DiagnosticSpan::new(observer, Diagnostic::Items);
                 for (component, origin) in components {
                     crate::item_rendering::render_component_items(
                         component,
@@ -630,6 +644,7 @@ impl SoftwareRenderer {
                         &window_adapter,
                     );
                 }
+                drop(items_span);
 
                 if let Some(metrics) = &self.rendering_metrics_collector {
                     metrics.measure_frame_rendered(&mut renderer);
@@ -926,10 +941,8 @@ impl RendererSealed for SoftwareRenderer {
         // Output rotation belongs to the display, not to the logical window contents returned by
         // a snapshot. Rendering a quarter-turned window into this logical-size buffer also violates
         // render()'s stride requirements and panics for non-square windows.
-        let restore_rotation = RestoreRotation {
-            renderer: self,
-            rotation: self.rendering_rotation(),
-        };
+        let restore_rotation =
+            RestoreRotation { renderer: self, rotation: self.rendering_rotation() };
         self.set_rendering_rotation(RenderingRotation::NoRotation);
         self.set_repaint_buffer_type(RepaintBufferType::NewBuffer);
         self.render(target_buffer.make_mut_slice(), width as usize);
@@ -1182,6 +1195,9 @@ fn prepare_scene(
 }
 
 trait ProcessScene {
+    fn diagnostic_observer(&self) -> Option<diagnostics::DrawDiagnosticObserver> {
+        None
+    }
     fn process_scene_texture(&mut self, geometry: PhysicalRect, texture: SceneTexture<'static>);
     fn process_target_texture(
         &mut self,
@@ -1489,7 +1505,12 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
 }
 
 impl<B: target_pixel_buffer::TargetPixelBuffer> ProcessScene for RenderToBuffer<'_, B> {
+    fn diagnostic_observer(&self) -> Option<diagnostics::DrawDiagnosticObserver> {
+        self.buffer.diagnostic_observer()
+    }
+
     fn process_scene_texture(&mut self, geometry: PhysicalRect, texture: SceneTexture<'static>) {
+        let _span = DiagnosticSpan::new(self.diagnostic_observer(), Diagnostic::TextureFallback);
         self.process_texture_impl(geometry, texture);
     }
 
@@ -1498,10 +1519,13 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> ProcessScene for RenderToBuffer<
         texture: &target_pixel_buffer::DrawTextureArgs,
         clip: PhysicalRect,
     ) {
+        let _span = DiagnosticSpan::new(self.diagnostic_observer(), Diagnostic::Texture);
         if self.buffer.draw_texture(texture, &self.dirty_region.intersection(&clip)) {
             return;
         }
 
+        let _fallback =
+            DiagnosticSpan::new(self.diagnostic_observer(), Diagnostic::TextureFallback);
         let Some((texture, geometry)) = SceneTexture::from_target_texture(texture, &clip) else {
             return;
         };
@@ -1514,6 +1538,7 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> ProcessScene for RenderToBuffer<
         args: &target_pixel_buffer::DrawRectangleArgs,
         clip: PhysicalRect,
     ) {
+        let _span = DiagnosticSpan::new(self.diagnostic_observer(), Diagnostic::Rectangle);
         if self.buffer.draw_rectangle(args, &self.dirty_region.intersection(&clip)) {
             return;
         }
@@ -2236,6 +2261,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
         size: LogicalSize,
         _: &CachedRenderingData,
     ) {
+        let _span = DiagnosticSpan::new(self.processor.diagnostic_observer(), Diagnostic::Image);
         let geom = LogicalRect::from(size);
         if self.should_draw(&geom) {
             let source = image.source();
@@ -2285,6 +2311,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
         size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
+        let _span = DiagnosticSpan::new(self.processor.diagnostic_observer(), Diagnostic::Text);
         let string = text.text();
         if string.trim().is_empty() {
             return;
@@ -2359,6 +2386,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
         self_rc: &ItemRc,
         size: LogicalSize,
     ) {
+        let _span = DiagnosticSpan::new(self.processor.diagnostic_observer(), Diagnostic::Text);
         let geom = LogicalRect::from(size);
         if !self.should_draw(&geom) {
             return;
@@ -2468,6 +2496,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
 
     #[cfg(feature = "std")]
     fn draw_path(&mut self, _path: Pin<&crate::items::Path>, _: &ItemRc, _size: LogicalSize) {
+        let _span = DiagnosticSpan::new(self.processor.diagnostic_observer(), Diagnostic::Path);
         // TODO
     }
 

--- a/vendor/i-slint-core/software_renderer/diagnostics.rs
+++ b/vendor/i-slint-core/software_renderer/diagnostics.rs
@@ -1,0 +1,62 @@
+// Copyright © Space-Wars contributors
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Optional, clock-free observation points for local software-renderer diagnostics.
+
+/// Nested CPU-rendering operations. Begin/end events do not imply visible pixels.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub enum DrawDiagnostic {
+    /// Complete render call.
+    Render,
+    /// Window/buffer setup before dirty-region calculation.
+    Prepare,
+    /// Compute dirty regions and update item caches.
+    DirtyRegion,
+    /// Traverse and render the component trees, including operations below.
+    Items,
+    /// Image preparation and drawing, including texture operations.
+    Image,
+    /// Target texture operation, including accelerated or fallback drawing.
+    Texture,
+    /// Software texture fallback, including sampling and pixel writes.
+    TextureFallback,
+    /// Rectangle operation, including borders and gradients.
+    Rectangle,
+    /// Text preparation and glyph drawing.
+    Text,
+    /// Path operation (possibly unsupported by this renderer).
+    Path,
+    /// Window background fill (accelerated or software fallback).
+    Background,
+}
+
+/// Number of diagnostic operation kinds.
+pub const DRAW_DIAGNOSTIC_COUNT: usize = 11;
+
+/// Receives balanced begin (`true`) and end (`false`) events on the rendering
+/// thread. Observers must not re-enter rendering or panic. No observer is installed
+/// by default; the renderer itself does not read clocks or retain measurements.
+pub type DrawDiagnosticObserver = fn(DrawDiagnostic, bool);
+
+pub(super) struct Span {
+    observer: Option<DrawDiagnosticObserver>,
+    operation: DrawDiagnostic,
+}
+
+impl Span {
+    pub(super) fn new(observer: Option<DrawDiagnosticObserver>, operation: DrawDiagnostic) -> Self {
+        if let Some(observer) = observer {
+            observer(operation, true);
+        }
+        Self { observer, operation }
+    }
+}
+
+impl Drop for Span {
+    fn drop(&mut self) {
+        if let Some(observer) = self.observer {
+            observer(self.operation, false);
+        }
+    }
+}

--- a/vendor/i-slint-core/software_renderer/target_pixel_buffer.rs
+++ b/vendor/i-slint-core/software_renderer/target_pixel_buffer.rs
@@ -212,6 +212,12 @@ pub trait TargetPixelBuffer {
     /// Returns the number of lines the buffer has. This is typically the height in pixels.
     fn num_lines(&self) -> usize;
 
+    /// Optional local diagnostic observer for nested render operations. This
+    /// does not change rendering, and returning `None` avoids reading clocks.
+    fn diagnostic_observer(&self) -> Option<super::diagnostics::DrawDiagnosticObserver> {
+        None
+    }
+
     /// Fill the background of the buffer with the given brush.
     fn fill_background(&mut self, _brush: &Brush, _region: &PhysicalRegion) -> bool {
         false


### PR DESCRIPTION
## Summary

Reduce the cost of Clock rendering and the shared software-presentation path without lowering resolution, changing visual quality, or changing simulation/frame-rate defaults.

- Use bulk RGB fills and conservatively fold a covering first background rectangle into buffer initialization.
- Add a guarded LinuxKMS fast path for opaque 1:1 and 2:1 RGB texture sampling, preserving Slint's generic fallback for unsupported operations. Keep direct rendering as the default; RAM-copy and alternating generic/RGB modes remain available for controlled comparisons.
- Construct inactive launcher, pause, notification, and scenario HUD panels conditionally. Removing their hidden item trees eliminates substantial dirty-region bookkeeping while retaining settings, selection, callbacks, and keyboard focus on the root window.
- Add bounded LinuxKMS CPU/wall-time diagnostics through `spacewars-cli status`, nested optional software-renderer observation hooks, and a display-free `--benchmark-presentation` probe comparing identical frozen images in bare and full UI windows.

Related to #19; this does not close the broader Clock scenario issue.

## Measurements

The final Clock matrix completed **42 runs / 37,800 measured frames on each of Picade and desktop**: seven cases, raster scales 1 and 2, and three repeats. Picade's CPU-only workload is **2.0–2.4× faster** than the initial baseline. At scale 2, idle Clock falls from 11.969 to 5.383 ms/frame; Duck falls from 13.538 to 6.433 ms/frame.

The separate final conditional-panel experiment measured these live results on the Pi 4's 1024×768 display, after the raster/blit optimizations were already present:

| Measurement | Before conditional panels | After |
| --- | ---: | ---: |
| Clock draw CPU/frame, raster 2×, events Off | 14.82 ms | 7.06 ms |
| Clock dirty-region CPU/frame | 8.87 ms | 0.06 ms |
| Clock displayed FPS | ~49 | 60 |
| Clock process CPU, one core = 100% | 99% | 77% |
| Falling title-screen draw CPU/frame | 13.26 ms | 6.76 ms |
| Falling process CPU, one core = 100% | 156% | 122% |

Frozen-image old/new/old/new comparisons support the UI-bookkeeping improvement. These are not fixed-frequency trials; the documentation records thermal/governor caveats. Headless Clock timings exclude Slint/DRM presentation, and the live idle/title-screen results do not establish 60 FPS for every active effect or NES game.

Full methodology, repeat results, binary hashes, controls, and local artifact locations:

- [Clock performance lab](https://github.com/aortez/space-wars/blob/more-clock-ii/docs/clock-performance-lab.md)
- [Software presentation performance lab](https://github.com/aortez/space-wars/blob/more-clock-ii/docs/presentation-performance-lab.md)

## Validation

- Rust **1.89**: **936** workspace/all-target tests passed.
- All **20** display-dependent UI functional tests passed under Xvfb.
- **19** vendored LinuxKMS tests passed; the explicit timing benchmark remains opt-in.
- Pixel-equivalence coverage includes RGB formats, scaling/cropping/clipping, generic fallbacks, rotations, alpha, partial damage, reuse/resize, and all Clock effects.
- **34 before/after menu PNGs** and frozen-image checksums matched. Panel lifecycle tests cover partial versus full repaint, preserved root state, removal of pressed buttons, and restored keyboard/touch operation.
- Formatting and whitespace checks passed. Strict NES/Falling CI Clippy passed; client Clippy completed with existing warnings.
- Desktop and Pi release builds passed. The optimized release was deployed and exercised on Picade, including menu/scenario round trips. Clock Demo and the original display/effect/audio settings were restored; the Pi 5 target was not changed.

The existing LinuxKMS CI step now also exercises the new profiling and rendering tests; its label has been updated accordingly. No machine-speed assertions were added to correctness tests.
