### PR TITLE
Add Device Info and responsive kiosk menus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ dependencies = [
  "gilrs",
  "i-slint-backend-linuxkms",
  "i-slint-core",
+ "nix 0.30.1",
  "png 0.17.16",
  "scenario-clock",
  "scenario-falling",
@@ -3305,6 +3306,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ game. Changes apply live and save in the background. New volume settings default
 to 25%; existing saved levels are preserved.
 A failed save leaves the controls usable and offers **Retry Save**.
 
+**App Settings → Device Info** shows the running build, hostname, network
+addresses, CPU/memory/storage information, and connected controller assignments.
+D-pad/arrow keys scroll; A/Enter or B/Esc returns one level to App Settings.
+It is read-only and samples in the background only while open. See
+[Device Info and menu navigation](docs/device-info.md), including the boundary
+for future Wi-Fi setup and controller assignment screens.
+
 The FPS counter is off by default and saved as `video.show_fps`. When enabled,
 a small translucent, non-interactive overlay shows **FPS** (new scenario frames
 submitted to Slint) and **UPS** (simulation updates, or emulated NES frames).

--- a/crates/engine-client/Cargo.toml
+++ b/crates/engine-client/Cargo.toml
@@ -48,6 +48,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+nix = { version = "0.30.1", default-features = false, features = ["fs", "net", "hostname"] }
 # Public diagnostics from our existing vendored LinuxKMS backend, on its UI thread.
 i-slint-backend-linuxkms = { version = "=1.13.1", default-features = false, optional = true }
 

--- a/crates/engine-client/build.rs
+++ b/crates/engine-client/build.rs
@@ -1,3 +1,39 @@
 fn main() {
+    // Source archives may inject an identity; never mistake a runtime checkout
+    // or a machine's installed git for the version of this executable.
+    println!("cargo:rerun-if-env-changed=SPACEWARS_BUILD_REVISION");
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(&root)
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .map(|text| text.trim().to_owned())
+    };
+    // Resolve these via git as .git can be a worktree indirection file.
+    for path in ["HEAD", "index", "packed-refs"] {
+        if let Some(path) = git(&["rev-parse", "--git-path", path]) {
+            println!("cargo:rerun-if-changed={}", root.join(path).display());
+        }
+    }
+    if let Some(reference) = git(&["symbolic-ref", "-q", "HEAD"])
+        && let Some(path) = git(&["rev-parse", "--git-path", &reference])
+    {
+        println!("cargo:rerun-if-changed={}", root.join(path).display());
+    }
+    // Track source edits too, so a clean build followed by an unstaged edit is
+    // not accidentally labelled as a clean commit. Exclude build/data trees.
+    for path in ["Cargo.toml", "Cargo.lock", "crates", "scenarios", "vendor"] {
+        println!("cargo:rerun-if-changed={}", root.join(path).display());
+    }
+    let revision = std::env::var("SPACEWARS_BUILD_REVISION")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| git(&["describe", "--always", "--dirty", "--abbrev=12"]))
+        .unwrap_or_else(|| "unknown (source archive)".into());
+    println!("cargo:rustc-env=SPACEWARS_BUILD_REVISION={revision}");
     slint_build::compile("ui/main.slint").expect("slint compile failed");
 }

--- a/crates/engine-client/src/client_scenarios/mod.rs
+++ b/crates/engine-client/src/client_scenarios/mod.rs
@@ -202,6 +202,27 @@ type ScenarioFactory = fn(
 ) -> Result<Box<dyn ClientScenario>, ScenarioCreateError>;
 
 impl ScenarioRegistration {
+    /// Presentation only: saved scenario IDs and control API values stay stable.
+    pub fn display_name(&self) -> String {
+        if self.id == "nes" {
+            return "NES Library".into();
+        }
+        self.id
+            .split('-')
+            .map(|word| match word {
+                "spacewars" => "Space-Wars".into(),
+                "ai" => "AI".into(),
+                _ => {
+                    let mut chars = word.chars();
+                    chars.next().map_or_else(String::new, |first| {
+                        first.to_uppercase().to_string() + chars.as_str()
+                    })
+                }
+            })
+            .collect::<Vec<String>>()
+            .join(" ")
+    }
+
     #[cfg(test)]
     pub fn create(
         &'static self,
@@ -429,6 +450,21 @@ pub fn launcher_registrations() -> impl Iterator<Item = &'static ScenarioRegistr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn launcher_labels_are_friendly_without_changing_scenario_ids() {
+        for (id, title) in [
+            ("spacewars", "Space-Wars"),
+            ("spacewars-classic", "Space-Wars Classic"),
+            ("nes", "NES Library"),
+            ("rover-lab", "Rover Lab"),
+            ("spacewars-terrain-ai", "Space-Wars Terrain AI"),
+        ] {
+            let registration = registration(id).unwrap();
+            assert_eq!(registration.id, id);
+            assert_eq!(registration.display_name(), title);
+        }
+    }
 
     fn missing_asset_factory(
         _seed: u64,

--- a/crates/engine-client/src/device_info.rs
+++ b/crates/engine-client/src/device_info.rs
@@ -1,0 +1,269 @@
+//! Read-only diagnostics. No network configuration, credentials, shell commands,
+//! or scenario mutation. Sampling is off-thread and demand-driven by visibility.
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use slint::{ComponentHandle, Model, ModelRc, Timer, TimerMode, VecModel};
+use spacewars_control::{UiAction, UiControl};
+
+use crate::{DeviceInfoRow, MainWindow};
+
+mod system;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Field {
+    id: String,
+    label: String,
+    value: String,
+}
+
+impl Field {
+    fn new(id: &str, label: &str, value: impl Into<String>) -> Self {
+        Self {
+            id: format!("info.{id}"),
+            label: label.into(),
+            value: value.into(),
+        }
+    }
+}
+
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// One outstanding sample at most, including across close/reopen. Generations
+/// prevent a slow response from a previous visit being published as fresh data.
+#[derive(Default)]
+struct Sampling {
+    visible: bool,
+    generation: u64,
+    in_flight: bool,
+    next_sample: Option<Instant>,
+}
+
+impl Sampling {
+    fn opened(&mut self) {
+        self.visible = true;
+        self.generation += 1;
+        self.next_sample = None;
+    }
+
+    fn request(&mut self, now: Instant) -> Option<u64> {
+        if !self.visible || self.in_flight || self.next_sample.is_some_and(|next| now < next) {
+            return None;
+        }
+        self.in_flight = true;
+        self.next_sample = Some(now + SAMPLE_INTERVAL);
+        Some(self.generation)
+    }
+
+    fn received(&mut self, generation: u64) -> bool {
+        self.in_flight = false;
+        generation == self.generation
+    }
+}
+
+pub(crate) fn install(window: &MainWindow, config_directory: PathBuf) -> std::io::Result<()> {
+    let (request_tx, request_rx) = mpsc::channel::<u64>();
+    let (result_tx, result_rx) = mpsc::channel();
+    std::thread::Builder::new()
+        .name("device-info".into())
+        .spawn(move || {
+            let mut system = system::Collector::new(config_directory);
+            let mut previous_generation = None;
+            while let Ok(generation) = request_rx.recv() {
+                if previous_generation != Some(generation) {
+                    system.reset_cpu_sample();
+                    previous_generation = Some(generation);
+                }
+                if result_tx.send((generation, system.collect())).is_err() {
+                    break;
+                }
+            }
+        })?;
+    let sampling = Rc::new(RefCell::new(Sampling::default()));
+    let receiver = Rc::new(result_rx);
+    let timer = Timer::default();
+    let weak = window.as_weak();
+    // Slint invokes this for every visibility change, including host cleanup.
+    window.on_device_info_visibility_changed(move || {
+        let Some(window) = weak.upgrade() else { return };
+        timer.stop();
+        if !window.get_device_info_visible() {
+            sampling.borrow_mut().visible = false;
+            return;
+        }
+        sampling.borrow_mut().opened();
+        window.set_device_info_scroll_offset(0.0);
+        window.set_device_info_ready(false);
+        window.set_device_info_rows(ModelRc::default());
+        let refresh = {
+            let sampling = Rc::clone(&sampling);
+            let receiver = Rc::clone(&receiver);
+            let request_tx = request_tx.clone();
+            let weak = window.as_weak();
+            move || {
+                let Some(window) = weak.upgrade() else { return };
+                if !window.get_device_info_visible() {
+                    return;
+                }
+                while let Ok((generation, mut fields)) = receiver.try_recv() {
+                    if sampling.borrow_mut().received(generation) {
+                        fields.extend(runtime_fields(&window));
+                        let rows: Vec<_> = fields
+                            .into_iter()
+                            .map(|field| DeviceInfoRow {
+                                id: field.id.into(),
+                                label: field.label.into(),
+                                value: field.value.into(),
+                            })
+                            .collect();
+                        // Avoid replacing the visual tree for identical samples.
+                        if !window
+                            .get_device_info_rows()
+                            .iter()
+                            .eq(rows.iter().cloned())
+                        {
+                            window.set_device_info_rows(ModelRc::new(VecModel::from(rows)));
+                        }
+                        window.set_device_info_ready(true);
+                    }
+                }
+                if let Some(generation) = sampling.borrow_mut().request(Instant::now())
+                    && request_tx.send(generation).is_err()
+                {
+                    window.set_device_info_rows(ModelRc::new(VecModel::from(vec![
+                        DeviceInfoRow {
+                            id: "info.error".into(),
+                            label: "Diagnostics unavailable".into(),
+                            value: "The system information worker stopped. Back remains available."
+                                .into(),
+                        },
+                    ])));
+                }
+            }
+        };
+        refresh();
+        timer.start(TimerMode::Repeated, Duration::from_millis(100), refresh);
+    });
+    let weak = window.as_weak();
+    window.on_device_info_open(move || {
+        let Some(window) = weak.upgrade() else { return };
+        if window.get_launcher_busy()
+            || !window.get_sound_visible()
+            || (!window.get_launcher_visible() && !window.get_ingame_menu_visible())
+        {
+            return;
+        }
+        window.set_sound_focus_index(3);
+        window.set_device_info_ready(false);
+        window.set_device_info_visible(true);
+    });
+    Ok(())
+}
+
+fn runtime_fields(window: &MainWindow) -> Vec<Field> {
+    let scenario = if window.get_launcher_visible() {
+        "Launcher (no active scenario)".into()
+    } else {
+        format!("{} · paused", window.get_launcher_scenario())
+    };
+    vec![
+        Field::new(
+            "controllers",
+            "Controllers · Current player assignments",
+            window.get_device_controllers().to_string(),
+        ),
+        Field::new("scenario", "Application · Active scenario", scenario),
+        Field::new(
+            "performance",
+            "Application · Frame / update rate",
+            if window.get_launcher_visible() {
+                "Not running"
+            } else {
+                "Paused (frame / update rates stop in menus)"
+            },
+        ),
+    ]
+}
+
+pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
+    match action {
+        UiAction::Up | UiAction::Left => window.invoke_device_info_scroll(-1),
+        UiAction::Down | UiAction::Right => window.invoke_device_info_scroll(1),
+        UiAction::Back | UiAction::Controls | UiAction::Confirm => {
+            window.set_device_info_visible(false)
+        }
+        UiAction::Start => {
+            window.set_device_info_visible(false);
+            if !window.get_launcher_visible() {
+                window.set_sound_visible(false);
+                window.invoke_ingame_resume();
+            }
+        }
+    }
+}
+
+pub(crate) fn inventory(window: &MainWindow) -> Vec<UiControl> {
+    let mut controls: Vec<_> = window
+        .get_device_info_rows()
+        .iter()
+        .map(|row| {
+            UiControl::new(row.id.to_string(), row.label.to_string(), false)
+                .with_value(row.value.to_string())
+        })
+        .collect();
+    controls.extend([
+        UiControl::new("info.status", "Sampling status", false).with_value(
+            if window.get_device_info_ready() {
+                "ready"
+            } else {
+                "loading"
+            },
+        ),
+        UiControl::new("info.scroll-up", "Scroll up", true),
+        UiControl::new("info.scroll-down", "Scroll down", true),
+        UiControl::new("info.scroll-offset", "Scroll offset", false)
+            .with_value(format!("{:.0}", window.get_device_info_scroll_offset())),
+        UiControl::new("info.back", "Back to App Settings", true),
+    ]);
+    controls
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sampler_is_bounded_throttled_and_rejects_previous_visit() {
+        let mut sampler = Sampling::default();
+        let now = Instant::now();
+        assert_eq!(sampler.request(now), None, "no sampling before first open");
+        sampler.opened();
+        let first = sampler.request(now).unwrap();
+        assert_eq!(sampler.request(now + SAMPLE_INTERVAL), None);
+        sampler.opened();
+        assert_eq!(
+            sampler.request(now),
+            None,
+            "reopen cannot queue behind a slow sample"
+        );
+        assert!(
+            !sampler.received(first),
+            "old sample must not appear in the new visit"
+        );
+        let second = sampler.request(now).unwrap();
+        assert!(sampler.received(second));
+        assert_eq!(sampler.request(now), None);
+        sampler.visible = false;
+        assert_eq!(
+            sampler.request(now + SAMPLE_INTERVAL * 100),
+            None,
+            "closed panels do not sample"
+        );
+        sampler.opened();
+        assert!(sampler.request(now + SAMPLE_INTERVAL).is_some());
+    }
+}

--- a/crates/engine-client/src/device_info/system.rs
+++ b/crates/engine-client/src/device_info/system.rs
@@ -1,0 +1,280 @@
+//! Small OS probes, all executed on the diagnostic worker. Unavailable fields
+//! remain explicit; no elevated access or external processes are needed.
+
+use super::Field;
+use std::path::PathBuf;
+
+pub(super) struct Collector {
+    config_directory: PathBuf,
+    previous_cpu: Option<CpuSample>,
+}
+
+impl Collector {
+    pub(super) fn new(config_directory: PathBuf) -> Self {
+        Self {
+            config_directory,
+            previous_cpu: None,
+        }
+    }
+
+    pub(super) fn reset_cpu_sample(&mut self) {
+        self.previous_cpu = None;
+    }
+
+    pub(super) fn collect(&mut self) -> Vec<Field> {
+        let mut fields = vec![
+            Field::new(
+                "version",
+                "Application · Build",
+                format!(
+                    "{} · {} · {}",
+                    env!("CARGO_PKG_VERSION"),
+                    env!("SPACEWARS_BUILD_REVISION"),
+                    if cfg!(debug_assertions) {
+                        "debug"
+                    } else {
+                        "release"
+                    }
+                ),
+            ),
+            Field::new(
+                "platform",
+                "Device · Platform",
+                format!("{} / {}", std::env::consts::OS, std::env::consts::ARCH),
+            ),
+        ];
+        #[cfg(target_os = "linux")]
+        self.linux_fields(&mut fields);
+        #[cfg(not(target_os = "linux"))]
+        fields.push(Field::new(
+            "system",
+            "Device · System metrics",
+            "Available on Linux kiosks; not available on this platform.",
+        ));
+        fields.push(Field::new(
+            "config-directory",
+            "Application · Configuration directory",
+            self.config_directory.display().to_string(),
+        ));
+        fields
+    }
+
+    #[cfg(target_os = "linux")]
+    fn linux_fields(&mut self, fields: &mut Vec<Field>) {
+        use nix::sys::statvfs::statvfs;
+        let hostname = nix::unistd::gethostname()
+            .ok()
+            .map(|value| value.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "Unavailable".into());
+        fields.insert(0, Field::new("hostname", "Device · Hostname", hostname));
+        let model = read_text("/sys/firmware/devicetree/base/model")
+            .or_else(|| read_text("/sys/devices/virtual/dmi/id/product_name"))
+            .unwrap_or_else(|| "Unavailable".into());
+        fields.push(Field::new("model", "Device · Hardware", model));
+        fields.push(Field::new(
+            "addresses",
+            "Network · Local addresses (not an internet connectivity test)",
+            network_addresses(),
+        ));
+        let cpu_info = read_text("/proc/cpuinfo").unwrap_or_default();
+        let cpu_model = cpu_info
+            .lines()
+            .find_map(|line| {
+                line.strip_prefix("model name")
+                    .or_else(|| line.strip_prefix("Hardware"))
+                    .and_then(|line| line.split_once(':'))
+                    .map(|(_, value)| value.trim())
+            })
+            .unwrap_or(std::env::consts::ARCH);
+        let cores = cpu_info
+            .lines()
+            .filter(|line| line.starts_with("processor\t"))
+            .count();
+        fields.push(Field::new(
+            "cpu",
+            "System · CPU",
+            format!("{cpu_model} · {cores} logical cores"),
+        ));
+        let current = read_text("/proc/stat").and_then(|text| CpuSample::parse(&text));
+        let usage = current
+            .zip(self.previous_cpu)
+            .and_then(|(current, previous)| current.usage_since(previous));
+        self.previous_cpu = current;
+        fields.push(Field::new(
+            "cpu-usage",
+            "System · CPU busy (all cores, 0–100%)",
+            match (current, usage) {
+                (_, Some(percent)) => format!("{percent:.1}%"),
+                (Some(_), None) => "Sampling…".into(),
+                _ => "Unavailable".into(),
+            },
+        ));
+        let memory = read_text("/proc/meminfo")
+            .and_then(|text| memory(&text))
+            .map(|(available, total)| {
+                format!("{} available / {} total", size(available), size(total))
+            })
+            .unwrap_or_else(|| "Unavailable".into());
+        fields.push(Field::new("memory", "System · Memory", memory));
+        let temperature = read_text("/sys/class/thermal/thermal_zone0/temp")
+            .and_then(|text| text.parse::<f64>().ok())
+            .map(|temp| format!("{:.1} °C", temp / 1000.0))
+            .unwrap_or_else(|| "Unavailable".into());
+        fields.push(Field::new(
+            "temperature",
+            "System · Thermal zone 0",
+            temperature,
+        ));
+        // /data is the Pi's persistent volume. Desktop runs report the actual
+        // config filesystem instead, never silently label / free space as data.
+        let data_path = if std::path::Path::new("/data/spacewars").is_dir() {
+            PathBuf::from("/data/spacewars")
+        } else {
+            self.config_directory.clone()
+        };
+        let disk = statvfs(&data_path)
+            .ok()
+            .map(|disk| {
+                format!(
+                    "{} available / {} total",
+                    size(disk.blocks_available().saturating_mul(disk.fragment_size())),
+                    size(disk.blocks().saturating_mul(disk.fragment_size()))
+                )
+            })
+            .unwrap_or_else(|| "Unavailable".into());
+        fields.push(Field::new(
+            "storage",
+            "Storage · Persistent data / config filesystem",
+            format!("{}\n{disk}", data_path.display()),
+        ));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_text(path: &str) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|text| {
+            text.trim_matches(|ch: char| ch == '\0' || ch.is_whitespace())
+                .to_owned()
+        })
+        .filter(|text| !text.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn network_addresses() -> String {
+    use nix::net::if_::InterfaceFlags;
+    let Ok(addresses) = nix::ifaddrs::getifaddrs() else {
+        return "Unavailable".into();
+    };
+    let mut rows = std::collections::BTreeSet::new();
+    for interface in addresses {
+        if !interface.flags.contains(InterfaceFlags::IFF_UP)
+            || interface.flags.contains(InterfaceFlags::IFF_LOOPBACK)
+        {
+            continue;
+        }
+        let Some(address) = interface.address else {
+            continue;
+        };
+        let ip = if let Some(address) = address.as_sockaddr_in() {
+            address.ip().to_string()
+        } else if let Some(address) = address.as_sockaddr_in6() {
+            address.ip().to_string()
+        } else {
+            continue;
+        };
+        rows.insert(format!("{}: {ip}", interface.interface_name));
+    }
+    if rows.is_empty() {
+        "No addresses on active network interfaces".into()
+    } else {
+        rows.into_iter().collect::<Vec<_>>().join("\n")
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CpuSample {
+    busy: u64,
+    total: u64,
+}
+
+impl CpuSample {
+    fn parse(text: &str) -> Option<Self> {
+        let mut values = text.lines().next()?.split_whitespace();
+        if values.next()? != "cpu" {
+            return None;
+        }
+        // guest/guest_nice are already counted in user/nice, don't count twice.
+        let values = values
+            .take(8)
+            .map(str::parse::<u64>)
+            .collect::<Result<Vec<_>, _>>()
+            .ok()?;
+        if values.len() < 4 {
+            return None;
+        }
+        let total = values
+            .iter()
+            .try_fold(0u64, |total, value| total.checked_add(*value))?;
+        let idle = values[3].checked_add(values.get(4).copied().unwrap_or(0))?;
+        Some(Self {
+            busy: total.checked_sub(idle)?,
+            total,
+        })
+    }
+
+    fn usage_since(self, previous: Self) -> Option<f64> {
+        let elapsed = self.total.checked_sub(previous.total)?;
+        let busy = self.busy.checked_sub(previous.busy)?;
+        (elapsed > 0 && busy <= elapsed).then(|| busy as f64 * 100.0 / elapsed as f64)
+    }
+}
+
+fn memory(text: &str) -> Option<(u64, u64)> {
+    let value = |key: &str| {
+        text.lines()
+            .find_map(|line| line.strip_prefix(key))?
+            .split_whitespace()
+            .next()?
+            .parse::<u64>()
+            .ok()?
+            .checked_mul(1024)
+    };
+    let total = value("MemTotal:")?;
+    let available = value("MemAvailable:")?;
+    (available <= total && total > 0).then_some((available, total))
+}
+
+fn size(bytes: u64) -> String {
+    format!("{:.2} GiB", bytes as f64 / 1_073_741_824.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_usage_uses_deltas_and_excludes_guest_double_counting() {
+        let first = CpuSample::parse("cpu 10 0 10 80 0 0 0 0 999 999\ncpu0 1").unwrap();
+        let second = CpuSample::parse("cpu 20 0 20 100 0 0 0 0 999 999").unwrap();
+        assert_eq!(first.total, 100);
+        assert_eq!(second.usage_since(first), Some(50.0));
+        assert_eq!(first.usage_since(first), None);
+        assert_eq!(first.usage_since(second), None);
+        for text in ["", "cpu0 1 2 3 4", "cpu 1 2", "cpu x 2 3 4"] {
+            assert!(CpuSample::parse(text).is_none());
+        }
+    }
+
+    #[test]
+    fn memory_reports_available_instead_of_only_unused_pages() {
+        assert_eq!(
+            memory("MemTotal: 8192 kB\nMemFree: 10 kB\nMemAvailable: 4096 kB"),
+            Some((4194304, 8388608))
+        );
+        assert_eq!(memory("MemTotal: 10 kB\nMemFree: 5 kB"), None);
+        assert_eq!(memory("MemTotal: 10 kB\nMemAvailable: 20 kB"), None);
+        assert_eq!(size(1073741824), "1.00 GiB");
+    }
+}

--- a/crates/engine-client/src/gamepad.rs
+++ b/crates/engine-client/src/gamepad.rs
@@ -312,6 +312,28 @@ impl GamepadPump {
     }
 
     fn refresh_connection_ui(&self, window: &MainWindow) {
+        let devices = self
+            .gilrs
+            .gamepads()
+            .map(|(id, pad)| {
+                let seat = self
+                    .assignments
+                    .seats
+                    .iter()
+                    .position(|assigned| *assigned == Some(usize::from(id)));
+                format!(
+                    "{} · {}",
+                    pad.name(),
+                    seat.map(|seat| format!("Player {}", seat + 1))
+                        .unwrap_or_else(|| "Unassigned".into())
+                )
+            })
+            .collect::<Vec<_>>();
+        window.set_device_controllers(if devices.is_empty() {
+            "No gamepads connected · Keyboard input available".into()
+        } else {
+            devices.join("\n").into()
+        });
         let connected = &self.assignments.connected;
         let binding = |seat: usize| {
             let player = seat + 1;

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -864,6 +864,7 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
     let screen = classify_screen(ScreenVisibility {
         launcher_busy: window.get_launcher_busy(),
         sound: window.get_sound_visible(),
+        device_info: window.get_device_info_visible(),
         launcher: window.get_launcher_visible(),
         launcher_controls: window.get_launcher_controls_visible(),
         launcher_settings: window.get_launcher_settings_visible(),
@@ -878,6 +879,12 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
     let inventory = inventory_for_screen(
         screen,
         &UiInventoryContext {
+            device_info_controls: if matches!(screen, UiScreen::LauncherInfo | UiScreen::PauseInfo)
+            {
+                crate::device_info::inventory(window)
+            } else {
+                Vec::new()
+            },
             launcher_busy_stage: window.get_launcher_busy_stage().to_string(),
             launcher_busy_elapsed: window.get_launcher_busy_elapsed().to_string(),
             sound_focus_index: window.get_sound_focus_index(),

--- a/crates/engine-client/src/keyboard_tests.rs
+++ b/crates/engine-client/src/keyboard_tests.rs
@@ -23,6 +23,78 @@ fn key(window: &MainWindow, text: impl Into<SharedString>) {
 }
 
 #[test]
+fn scenario_confirmation_focuses_play_without_changing_the_selection() {
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let window = MainWindow::new().unwrap();
+    window
+        .window()
+        .set_size(slint::LogicalSize::new(800.0, 480.0));
+    install_ui_navigation(&window);
+    install_keyboard_navigation(
+        &window,
+        Rc::new(RefCell::new(input::ClientInput::default())),
+    );
+    window.set_launcher_scenarios(ModelRc::new(VecModel::from(vec![
+        "spacewars".into(),
+        "clock".into(),
+        "pizza".into(),
+    ])));
+    window.set_launcher_scenario("spacewars".into());
+    window.set_launcher_seed_text("12345".into());
+    window.set_launcher_visible(true);
+    let starts = Rc::new(Cell::new(0));
+    let started = Rc::clone(&starts);
+    window.on_launcher_start_game(move || started.set(started.get() + 1));
+    window.show().unwrap();
+
+    key(&window, Key::RightArrow);
+    assert_eq!(window.get_launcher_scenario(), "clock");
+    key(&window, Key::LeftArrow);
+    assert_eq!(window.get_launcher_scenario(), "spacewars");
+    click(&window, 725.0, 125.0);
+    assert_eq!(window.get_launcher_scenario(), "clock");
+    click(&window, 75.0, 125.0);
+    assert_eq!(window.get_launcher_scenario(), "spacewars");
+    assert_eq!(window.get_launcher_focus_index(), 0);
+
+    // Exercise both launcher layouts and the shared controller action as well
+    // as real Slint keyboard dispatch. Confirmation must not start or browse.
+    for scenario in ["spacewars", "clock"] {
+        for keyboard in [true, false] {
+            window.set_launcher_scenario(scenario.into());
+            window.set_launcher_focus_index(0);
+            let before = starts.get();
+            if keyboard {
+                key(&window, Key::Return);
+                window
+                    .window()
+                    .dispatch_event(WindowEvent::KeyPressRepeated {
+                        text: Key::Return.into(),
+                    });
+            } else {
+                window.invoke_ui_action(UiAction::Confirm.code());
+            }
+            assert_eq!(window.get_launcher_focus_index(), 1);
+            assert_eq!(starts.get(), before);
+            assert_eq!(window.get_launcher_scenario(), scenario);
+            assert_eq!(window.get_launcher_seed_text(), "12345");
+
+            if keyboard {
+                key(&window, Key::Return);
+            } else {
+                window.invoke_ui_action(UiAction::Confirm.code());
+            }
+            assert_eq!(starts.get(), before + 1);
+
+            window.set_launcher_focus_index(0);
+            window.invoke_ui_action(UiAction::Start.code());
+            assert_eq!(starts.get(), before + 2);
+            assert_eq!(window.get_launcher_scenario(), scenario);
+        }
+    }
+}
+
+#[test]
 fn backend_neutral_keyboard_reaches_clock_settings_and_does_not_repeat_shortcuts() {
     slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
     let window = MainWindow::new().unwrap();
@@ -264,11 +336,11 @@ fn sound_keyboard_touch_and_menu_actions_share_persistent_controls() {
     key(&window, Key::RightArrow);
     assert_eq!(window.get_sound_volume_percent(), 30);
     // Touch hits the same shared callbacks; no platform-specific key injection.
-    click(&window, 612.0, 98.0);
+    click(&window, 710.0, 120.0);
     assert_eq!(window.get_sound_volume_percent(), 35);
-    click(&window, 400.0, 161.0);
+    click(&window, 400.0, 182.0);
     assert!(window.get_sound_muted());
-    click(&window, 400.0, 221.0);
+    click(&window, 400.0, 244.0);
     assert!(window.get_performance_overlay_enabled());
     key(&window, Key::DownArrow);
     assert_eq!(window.get_sound_focus_index(), 3);
@@ -289,6 +361,27 @@ fn sound_keyboard_touch_and_menu_actions_share_persistent_controls() {
     assert_eq!(window.get_sound_focus_index(), 3);
     assert_eq!(settings.read().unwrap().audio, audio_before_info);
     assert_eq!(resumes.get(), 0);
+    // A shorter window forces the settings body to scroll. Its focused Device
+    // Info row is revealed after resizing and remains a real touch target.
+    window
+        .window()
+        .set_size(slint::LogicalSize::new(800.0, 360.0));
+    window.window().take_snapshot().unwrap();
+    click(&window, 400.0, 190.0);
+    assert!(window.get_device_info_visible());
+    key(&window, Key::Escape);
+    assert!(window.get_sound_visible());
+    assert_eq!(window.get_sound_focus_index(), 3);
+    window.window().take_snapshot().unwrap();
+    // Back remains below the scroll area, even when the last row is selected.
+    click(&window, 400.0, 288.0);
+    assert!(!window.get_sound_visible());
+    assert_eq!(resumes.get(), 0);
+    window
+        .window()
+        .set_size(slint::LogicalSize::new(800.0, 480.0));
+    window.invoke_sound_open();
+    window.set_sound_focus_index(3);
     key(&window, Key::UpArrow);
     assert_eq!(window.get_sound_focus_index(), 2);
     key(&window, Key::LeftArrow);

--- a/crates/engine-client/src/keyboard_tests.rs
+++ b/crates/engine-client/src/keyboard_tests.rs
@@ -246,6 +246,7 @@ fn sound_keyboard_touch_and_menu_actions_share_persistent_controls() {
         Arc::clone(&settings),
         writer.clone(),
     );
+    device_info::install(&window, directory.path().to_path_buf()).unwrap();
     let resumes = Rc::new(Cell::new(0));
     let resumed = Rc::clone(&resumes);
     window.on_ingame_resume(move || resumed.set(resumed.get() + 1));
@@ -263,14 +264,31 @@ fn sound_keyboard_touch_and_menu_actions_share_persistent_controls() {
     key(&window, Key::RightArrow);
     assert_eq!(window.get_sound_volume_percent(), 30);
     // Touch hits the same shared callbacks; no platform-specific key injection.
-    click(&window, 612.0, 122.0);
+    click(&window, 612.0, 98.0);
     assert_eq!(window.get_sound_volume_percent(), 35);
-    click(&window, 400.0, 191.0);
+    click(&window, 400.0, 161.0);
     assert!(window.get_sound_muted());
-    click(&window, 400.0, 257.0);
+    click(&window, 400.0, 221.0);
     assert!(window.get_performance_overlay_enabled());
     key(&window, Key::DownArrow);
     assert_eq!(window.get_sound_focus_index(), 3);
+    let audio_before_info = settings.read().unwrap().audio;
+    key(&window, Key::Return);
+    assert!(window.get_device_info_visible());
+    pump_until(|| window.get_device_info_ready());
+    // The minimal non-Winit test platform has no draw loop. Realize the new
+    // scroll layout before using its bounds, just as a displayed frame does.
+    window.window().take_snapshot().unwrap();
+    pump_until(|| window.get_device_info_scroll_limit() > 0.0);
+    key(&window, Key::DownArrow);
+    assert!(window.get_device_info_scroll_offset() < 0.0);
+    // Touch Back belongs to Info, not the covered launcher or App Settings.
+    click(&window, 250.0, 410.0);
+    assert!(!window.get_device_info_visible());
+    assert!(window.get_sound_visible());
+    assert_eq!(window.get_sound_focus_index(), 3);
+    assert_eq!(settings.read().unwrap().audio, audio_before_info);
+    assert_eq!(resumes.get(), 0);
     key(&window, Key::UpArrow);
     assert_eq!(window.get_sound_focus_index(), 2);
     key(&window, Key::LeftArrow);
@@ -320,7 +338,7 @@ fn sound_keyboard_touch_and_menu_actions_share_persistent_controls() {
     assert_eq!(settings.read().unwrap().audio.master_volume, 0.40);
     assert!(!window.get_settings_save_error().is_empty());
     std::fs::remove_dir(&path).unwrap();
-    window.set_sound_focus_index(4);
+    window.set_sound_focus_index(5);
     window.invoke_ui_action(UiAction::Confirm.code());
     pump_until(|| !window.get_settings_save_pending());
     assert!(window.get_settings_save_error().is_empty());

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -6,6 +6,7 @@
 
 mod client_scenarios;
 mod clock_controls;
+mod device_info;
 mod gamepad;
 mod host;
 mod input;
@@ -464,6 +465,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&settings),
         settings_writer.clone(),
     );
+    device_info::install(
+        &window,
+        settings_path
+            .parent()
+            .unwrap_or(Path::new("."))
+            .to_path_buf(),
+    )?;
     apply_video_settings(&window, &args, &settings.read().unwrap());
     let _gamepad_timer = gamepad::start_gamepad_pump(&window, Rc::clone(&input), gamepad_input);
 
@@ -1122,7 +1130,9 @@ fn handle_ui_action(window: &MainWindow, action: UiAction) {
     if window.get_launcher_busy() {
         return;
     }
-    if window.get_sound_visible() {
+    if window.get_device_info_visible() && window.get_sound_visible() {
+        device_info::handle_action(window, action);
+    } else if window.get_sound_visible() {
         sound_controls::handle_action(window, action);
     } else if window.get_touch_test_visible() {
         if matches!(action, UiAction::Back | UiAction::Controls) {

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -858,6 +858,7 @@ fn resolve_launch_asset(
 }
 
 fn apply_scenario_metadata(window: &MainWindow, scenario: &str) {
+    window.set_launcher_scenario_title(scenario.into());
     let Some(registration) = host::scenario_registration(scenario) else {
         window.set_scenario_benchmark_available(false);
         window.set_scenario_player_zoom_available(false);
@@ -866,6 +867,7 @@ fn apply_scenario_metadata(window: &MainWindow, scenario: &str) {
         window.set_scenario_controls_help(SharedString::from(""));
         return;
     };
+    window.set_launcher_scenario_title(registration.display_name().into());
     window.set_scenario_benchmark_available(registration.capabilities.benchmark);
     window.set_scenario_player_zoom_available(registration.capabilities.player_zoom);
     window.set_scenario_captures_gamepad_start(registration.capabilities.captures_gamepad_start);
@@ -1239,7 +1241,7 @@ fn handle_launcher_ui_action(window: &MainWindow, action: UiAction) {
             }
         }
         UiAction::Confirm => match window.get_launcher_focus_index() {
-            0 => cycle_launcher_scenario(window, 1),
+            0 => window.set_launcher_focus_index(1),
             1 => window.invoke_launcher_start_game(),
             2 => window.set_launcher_settings_visible(true),
             3 => window.set_launcher_controls_visible(true),

--- a/crates/engine-client/src/sound_controls.rs
+++ b/crates/engine-client/src/sound_controls.rs
@@ -78,7 +78,7 @@ pub(crate) fn install(
         writer.save(snapshot);
         window.set_settings_save_pending(true);
         window.set_settings_save_error("".into());
-        window.set_sound_focus_index(3);
+        window.set_sound_focus_index(4);
     });
 }
 
@@ -123,9 +123,9 @@ fn adjusted(audio: AudioSettings, index: i32, delta: i32) -> AudioSettings {
 pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
     let index = window.get_sound_focus_index();
     let count = if window.get_settings_save_error().is_empty() {
-        4
-    } else {
         5
+    } else {
+        6
     };
     match action {
         UiAction::Up | UiAction::Down => {
@@ -138,13 +138,14 @@ pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
         UiAction::Left | UiAction::Right if index <= 2 => {
             window.invoke_sound_adjust(index, if action == UiAction::Left { -1 } else { 1 })
         }
-        UiAction::Left | UiAction::Right if count == 5 => {
-            window.set_sound_focus_index(if index == 3 { 4 } else { 3 })
+        UiAction::Left | UiAction::Right if count == 6 && index >= 4 => {
+            window.set_sound_focus_index(if index == 4 { 5 } else { 4 })
         }
         UiAction::Confirm if index == 1 || index == 2 => window.invoke_sound_adjust(index, 0),
-        UiAction::Confirm if index == 4 && count == 5 => window.invoke_sound_retry(),
+        UiAction::Confirm if index == 3 => window.invoke_device_info_open(),
+        UiAction::Confirm if index == 5 && count == 6 => window.invoke_sound_retry(),
         UiAction::Back | UiAction::Controls | UiAction::Confirm
-            if action != UiAction::Confirm || index == 3 =>
+            if action != UiAction::Confirm || index == 4 =>
         {
             window.set_sound_visible(false)
         }

--- a/crates/engine-client/src/ui_activation.rs
+++ b/crates/engine-client/src/ui_activation.rs
@@ -13,6 +13,7 @@ enum ActivationFocus {
     PauseMain(i32),
     PauseSound,
     Sound(i32),
+    DeviceInfo,
     PauseControls,
     PauseClock(i32),
     GameOver(i32),
@@ -44,8 +45,10 @@ pub(crate) fn activate(window: &MainWindow, control_id: &str) -> bool {
         ActivationFocus::LauncherControls(index) => {
             window.set_launcher_controls_focus_index(index);
         }
-        ActivationFocus::TouchTest | ActivationFocus::PauseControls | ActivationFocus::Gameplay => {
-        }
+        ActivationFocus::TouchTest
+        | ActivationFocus::PauseControls
+        | ActivationFocus::Gameplay
+        | ActivationFocus::DeviceInfo => {}
         ActivationFocus::PauseMain(index) => window.set_ingame_menu_focus_index(index),
         ActivationFocus::PauseSound => window.set_ingame_menu_focus_index(
             4 + i32::from(
@@ -95,8 +98,21 @@ fn activation_target(
         "sound.volume.next" => sound(0, UiAction::Right),
         "sound.mute" => sound(1, UiAction::Confirm),
         "settings.fps-counter" => sound(2, UiAction::Confirm),
-        "sound.back" => sound(3, UiAction::Confirm),
-        "sound.retry" => sound(4, UiAction::Confirm),
+        "settings.device-info" => sound(3, UiAction::Confirm),
+        "sound.back" => sound(4, UiAction::Confirm),
+        "sound.retry" => sound(5, UiAction::Confirm),
+        "info.back" => ActivationTarget {
+            focus: ActivationFocus::DeviceInfo,
+            action: UiAction::Back,
+        },
+        "info.scroll-up" => ActivationTarget {
+            focus: ActivationFocus::DeviceInfo,
+            action: UiAction::Up,
+        },
+        "info.scroll-down" => ActivationTarget {
+            focus: ActivationFocus::DeviceInfo,
+            action: UiAction::Down,
+        },
         "launcher.settings.back" => launcher_settings(None, UiAction::Back),
         "launcher.settings.start" => launcher_settings(None, UiAction::Start),
         "launcher.controls.back" => launcher_controls(0),

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -6,6 +6,7 @@ use spacewars_control::{UiAction, UiControl, UiScreen};
 pub(crate) struct ScreenVisibility {
     pub(crate) launcher_busy: bool,
     pub(crate) sound: bool,
+    pub(crate) device_info: bool,
     pub(crate) launcher: bool,
     pub(crate) launcher_controls: bool,
     pub(crate) launcher_settings: bool,
@@ -22,7 +23,9 @@ pub(crate) fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
     } else if visibility.touch_test {
         UiScreen::LauncherTouchTest
     } else if visibility.launcher {
-        if visibility.sound {
+        if visibility.sound && visibility.device_info {
+            UiScreen::LauncherInfo
+        } else if visibility.sound {
             UiScreen::LauncherSound
         } else if visibility.launcher_controls {
             UiScreen::LauncherControls
@@ -33,6 +36,8 @@ pub(crate) fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
         }
     } else if visibility.game_over {
         UiScreen::GameOver
+    } else if visibility.ingame_menu && visibility.sound && visibility.device_info {
+        UiScreen::PauseInfo
     } else if visibility.ingame_menu && visibility.sound {
         UiScreen::PauseSound
     } else if visibility.ingame_menu && visibility.ingame_clock {
@@ -48,6 +53,7 @@ pub(crate) fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct UiInventoryContext {
+    pub(crate) device_info_controls: Vec<UiControl>,
     pub(crate) launcher_busy_stage: String,
     pub(crate) launcher_busy_elapsed: String,
     pub(crate) sound_focus_index: i32,
@@ -122,6 +128,12 @@ pub(crate) fn inventory_for_screen(screen: UiScreen, context: &UiInventoryContex
         },
         UiScreen::LauncherMain => launcher_main_inventory(context),
         UiScreen::LauncherSound | UiScreen::PauseSound => sound_inventory(context),
+        UiScreen::LauncherInfo | UiScreen::PauseInfo => UiInventory {
+            selected_control: Some("info.back".into()),
+            controls: context.device_info_controls.clone(),
+            actions: UiAction::ALL.to_vec(),
+            error: None,
+        },
         UiScreen::LauncherSettings => launcher_settings_inventory(context),
         UiScreen::LauncherControls => launcher_controls_inventory(context),
         UiScreen::LauncherTouchTest => UiInventory {
@@ -705,11 +717,13 @@ fn sound_inventory(context: &UiInventoryContext) -> UiInventory {
             },
         ),
     );
+    controls.push(UiControl::new("settings.device-info", "Device Info", true));
     controls.push(UiControl::new("sound.back", "Back", true));
     let mut ids = vec![
         "sound.volume",
         "sound.mute",
         "settings.fps-counter",
+        "settings.device-info",
         "sound.back",
     ];
     if context.settings_save_error.is_some() {
@@ -965,6 +979,26 @@ mod tests {
 
     #[test]
     fn classification_uses_visible_layer_order() {
+        for (launcher, expected) in [(true, UiScreen::LauncherInfo), (false, UiScreen::PauseInfo)] {
+            assert_eq!(
+                classify_screen(ScreenVisibility {
+                    launcher,
+                    sound: true,
+                    device_info: true,
+                    ingame_menu: !launcher,
+                    ..Default::default()
+                }),
+                expected
+            );
+        }
+        assert_eq!(
+            classify_screen(ScreenVisibility {
+                device_info: true,
+                ..Default::default()
+            }),
+            UiScreen::Gameplay,
+            "a stale child flag alone must not hide gameplay"
+        );
         assert_eq!(
             classify_screen(ScreenVisibility {
                 launcher_busy: true,
@@ -979,6 +1013,7 @@ mod tests {
             classify_screen(ScreenVisibility {
                 launcher_busy: false,
                 sound: false,
+                device_info: false,
                 launcher: true,
                 launcher_controls: true,
                 launcher_settings: true,

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -247,9 +247,9 @@ fn launcher_main_inventory(context: &UiInventoryContext) -> UiInventory {
             UiControl::new("launcher.scenario.next", "›", true)
                 .with_value(context.selected_scenario.clone()),
             if material_match {
-                world_control("launcher.start", "Play World", "Start Game", context)
+                world_control("launcher.start", "Play", "Play", context)
             } else {
-                UiControl::new("launcher.start", "Start Game", context.launch_available)
+                UiControl::new("launcher.start", "Play", context.launch_available)
             },
             UiControl::new("launcher.settings", "Scenario Settings", true),
             UiControl::new("launcher.controls", "Controls", true),
@@ -268,11 +268,9 @@ fn launcher_main_inventory(context: &UiInventoryContext) -> UiInventory {
         error: context.launcher_error.clone(),
     };
     if material_match {
-        inventory.controls.push(UiControl::new(
-            "launcher.new-match",
-            "New Match · New World",
-            true,
-        ));
+        inventory
+            .controls
+            .push(UiControl::new("launcher.new-match", "Play New World", true));
         if context.launcher_focus_index == 6 {
             inventory.selected_control = Some("launcher.new-match".into());
         }
@@ -696,11 +694,12 @@ fn push_choice(controls: &mut Vec<UiControl>, id: &str, value: &str) {
 
 fn sound_inventory(context: &UiInventoryContext) -> UiInventory {
     let mut controls = Vec::new();
-    push_choice(
-        &mut controls,
-        "sound.volume",
-        &format!("{}%", context.sound_volume_percent),
-    );
+    for (id, label) in [("sound.volume.previous", "-"), ("sound.volume.next", "+")] {
+        controls.push(
+            UiControl::new(id, label, true)
+                .with_value(format!("{}%", context.sound_volume_percent)),
+        );
+    }
     controls.push(
         UiControl::new("sound.mute", "Mute", true).with_value(if context.sound_muted {
             "on"

--- a/crates/engine-client/src/ui_navigation.rs
+++ b/crates/engine-client/src/ui_navigation.rs
@@ -10,25 +10,26 @@ pub(crate) fn moved_selection(current: i32, item_count: i32, delta: i32) -> i32 
 }
 
 pub(crate) fn moved_launcher_selection(current: i32, action: UiAction) -> i32 {
-    // Scenario, [Start, Settings], [Controls, Sound, Quit]. Keep old IDs stable.
+    // Scenario, Play, [Settings, Controls, App Settings], Quit footer.
+    // Keep old control indices stable even though their layout has changed.
     let current = current.clamp(0, 5);
     match action {
-        UiAction::Up => [3, 0, 0, 1, 2, 1][current as usize],
-        UiAction::Down => [1, 3, 4, 0, 0, 0][current as usize],
-        UiAction::Left => [0, 2, 1, 4, 5, 3][current as usize],
-        UiAction::Right => [0, 2, 1, 5, 3, 4][current as usize],
+        UiAction::Up => [4, 0, 1, 1, 2, 1][current as usize],
+        UiAction::Down => [1, 2, 4, 4, 0, 4][current as usize],
+        UiAction::Left => [0, 1, 5, 2, 4, 3][current as usize],
+        UiAction::Right => [0, 1, 3, 5, 4, 2][current as usize],
         _ => current,
     }
 }
 
-/// World actions occupy the first row; Settings, Controls, Sound and Quit the second.
+/// The same layout adds Play New World beside Play; Quit stays in the footer.
 pub(crate) fn moved_match_launcher_selection(current: i32, action: UiAction) -> i32 {
     let current = current.clamp(0, 6) as usize;
     match action {
-        UiAction::Up => [2, 0, 1, 1, 6, 6, 0][current],
-        UiAction::Down => [1, 2, 0, 0, 0, 0, 4][current],
-        UiAction::Left => [0, 6, 4, 2, 5, 3, 1][current],
-        UiAction::Right => [0, 6, 3, 5, 2, 4, 1][current],
+        UiAction::Up => [4, 0, 1, 1, 2, 6, 0][current],
+        UiAction::Down => [1, 2, 4, 4, 0, 4, 5][current],
+        UiAction::Left => [0, 6, 5, 2, 4, 3, 1][current],
+        UiAction::Right => [0, 6, 3, 5, 4, 2, 1][current],
         _ => current as i32,
     }
 }
@@ -120,11 +121,18 @@ mod tests {
     #[test]
     fn launcher_navigation_matches_the_visible_grid() {
         assert_eq!(moved_launcher_selection(0, UiAction::Down), 1);
-        assert_eq!(moved_launcher_selection(1, UiAction::Right), 2);
+        assert_eq!(moved_launcher_selection(1, UiAction::Down), 2);
+        assert_eq!(moved_launcher_selection(2, UiAction::Right), 3);
+        assert_eq!(moved_launcher_selection(3, UiAction::Right), 5);
+        assert_eq!(moved_launcher_selection(5, UiAction::Right), 2);
         assert_eq!(moved_launcher_selection(2, UiAction::Down), 4);
-        assert_eq!(moved_launcher_selection(4, UiAction::Left), 5);
+        assert_eq!(moved_launcher_selection(4, UiAction::Down), 0);
         assert_eq!(moved_launcher_selection(5, UiAction::Left), 3);
-        assert_eq!(moved_launcher_selection(3, UiAction::Down), 0);
+        assert_eq!(moved_match_launcher_selection(1, UiAction::Right), 6);
+        assert_eq!(moved_match_launcher_selection(6, UiAction::Down), 5);
+        assert_eq!(moved_match_launcher_selection(5, UiAction::Down), 4);
+        assert_eq!(moved_match_launcher_selection(4, UiAction::Up), 2);
+        assert_eq!(moved_match_launcher_selection(6, UiAction::Left), 1);
     }
 
     #[test]

--- a/crates/engine-client/src/ui_render_tests.rs
+++ b/crates/engine-client/src/ui_render_tests.rs
@@ -34,6 +34,7 @@ fn reset_panels(ui: &MainWindow) {
     ui.set_scenario_error_text("".into());
     ui.set_touch_test_visible(false);
     ui.set_sound_visible(false);
+    ui.set_device_info_visible(false);
     ui.set_performance_overlay_enabled(false);
     ui.set_performance_overlay_text("".into());
     ui.set_launcher_busy(false);
@@ -60,6 +61,24 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
         ui.set_clock_event_labels(Rc::new(slint::VecModel::from(vec!["Falling".into()])).into());
         ui.set_scenario_controls_help("Move with the joystick. A selects. B goes back.".into());
         ui.set_sound_volume_percent(5);
+        ui.set_device_info_ready(true);
+        ui.set_device_info_rows(slint::ModelRc::new(slint::VecModel::from(vec![
+            crate::DeviceInfoRow {
+                id: "info.hostname".into(),
+                label: "Device · Hostname".into(),
+                value: "sw-picade-2".into(),
+            },
+            crate::DeviceInfoRow {
+                id: "info.addresses".into(),
+                label: "Network · Local addresses".into(),
+                value: "wlan0: 192.168.1.142\nwlan0: fe80::1234:5678:abcd:ef12".into(),
+            },
+            crate::DeviceInfoRow {
+                id: "info.controllers".into(),
+                label: "Controllers · Current player assignments".into(),
+                value: "Space-Wars Picade · Player 1\nMicrosoft X-Box 360 pad · Player 2".into(),
+            },
+        ])));
         ui.set_p1_name("Player 1".into());
         ui.set_p1_status("Ship Health: 80%".into());
         ui.set_p1_status_fraction(0.8);
@@ -105,6 +124,11 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_launcher_visible(true);
             ui.set_sound_visible(true);
         }),
+        ("launcher-info", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_sound_visible(true);
+            ui.set_device_info_visible(true);
+        }),
         ("busy", |ui| {
             ui.set_launcher_visible(true);
             ui.set_launcher_busy(true);
@@ -121,6 +145,11 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
         ("pause-sound", |ui| {
             ui.set_ingame_menu_visible(true);
             ui.set_sound_visible(true);
+        }),
+        ("pause-info", |ui| {
+            ui.set_ingame_menu_visible(true);
+            ui.set_sound_visible(true);
+            ui.set_device_info_visible(true);
         }),
         ("disconnected", |ui| {
             ui.set_controller_disconnected_visible(true)

--- a/crates/engine-client/src/ui_render_tests.rs
+++ b/crates/engine-client/src/ui_render_tests.rs
@@ -34,12 +34,17 @@ fn reset_panels(ui: &MainWindow) {
     ui.set_scenario_error_text("".into());
     ui.set_touch_test_visible(false);
     ui.set_sound_visible(false);
+    ui.set_settings_save_error("".into());
+    ui.set_settings_save_pending(false);
+    ui.set_sound_focus_index(0);
     ui.set_device_info_visible(false);
     ui.set_performance_overlay_enabled(false);
     ui.set_performance_overlay_text("".into());
     ui.set_launcher_busy(false);
     ui.set_spacewars_ui_visible(false);
     ui.set_launcher_scenario("clock".into());
+    ui.set_launcher_scenario_title("Clock".into());
+    ui.set_launcher_focus_index(0);
 }
 
 #[test]
@@ -107,6 +112,22 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_performance_overlay_text("FPS 60 | UPS 60".into());
         }),
         ("launcher", |ui| ui.set_launcher_visible(true)),
+        ("launcher-confirmed", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_launcher_focus_index(1);
+        }),
+        ("launcher-spacewars", |ui| {
+            ui.set_launcher_scenario("spacewars".into());
+            ui.set_launcher_scenario_title("Space-Wars".into());
+            ui.set_launcher_seed_text(u64::MAX.to_string().into());
+            ui.set_launcher_p2_controller("rule bot".into());
+            ui.set_launcher_visible(true);
+        }),
+        ("launcher-long-title", |ui| {
+            ui.set_launcher_scenario("spacewars-terrain-travel-duel".into());
+            ui.set_launcher_scenario_title("Space-Wars Terrain Travel Duel".into());
+            ui.set_launcher_visible(true);
+        }),
         ("launcher-settings", |ui| {
             ui.set_launcher_visible(true);
             ui.set_launcher_settings_visible(true);
@@ -128,6 +149,12 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_launcher_visible(true);
             ui.set_sound_visible(true);
             ui.set_device_info_visible(true);
+        }),
+        ("launcher-sound-save-error", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_sound_visible(true);
+            ui.set_settings_save_error("Storage is not writable".into());
+            ui.set_sound_focus_index(5);
         }),
         ("busy", |ui| {
             ui.set_launcher_visible(true);
@@ -171,7 +198,7 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
     ];
     // Keep both trees alive across transitions and a resize. The first buffer
     // preserves old pixels; the reference repaints the entire window every time.
-    for (width, height) in [(800, 480), (480, 800)] {
+    for (width, height) in [(800, 480), (1024, 768), (480, 800)] {
         for window in windows.iter() {
             window.set_size(PhysicalSize::new(width, height));
         }

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -61,7 +61,7 @@ fn launcher_navigation_uses_the_public_control_api() {
             UiAction::Down,
             UiAction::Left,
             UiAction::Left,
-            UiAction::Left,
+            UiAction::Down,
             UiAction::Down,
         ] {
             state = harness.press_guarded(action, &state);
@@ -80,6 +80,21 @@ fn launcher_navigation_uses_the_public_control_api() {
             ])
         );
         assert_eq!(selected_control(&state), "launcher.scenario");
+
+        let scenario_before = state.selected_scenario.clone();
+        let seed_before = control_value(&state, "launcher.start").map(str::to_owned);
+        state = harness.press_guarded(UiAction::Right, &state);
+        assert_ne!(state.selected_scenario, scenario_before);
+        state = harness.press_guarded(UiAction::Left, &state);
+        assert_eq!(state.selected_scenario, scenario_before);
+        state = harness.press_guarded(UiAction::Confirm, &state);
+        assert_eq!(state.screen, UiScreen::LauncherMain);
+        assert_eq!(selected_control(&state), "launcher.start");
+        assert_eq!(state.selected_scenario, scenario_before);
+        assert_eq!(
+            control_value(&state, "launcher.start"),
+            seed_before.as_deref()
+        );
 
         state = harness.activate_guarded("launcher.settings", &state);
         assert_eq!(state.screen, UiScreen::LauncherSettings);

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -29,6 +29,9 @@ mod clock;
 #[path = "ui_control_functional/sound.rs"]
 mod sound;
 
+#[path = "ui_control_functional/device_info.rs"]
+mod device_info;
+
 #[path = "ui_control_functional/performance.rs"]
 mod performance;
 

--- a/crates/engine-client/tests/ui_control_functional/device_info.rs
+++ b/crates/engine-client/tests/ui_control_functional/device_info.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn device_info_is_shared_read_only_scrollable_and_returns_to_its_parent() {
+    run_functional_test("device-info", |harness| {
+        let launcher = harness.wait_until_ready();
+        let settings = harness.activate_guarded("launcher.sound", &launcher);
+        let info = harness.activate_guarded("settings.device-info", &settings);
+        assert_eq!(info.screen, UiScreen::LauncherInfo);
+        let info = harness.wait_info_ready();
+        assert!(info.active_scenario.is_none());
+        assert_eq!(selected_control(&info), "info.back");
+        assert!(
+            info.controls
+                .iter()
+                .any(|control| control.id == "info.version" && !control.enabled)
+        );
+        assert!(control_value(&info, "info.controllers").is_some());
+        #[cfg(target_os = "linux")]
+        {
+            assert!(!control_value(&info, "info.hostname").unwrap().is_empty());
+            assert!(
+                control_value(&info, "info.memory")
+                    .unwrap()
+                    .contains("total")
+            );
+            assert!(
+                control_value(&info, "info.storage")
+                    .unwrap()
+                    .contains("available")
+            );
+        }
+        harness.capture_screenshot("launcher-info.png");
+        // Telemetry deliberately changes revisions. Navigation depends on the
+        // screen, not the CPU sample that happened to be visible before a PNG.
+        let info = harness.press(UiAction::Down, Some(UiScreen::LauncherInfo), None);
+        assert!(
+            control_value(&info, "info.scroll-offset")
+                .unwrap()
+                .parse::<i32>()
+                .unwrap()
+                < 0
+        );
+        let info = harness.activate("info.scroll-up", Some(UiScreen::LauncherInfo), None);
+        assert_eq!(control_value(&info, "info.scroll-offset"), Some("0"));
+        let settings = harness.press(UiAction::Back, Some(UiScreen::LauncherInfo), None);
+        assert_eq!(settings.screen, UiScreen::LauncherSound);
+        assert_eq!(selected_control(&settings), "settings.device-info");
+        let launcher = harness.activate_guarded("sound.back", &settings);
+        assert_eq!(selected_control(&launcher), "launcher.sound");
+
+        let launcher = harness.activate_until_scenario("clock", launcher);
+        harness.activate_guarded("launcher.start", &launcher);
+        let gameplay = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                ..Default::default()
+            },
+            TRANSITION_TIMEOUT,
+        );
+        harness.pause_guarded(&gameplay);
+        let pause = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::PauseMain),
+                ..Default::default()
+            },
+            TRANSITION_TIMEOUT,
+        );
+        let settings = harness.activate_guarded("pause.sound", &pause);
+        let info = harness.activate_guarded("settings.device-info", &settings);
+        assert_eq!(info.screen, UiScreen::PauseInfo);
+        let info = harness.wait_info_ready();
+        assert!(info.paused);
+        assert_eq!(info.scenario_revision, gameplay.scenario_revision);
+        assert_eq!(
+            control_value(&info, "info.scenario"),
+            Some("clock · paused")
+        );
+        harness.capture_screenshot("pause-info.png");
+        let settings = harness.activate("info.back", Some(UiScreen::PauseInfo), None);
+        assert_eq!(settings.screen, UiScreen::PauseSound);
+        assert!(settings.paused);
+        assert_eq!(selected_control(&settings), "settings.device-info");
+        let pause = harness.press_guarded(UiAction::Back, &settings);
+        assert_eq!(pause.screen, UiScreen::PauseMain);
+        assert_eq!(selected_control(&pause), "pause.sound");
+        assert!(pause.paused);
+        // Start remains the explicit shortcut out of all paused menu levels.
+        let settings = harness.activate_guarded("pause.sound", &pause);
+        harness.activate_guarded("settings.device-info", &settings);
+        harness.press(UiAction::Start, Some(UiScreen::PauseInfo), None);
+        let resumed = harness.wait_for(
+            UiStatePredicate {
+                screen: Some(UiScreen::Gameplay),
+                ..Default::default()
+            },
+            TRANSITION_TIMEOUT,
+        );
+        assert!(!resumed.paused);
+        assert_eq!(resumed.scenario_revision, gameplay.scenario_revision);
+    });
+}
+
+impl FunctionalHarness {
+    fn wait_info_ready(&mut self) -> UiState {
+        let deadline = Instant::now() + TRANSITION_TIMEOUT;
+        loop {
+            let state = self.state();
+            if control_value(&state, "info.status") == Some("ready") {
+                return state;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "device info never became ready: {state:?}"
+            );
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -1,5 +1,7 @@
 // Root window for the engine-client.
 
+export struct DeviceInfoRow { id: string, label: string, value: string }
+
 export enum PrimitiveKind {
     path,
     text,
@@ -289,6 +291,12 @@ export component MainWindow inherits Window {
     in-out property <bool> clock-controls-pending: false;
     in property <string> clock-settings-error: "";
     in-out property <bool> sound-visible: false;
+    in-out property <bool> device-info-visible: false;
+    in property <bool> device-info-ready: false;
+    in property <[DeviceInfoRow]> device-info-rows;
+    in-out property <length> device-info-scroll-offset: 0px;
+    out property <length> device-info-scroll-limit: 0px;
+    in-out property <string> device-controllers: "Gamepad backend unavailable · Keyboard input available";
     in-out property <int> sound-focus-index: 0;
     in property <int> sound-volume-percent: 25;
     in property <bool> sound-muted: false;
@@ -385,6 +393,12 @@ export component MainWindow inherits Window {
     callback ingame-clock-preview();
     callback clock-settings-applied();
     callback sound-open();
+    callback device-info-open();
+    callback device-info-visibility-changed();
+    callback device-info-scroll(int);
+    device-info-scroll(direction) => {
+        root.device-info-scroll-offset = Math.max(-root.device-info-scroll-limit, Math.min(0px, root.device-info-scroll-offset - direction * 100px));
+    }
     callback sound-adjust(int, int);
     callback sound-retry();
     callback ingame-restart();
@@ -403,7 +417,14 @@ export component MainWindow inherits Window {
     callback keyboard-action(int, bool);
 
     forward-focus: launcher-shortcuts;
-    changed sound-visible => { launcher-shortcuts.focus(); }
+    changed sound-visible => {
+        if !root.sound-visible { root.device-info-visible = false; }
+        launcher-shortcuts.focus();
+    }
+    changed device-info-visible => {
+        root.device-info-visibility-changed();
+        launcher-shortcuts.focus();
+    }
 
     changed launcher-visible => {
         launcher-shortcuts.focus();
@@ -2221,7 +2242,7 @@ export component MainWindow inherits Window {
         }
     }
 
-    if root.sound-visible && (root.launcher-visible || root.ingame-menu-visible): Rectangle {
+    if root.sound-visible && !root.device-info-visible && (root.launcher-visible || root.ingame-menu-visible): Rectangle {
         width: parent.width;
         height: parent.height;
         background: #050514e8;
@@ -2231,7 +2252,7 @@ export component MainWindow inherits Window {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: Math.min(parent.width - 32px, 520px);
-            height: 424px;
+            height: Math.min(parent.height - 24px, 490px);
             background: #101827;
             border-color: #596273;
             border-width: 1px;
@@ -2245,8 +2266,8 @@ export component MainWindow inherits Window {
                 font-weight: 700;
             }
             ChoiceRow {
-                x: 24px; y: 64px;
-                width: parent.width - 48px; height: 60px;
+                x: 24px; y: 60px;
+                width: parent.width - 48px; height: 52px;
                 label: "Master volume";
                 value: root.sound-volume-percent + "%";
                 selected: root.sound-focus-index == 0;
@@ -2254,22 +2275,22 @@ export component MainWindow inherits Window {
                 next => { root.sound-adjust(0, 1); }
             }
             MenuButton {
-                x: 24px; y: 136px;
-                width: parent.width - 48px; height: 54px;
+                x: 24px; y: 124px;
+                width: parent.width - 48px; height: 50px;
                 text: root.sound-muted ? "Mute: On" : "Mute: Off";
                 selected: root.sound-focus-index == 1;
                 activated => { root.sound-adjust(1, 0); }
             }
             MenuButton {
-                x: 24px; y: 202px;
-                width: parent.width - 48px; height: 54px;
+                x: 24px; y: 184px;
+                width: parent.width - 48px; height: 50px;
                 text: "FPS Counter: " + (root.performance-overlay-enabled ? "On" : "Off");
                 selected: root.sound-focus-index == 2;
                 activated => { root.sound-adjust(2, 0); }
             }
             Text {
-                x: 24px; y: 262px;
-                width: parent.width - 48px; height: 48px;
+                x: 24px; y: 306px;
+                width: parent.width - 48px; height: 46px;
                 text: root.settings-save-pending ? "Saving settings…" : root.settings-save-error != "" ? "Applied for this session. Could not save settings; retry below." : "Saved · Applies to all scenarios";
                 color: root.settings-save-error != "" ? #ffb0a0 : #80d8ff;
                 font-size: 14px;
@@ -2278,27 +2299,110 @@ export component MainWindow inherits Window {
                 horizontal-alignment: center;
             }
             MenuButton {
-                x: 24px; y: 322px;
-                width: root.settings-save-error == "" ? parent.width - 48px : (parent.width - 60px) / 2;
-                height: 54px;
-                text: "Back";
+                x: 24px; y: 244px;
+                width: parent.width - 48px; height: 50px;
+                text: "Device Info  ›";
                 selected: root.sound-focus-index == 3;
+                activated => { root.device-info-open(); }
+            }
+            MenuButton {
+                x: 24px; y: parent.height - 90px;
+                width: root.settings-save-error == "" ? parent.width - 48px : (parent.width - 60px) / 2;
+                height: 48px;
+                text: "Back";
+                selected: root.sound-focus-index == 4;
                 activated => { root.sound-visible = false; }
             }
             if root.settings-save-error != "": MenuButton {
-                x: parent.width / 2 + 6px; y: 322px;
-                width: (parent.width - 60px) / 2; height: 54px;
+                x: parent.width / 2 + 6px; y: parent.height - 90px;
+                width: (parent.width - 60px) / 2; height: 48px;
                 text: "Retry Save";
-                selected: root.sound-focus-index == 4;
+                selected: root.sound-focus-index == 5;
                 activated => { root.sound-retry(); }
             }
             Text {
-                x: 24px; y: 390px;
+                x: 24px; y: parent.height - 28px;
                 width: parent.width - 48px;
                 text: "Left / Right adjust  ·  A selects  ·  B / Esc back";
                 color: #80d8ff;
                 font-size: 13px;
                 horizontal-alignment: center;
+            }
+        }
+    }
+
+    if root.device-info-visible && root.sound-visible && (root.launcher-visible || root.ingame-menu-visible): Rectangle {
+        init => { root.device-info-scroll-limit = info-scroll.scroll-limit; }
+        width: parent.width; height: parent.height;
+        background: #050514e8;
+        TouchArea { width: parent.width; height: parent.height; }
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: Math.min(parent.width - 24px, 760px);
+            height: Math.min(parent.height - 24px, 680px);
+            background: #101827;
+            border-color: #596273; border-width: 1px; border-radius: 8px;
+            Text {
+                x: 24px; y: 16px; text: "Device Info";
+                color: #ffffff; font-size: 26px; font-weight: 700;
+            }
+            Text {
+                x: 24px; y: 52px; width: parent.width - 48px;
+                text: root.device-info-ready ? "Read only · Refreshes every 2 seconds while open" : "Reading device information…";
+                color: #80d8ff; font-size: 14px; overflow: elide;
+            }
+            info-scroll := Flickable {
+                x: 24px; y: 82px;
+                width: parent.width - 48px; height: parent.height - 180px;
+                viewport-width: self.width;
+                viewport-height: info-body.preferred-height;
+                viewport-y <=> root.device-info-scroll-offset;
+                property <length> scroll-limit: Math.max(0px, self.viewport-height - self.height);
+                changed scroll-limit => {
+                    root.device-info-scroll-limit = self.scroll-limit;
+                    self.viewport-y = Math.max(-self.scroll-limit, Math.min(0px, self.viewport-y));
+                }
+                info-body := VerticalLayout {
+                    width: info-scroll.width - 12px;
+                    padding: 0px; spacing: 16px;
+                    for row in root.device-info-rows: VerticalLayout {
+                        spacing: 4px; padding: 0px;
+                        Text { text: row.label; color: #80d8ff; font-size: 15px; wrap: word-wrap; }
+                        Text { text: row.value; color: #ffffff; font-size: 18px; wrap: word-wrap; }
+                    }
+                }
+            }
+            Rectangle {
+                x: parent.width - 24px; y: 82px; width: 3px;
+                height: info-scroll.height; background: #283a50;
+                Rectangle {
+                    width: parent.width;
+                    height: Math.min(parent.height, Math.max(12px, parent.height * info-scroll.height / Math.max(info-scroll.height, info-scroll.viewport-height)));
+                    y: (parent.height - self.height) * Math.min(1, Math.max(0, -root.device-info-scroll-offset / Math.max(1px, info-scroll.viewport-height - info-scroll.height)));
+                    background: #80d8ff;
+                }
+            }
+            MenuButton {
+                x: 24px; y: parent.height - 82px;
+                width: parent.width - 228px; height: 48px;
+                text: "Back to App Settings"; selected: true;
+                activated => { root.device-info-visible = false; }
+            }
+            MenuButton {
+                x: parent.width - 192px; y: parent.height - 82px;
+                width: 78px; height: 48px; text: "Up";
+                activated => { root.device-info-scroll(-1); }
+            }
+            MenuButton {
+                x: parent.width - 102px; y: parent.height - 82px;
+                width: 78px; height: 48px; text: "Down";
+                activated => { root.device-info-scroll(1); }
+            }
+            Text {
+                x: 24px; y: parent.height - 24px; width: parent.width - 48px;
+                text: "D-pad scrolls · A / B / Esc back";
+                color: #80d8ff; font-size: 13px; horizontal-alignment: center;
             }
         }
     }

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -117,9 +117,11 @@ component MenuButton inherits Rectangle {
     in property <string> text;
     in property <bool> selected: false;
     in property <bool> enabled: true;
+    in property <bool> primary: false;
+    in property <bool> quiet: false;
     callback activated();
 
-    background: button-touch.pressed ? #236e96 : root.selected ? #174f70 : #151a27;
+    background: button-touch.pressed ? #236e96 : root.selected ? #174f70 : root.primary ? #17465e : root.quiet ? #101827 : #151a27;
     border-color: button-touch.pressed || root.selected ? #80d8ff : #596273;
     border-width: button-touch.pressed || root.selected ? 3px : 1px;
     border-radius: 6px;
@@ -133,6 +135,8 @@ component MenuButton inherits Rectangle {
         color: button-touch.pressed || root.selected ? #ffffff : #d9e1ec;
         font-size: 16px;
         font-weight: button-touch.pressed || root.selected ? 700 : 500;
+        wrap: word-wrap;
+        overflow: elide;
         horizontal-alignment: center;
         vertical-alignment: center;
     }
@@ -145,6 +149,130 @@ component MenuButton inherits Rectangle {
         clicked => {
             root.activated();
         }
+    }
+}
+
+// Shared page chrome. Content and actions use page coordinates; the footer
+// stays outside scrolling bodies. No translucent parent menus show through.
+component MenuPage inherits Rectangle {
+    in property <length> available-width;
+    in property <length> available-height;
+    in property <string> heading;
+    in property <string> subtitle;
+    in property <bool> error: false;
+    in property <string> hint;
+    x: (root.available-width - self.width) / 2;
+    y: (root.available-height - self.height) / 2;
+    width: Math.min(root.available-width - 32px, 760px);
+    height: Math.min(root.available-height - 24px, 520px);
+    background: #101827;
+    border-color: #596273;
+    border-width: 1px;
+    border-radius: 10px;
+    Text {
+        x: 24px; y: 12px; width: parent.width - 48px; height: 40px;
+        text: root.heading; color: #ffffff; font-size: 26px; font-weight: 700;
+        vertical-alignment: center;
+    }
+    Text {
+        x: 24px; y: 52px; width: parent.width - 48px; height: 24px;
+        text: root.subtitle; color: root.error ? #ffb0a0 : #9fb4cc;
+        font-size: 14px; overflow: elide;
+    }
+    @children
+    Text {
+        x: 24px; y: parent.height - 26px; width: parent.width - 48px; height: 20px;
+        text: root.hint; color: #9fb4cc; font-size: 14px;
+        horizontal-alignment: center;
+    }
+}
+
+component ScenarioPicker inherits Rectangle {
+    in property <string> title;
+    in property <bool> selected;
+    callback previous();
+    callback next();
+    background: root.selected ? #122f44 : #151a27;
+    border-color: root.selected ? #80d8ff : #596273;
+    border-width: root.selected ? 3px : 1px;
+    border-radius: 6px;
+    MenuButton {
+        x: 3px; y: 3px; width: 56px; height: parent.height - 6px;
+        text: "‹"; activated => { root.previous(); }
+    }
+    Text {
+        x: 72px; width: parent.width - 144px; height: parent.height;
+        text: root.title; color: #ffffff; font-size: 22px; font-weight: 700;
+        horizontal-alignment: center; vertical-alignment: center; overflow: elide;
+    }
+    MenuButton {
+        x: parent.width - 59px; y: 3px; width: 56px; height: parent.height - 6px;
+        text: "›"; activated => { root.next(); }
+    }
+}
+
+component SettingsRow inherits Rectangle {
+    in property <string> label;
+    in property <bool> checked: false;
+    in property <bool> navigation: false;
+    in property <bool> selected: false;
+    callback activated();
+    background: row-touch.pressed || root.selected ? #122f44 : #151a27;
+    border-color: row-touch.pressed || root.selected ? #80d8ff : #596273;
+    border-width: row-touch.pressed || root.selected ? 3px : 1px;
+    border-radius: 6px;
+    Text {
+        x: 16px; width: parent.width - 120px; height: parent.height;
+        text: root.label; color: #e6edf7; font-size: 16px; vertical-alignment: center;
+    }
+    Rectangle {
+        x: parent.width - 94px; y: (parent.height - 32px) / 2; width: 78px; height: 32px;
+        background: root.navigation ? #00000000 : root.checked ? #174f70 : #242c3b;
+        border-radius: 16px;
+        Text {
+            width: parent.width; height: parent.height;
+            text: root.navigation ? "›" : root.checked ? "On" : "Off";
+            color: root.navigation || root.checked ? #80d8ff : #c7d0dc;
+            font-size: root.navigation ? 24px : 16px;
+            horizontal-alignment: center; vertical-alignment: center;
+        }
+    }
+    row-touch := TouchArea {
+        width: parent.width; height: parent.height; mouse-cursor: pointer;
+        clicked => { root.activated(); }
+    }
+}
+
+component VolumeRow inherits Rectangle {
+    in property <int> percent;
+    in property <bool> selected;
+    callback previous();
+    callback next();
+    background: root.selected ? #122f44 : #151a27;
+    border-color: root.selected ? #80d8ff : #596273;
+    border-width: root.selected ? 3px : 1px;
+    border-radius: 6px;
+    Text {
+        x: 16px; width: parent.width - 216px; height: parent.height - 8px;
+        text: "Master volume"; color: #e6edf7; font-size: 16px; vertical-alignment: center;
+    }
+    MenuButton {
+        x: parent.width - 196px; y: 2px; width: 52px; height: parent.height - 4px;
+        text: "-"; activated => { root.previous(); }
+    }
+    Text {
+        x: parent.width - 140px; width: 64px; height: parent.height - 8px;
+        text: root.percent + "%"; color: #ffffff; font-size: 18px; font-weight: 700;
+        horizontal-alignment: center; vertical-alignment: center;
+    }
+    MenuButton {
+        x: parent.width - 72px; y: 2px; width: 52px; height: parent.height - 4px;
+        text: "+"; activated => { root.next(); }
+    }
+    Rectangle {
+        x: 16px; y: parent.height - 9px; width: parent.width - 232px; height: 3px;
+        background: #344255;
+        Rectangle { x: 0px; y: 0px; width: parent.width * root.percent / 100; height: parent.height; background: #80d8ff; }
     }
 }
 
@@ -307,6 +435,7 @@ export component MainWindow inherits Window {
     in-out property <bool> game-over-visible: false;
     in-out property <int> game-over-focus-index: 0;
     in property <[string]> launcher-scenarios;
+    in property <string> launcher-scenario-title: "Space-Wars";
     in-out property <string> launcher-scenario: "spacewars";
     in-out property <string> launcher-seed-text: "0";
     in-out property <string> launcher-renderer: "vector";
@@ -1251,63 +1380,33 @@ export component MainWindow inherits Window {
         }
 
 
-        if root.launcher-visible: Rectangle {
+        if root.launcher-visible && !root.sound-visible: Rectangle {
             width: parent.width;
             height: parent.height;
-            background: #050514f4;
+            background: #050514;
 
-            Rectangle {
-                x: (parent.width - self.width) / 2;
-                y: (parent.height - self.height) / 2;
-                width: root.width < 792px ? root.width - 32px : 760px;
-                height: root.height < 464px ? root.height - 24px : 440px;
-                background: #080a12f8;
-                border-color: #596273;
-                border-width: 1px;
-                border-radius: 10px;
-
-                Text {
-                    x: 24px;
-                    y: 16px;
-                    text: "Space-Wars";
-                    color: #ffffff;
-                    font-size: 28px;
-                    font-weight: 700;
-                }
-
-                Text {
-                    x: 24px;
-                    y: 50px;
-                    width: parent.width - 48px;
-                    text: root.launcher-error-text != "" ? root.launcher-error-text : root.launcher-controls-visible ? "Controls" : root.launcher-settings-visible ? "Settings · left/right adjusts the highlighted value" : "Choose a scenario";
-                    color: root.launcher-error-text != "" ? #ff7184 : #9fb4cc;
-                    font-size: 13px;
-                }
-
-                Text {
-                    x: parent.width - 300px;
-                    y: 22px;
-                    width: 276px;
-                    text: root.p1-input-binding + "   " + root.p2-input-binding;
-                    color: #80d8ff;
-                    font-size: 14px;
-                    horizontal-alignment: right;
-                }
+            MenuPage {
+                available-width: parent.width; available-height: parent.height;
+                // Scenario-specific forms retain their existing geometry in this pass.
+                height: Math.min(parent.height - 24px, root.launcher-controls-visible || root.launcher-settings-visible ? 440px : 520px);
+                heading: root.launcher-settings-visible ? "Scenario Settings" : root.launcher-controls-visible ? "Controls" : "Space-Wars";
+                subtitle: root.launcher-error-text != "" ? root.launcher-error-text : root.launcher-settings-visible && root.launcher-material-match ? "World seed: " + root.launcher-seed-text : root.launcher-controls-visible || root.launcher-settings-visible ? root.launcher-scenario-title : "Choose a scenario";
+                error: root.launcher-error-text != "";
+                hint: root.launcher-controls-visible || root.launcher-settings-visible ? "" : root.launcher-focus-index == 0 ? (self.width < 600px ? "Left / Right browse · A confirm" : "Left / Right browse · A / Enter confirm · Start plays") : self.width < 600px ? "D-pad move · A select · Tap to choose" : "D-pad / arrows move · A / Enter selects · Tap to choose";
 
                 if !root.launcher-controls-visible && !root.launcher-settings-visible: Rectangle {
                     x: 24px;
-                    y: 72px;
+                    y: 82px;
                     width: parent.width - 48px;
                     height: parent.height - 92px;
                     background: #00000000;
 
-                    ChoiceRow {
+                    ScenarioPicker {
                         x: 0px;
                         y: 0px;
                         width: parent.width;
-                        height: 58px;
-                        label: "Scenario";
-                        value: root.launcher-scenario == "nes" ? "NES Library" : root.launcher-scenario;
+                        height: 64px;
+                        title: root.launcher-scenario-title;
                         selected: root.launcher-focus-index == 0;
                         previous => {
                             root.launcher-focus-index = 0;
@@ -1321,41 +1420,42 @@ export component MainWindow inherits Window {
 
                     Rectangle {
                         x: 0px;
-                        y: 68px;
+                        y: 74px;
                         width: parent.width;
-                        height: 74px;
-                        background: #10141f;
-                        border-color: #424a5a;
-                        border-width: 1px;
-                        border-radius: 6px;
+                        height: 76px;
+                        background: #00000000;
 
                         Text {
-                            x: 14px;
-                            y: 9px;
-                            width: parent.width - 28px;
-                            height: 24px;
+                            x: 0px;
+                            y: 0px;
+                            width: parent.width;
+                            height: 40px;
+                            wrap: word-wrap;
                             text: root.launcher-material-arena ? (root.launcher-scenario == "spacewars-terrain-arena-duel" ? "Two mission bots in a generated three-planet arena" : "P1 human · P2 mission · Three generated planets") : root.launcher-material-travel ? (root.launcher-scenario == "spacewars-terrain-travel-duel" ? "Two mission bots on two planets" : "P1 human · P2 interplanetary mission") : root.launcher-scenario == "spacewars-terrain-jetpack" ? "P1 human · P2 jetpack crossing trial" : root.launcher-scenario == "spacewars-terrain-duel" ? "Watch two combat and recovery bots" : root.launcher-scenario == "spacewars-terrain-combat" ? "P1 human · P2 combat and recovery" : root.launcher-scenario == "spacewars-terrain-recovery" ? "P1 human · P2 asteroid strike and recovery" : root.launcher-scenario == "spacewars-terrain-ai" ? "P1 human · P2 swept-wing flight and capture" : root.launcher-scenario == "spacewars-terrain" ? "Land, claim, mine and recover on destructible ground" : root.launcher-material-match ? "Fight, mine, capture and rebuild on three destructible planets" : root.launcher-classic-spacewars ? "Classic orbital combat and berth capture" : root.launcher-scenario == "pizza" ? "Interactive many-body collision sandbox" : root.launcher-scenario == "clock" ? "Low-resolution clock driven by local device time" : root.launcher-scenario == "falling" ? "Rust-native NES homebrew game" : root.launcher-scenario == "nes" ? "User-supplied NES cartridge library" : (root.launcher-scenario == "surface-expedition" || root.launcher-scenario == "spacewars-terrain") ? "Land, disembark and raise your planet's flag" : root.launcher-scenario == "spaceling-lab" ? "Spaceling movement and recovery lab" : root.launcher-scenario == "rover-lab" ? "Rapier rover and wheel mechanics lab" : "Physical landing and surface interaction lab";
                             color: #e6edf7;
-                            font-size: 15px;
+                            font-size: 16px;
                         }
 
                         Text {
-                            x: 14px;
-                            y: 38px;
-                            width: parent.width - 28px;
-                            height: 22px;
+                            x: 0px;
+                            y: 44px;
+                            width: parent.width;
+                            height: 32px;
+                            wrap: word-wrap;
+                            overflow: elide;
                             text: root.launcher-material-travel ? "Choose planet · travel · land · claim · recover · depart" : root.launcher-scenario == "spacewars-terrain-jetpack" ? "Exit · fly over the ship · claim · cross back and board" : root.launcher-scenario == "spacewars-terrain-duel" ? (root.launcher-combat-mission == "Capture" ? "P1: capture and depart · P2: intercept" : "Physical dogfight · pod landing · rebuild and return") : root.launcher-scenario == "spacewars-terrain-combat" ? (root.launcher-combat-mission == "Capture" ? "Intercept P2 as it lands, captures and departs" : "Laser and cannon · destructible ground · recover and rejoin") : root.launcher-scenario == "spacewars-terrain-recovery" ? "Ship loss, pod landing, rebuilding and departure" : root.launcher-scenario == "spacewars-terrain-ai" ? "Fast circuit, brake, land and claim · watch P2 goals" : root.launcher-scenario == "spacewars-terrain" ? "Physical landing · surface flags · mining · ship recovery" : root.launcher-material-match ? ("P1 " + root.launcher-p1-controller + "  ·  P2 " + root.launcher-p2-controller + "  ·  Pilot death ends the round") : root.launcher-classic-spacewars ? (root.launcher-spacewars-preset + "  ·  health " + root.launcher-player-health-text + "%  ·  planets " + root.launcher-use-planets + "  ·  asteroids " + root.launcher-asteroids-enabled + "  ·  P2 " + root.launcher-p2-controller) : root.launcher-scenario == "pizza" ? (root.launcher-pizza-desired-balls-text + " balls  ·  spawn rate " + root.launcher-pizza-spawn-rate-text) : root.launcher-scenario == "clock" ? (root.launcher-clock-time-format + "  ·  local time  ·  " + root.launcher-clock-event-profile + " events") : root.launcher-scenario == "falling" ? "256×224 native video  ·  bounded 48 kHz audio" : root.launcher-scenario == "nes" ? (root.launcher-nes-rom-name + "  ·  " + root.launcher-nes-rom-status) : (root.launcher-scenario == "surface-expedition" || root.launcher-scenario == "spacewars-terrain") ? (root.launcher-expedition-players + " player(s)  ·  shared Surface V1 world  ·  no weapons") : "A semi-interactive mechanics scenario";
                             color: #9fb4cc;
-                            font-size: 13px;
+                            font-size: 14px;
                         }
                     }
 
                     MenuButton {
                         x: 0px;
-                        y: root.launcher-material-match ? 180px : 154px;
-                        width: (parent.width - 12px) / 2;
-                        height: 64px;
-                        text: root.launcher-material-match ? "Play World" : "Start Game";
+                        y: 158px;
+                        width: root.launcher-material-match ? (parent.width - 12px) * 0.60 : parent.width;
+                        height: 56px;
+                        text: "Play";
+                        primary: true;
                         selected: root.launcher-focus-index == 1;
                         activated => {
                             root.launcher-focus-index = 1;
@@ -1364,10 +1464,10 @@ export component MainWindow inherits Window {
                     }
 
                     MenuButton {
-                        x: root.launcher-material-match ? 0px : parent.width / 2 + 6px;
-                        y: root.launcher-material-match ? 254px : 154px;
-                        width: root.launcher-material-match ? (parent.width - 36px) / 4 : (parent.width - 12px) / 2;
-                        height: root.launcher-material-match ? 48px : 64px;
+                        x: 0px;
+                        y: 226px;
+                        width: (parent.width - 24px) / 3;
+                        height: 52px;
                         text: "Scenario Settings";
                         selected: root.launcher-focus-index == 2;
                         activated => {
@@ -1377,10 +1477,10 @@ export component MainWindow inherits Window {
                     }
 
                     MenuButton {
-                        x: root.launcher-material-match ? (parent.width + 12px) / 4 : 0px;
-                        y: root.launcher-material-match ? 254px : 228px;
-                        width: root.launcher-material-match ? (parent.width - 36px) / 4 : (parent.width - 24px) / 3;
-                        height: root.launcher-material-match ? 48px : 56px;
+                        x: (parent.width + 12px) / 3;
+                        y: 226px;
+                        width: (parent.width - 24px) / 3;
+                        height: 52px;
                         text: "Controls";
                         selected: root.launcher-focus-index == 3;
                         activated => {
@@ -1390,10 +1490,10 @@ export component MainWindow inherits Window {
                     }
 
                     MenuButton {
-                        x: root.launcher-material-match ? 2 * (parent.width + 12px) / 4 : (parent.width + 12px) / 3;
-                        y: root.launcher-material-match ? 254px : 228px;
-                        width: root.launcher-material-match ? (parent.width - 36px) / 4 : (parent.width - 24px) / 3;
-                        height: root.launcher-material-match ? 48px : 56px;
+                        x: 2 * (parent.width + 12px) / 3;
+                        y: 226px;
+                        width: (parent.width - 24px) / 3;
+                        height: 52px;
                         text: "App Settings";
                         selected: root.launcher-focus-index == 5;
                         activated => {
@@ -1403,11 +1503,12 @@ export component MainWindow inherits Window {
                     }
 
                     MenuButton {
-                        x: root.launcher-material-match ? 3 * (parent.width + 12px) / 4 : 2 * (parent.width + 12px) / 3;
-                        y: root.launcher-material-match ? 254px : 228px;
-                        width: root.launcher-material-match ? (parent.width - 36px) / 4 : (parent.width - 24px) / 3;
-                        height: root.launcher-material-match ? 48px : 56px;
+                        x: 0px;
+                        y: parent.height - 66px;
+                        width: 100px;
+                        height: 48px;
                         text: "Quit";
+                        quiet: true;
                         selected: root.launcher-focus-index == 4;
                         activated => {
                             root.launcher-focus-index = 4;
@@ -1415,23 +1516,13 @@ export component MainWindow inherits Window {
                         }
                     }
 
-                    Text {
-                        visible: root.launcher-material-match;
-                        x: 0px;
-                        y: 151px;
-                        width: parent.width;
-                        text: "World seed: " + root.launcher-seed-text;
-                        color: #9fb4cc;
-                        font-size: 14px;
-                    }
-
                     MenuButton {
                         visible: root.launcher-material-match;
-                        x: parent.width / 2 + 6px;
-                        y: 180px;
-                        width: (parent.width - 12px) / 2;
-                        height: 64px;
-                        text: "New Match · New World";
+                        x: (parent.width - 12px) * 0.60 + 12px;
+                        y: 158px;
+                        width: (parent.width - 12px) * 0.40;
+                        height: 56px;
+                        text: "Play New World";
                         selected: root.launcher-focus-index == 6;
                         activated => {
                             root.launcher-focus-index = 6;
@@ -1439,25 +1530,6 @@ export component MainWindow inherits Window {
                         }
                     }
 
-                    Text {
-                        x: 0px;
-                        y: root.launcher-material-match ? 312px : 296px;
-                        width: parent.width;
-                        text: "Tap buttons directly  ·  D-pad / left stick chooses  ·  A selects";
-                        color: #80d8ff;
-                        font-size: 14px;
-                        horizontal-alignment: center;
-                    }
-
-                    Text {
-                        x: 0px;
-                        y: root.launcher-material-match ? 334px : 322px;
-                        width: parent.width;
-                        text: root.scenario-benchmark-available ? "Keyboard: arrows + Enter  ·  B starts benchmark  ·  F1 opens controls" : "Keyboard: arrows + Enter  ·  F1 opens controls";
-                        color: #7d8494;
-                        font-size: 11px;
-                        horizontal-alignment: center;
-                    }
                 }
 
                 if root.launcher-settings-visible: Rectangle {
@@ -2245,68 +2317,89 @@ export component MainWindow inherits Window {
     if root.sound-visible && !root.device-info-visible && (root.launcher-visible || root.ingame-menu-visible): Rectangle {
         width: parent.width;
         height: parent.height;
-        background: #050514e8;
+        background: #050514;
         TouchArea { width: parent.width; height: parent.height; }
 
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: Math.min(parent.width - 32px, 520px);
-            height: Math.min(parent.height - 24px, 490px);
-            background: #101827;
-            border-color: #596273;
-            border-width: 1px;
-            border-radius: 8px;
+        MenuPage {
+            available-width: parent.width; available-height: parent.height;
+            heading: "App Settings";
+            subtitle: "Preferences for every scenario";
+            hint: self.width < 600px ? "← / → adjust · A select · B / Esc back" : "Left / Right adjust · A / Enter selects · B / Esc back";
+            property <length> row-height: self.height >= 500px ? 64px : 52px;
 
+            settings-scroll := Flickable {
+                x: 24px; y: 82px; width: parent.width - 48px; height: parent.height - 214px;
+                viewport-width: self.width;
+                viewport-height: settings-body.height;
+                property <int> focused-item: root.sound-focus-index;
+                property <length> row-height: parent.row-height;
+                property <length> scroll-limit: Math.max(0px, self.viewport-height - self.height);
+                function reveal-focus() {
+                    if self.focused-item >= 0 && self.focused-item < 4 {
+                        let top = self.focused-item * (self.row-height + 10px);
+                        let bottom = top + self.row-height;
+                        if -self.viewport-y > top { self.viewport-y = -top; }
+                        if -self.viewport-y + self.height < bottom { self.viewport-y = self.height - bottom; }
+                    }
+                    self.viewport-y = Math.max(-self.scroll-limit, Math.min(0px, self.viewport-y));
+                }
+                changed focused-item => { self.reveal-focus(); }
+                changed scroll-limit => { self.reveal-focus(); }
+                init => { self.reveal-focus(); }
+                settings-body := Rectangle {
+                    x: 0px; y: 0px;
+                    width: settings-scroll.width; height: 4 * settings-scroll.row-height + 30px;
+                    VolumeRow {
+                        x: 0px; y: 0px;
+                        width: parent.width; height: settings-scroll.row-height;
+                        percent: root.sound-volume-percent; selected: root.sound-focus-index == 0;
+                        previous => { root.sound-adjust(0, -1); }
+                        next => { root.sound-adjust(0, 1); }
+                    }
+                    SettingsRow {
+                        y: settings-scroll.row-height + 10px;
+                        width: parent.width; height: settings-scroll.row-height;
+                        label: "Mute"; checked: root.sound-muted; selected: root.sound-focus-index == 1;
+                        activated => { root.sound-adjust(1, 0); }
+                    }
+                    SettingsRow {
+                        y: 2 * (settings-scroll.row-height + 10px);
+                        width: parent.width; height: settings-scroll.row-height;
+                        label: "FPS Counter"; checked: root.performance-overlay-enabled; selected: root.sound-focus-index == 2;
+                        activated => { root.sound-adjust(2, 0); }
+                    }
+                    SettingsRow {
+                        y: 3 * (settings-scroll.row-height + 10px);
+                        width: parent.width; height: settings-scroll.row-height;
+                        label: "Device Info"; navigation: true; selected: root.sound-focus-index == 3;
+                        activated => { root.device-info-open(); }
+                    }
+                }
+            }
+            // Scroll position is visible when the list overflows. Future settings
+            // can extend the body without moving Back or durable-save feedback.
+            if settings-scroll.scroll-limit > 0px: Rectangle {
+                x: parent.width - 18px; y: 82px; width: 3px; height: settings-scroll.height;
+                background: #283a50;
+                Rectangle {
+                    width: parent.width;
+                    height: Math.max(12px, parent.height * settings-scroll.height / settings-scroll.viewport-height);
+                    y: (parent.height - self.height) * Math.min(1, Math.max(0, -settings-scroll.viewport-y / settings-scroll.scroll-limit));
+                    background: #80d8ff;
+                }
+            }
             Text {
-                x: 24px; y: 18px;
-                text: "App Settings";
-                color: #ffffff;
-                font-size: 26px;
-                font-weight: 700;
-            }
-            ChoiceRow {
-                x: 24px; y: 60px;
-                width: parent.width - 48px; height: 52px;
-                label: "Master volume";
-                value: root.sound-volume-percent + "%";
-                selected: root.sound-focus-index == 0;
-                previous => { root.sound-adjust(0, -1); }
-                next => { root.sound-adjust(0, 1); }
-            }
-            MenuButton {
-                x: 24px; y: 124px;
-                width: parent.width - 48px; height: 50px;
-                text: root.sound-muted ? "Mute: On" : "Mute: Off";
-                selected: root.sound-focus-index == 1;
-                activated => { root.sound-adjust(1, 0); }
-            }
-            MenuButton {
-                x: 24px; y: 184px;
-                width: parent.width - 48px; height: 50px;
-                text: "FPS Counter: " + (root.performance-overlay-enabled ? "On" : "Off");
-                selected: root.sound-focus-index == 2;
-                activated => { root.sound-adjust(2, 0); }
-            }
-            Text {
-                x: 24px; y: 306px;
-                width: parent.width - 48px; height: 46px;
-                text: root.settings-save-pending ? "Saving settings…" : root.settings-save-error != "" ? "Applied for this session. Could not save settings; retry below." : "Saved · Applies to all scenarios";
-                color: root.settings-save-error != "" ? #ffb0a0 : #80d8ff;
+                x: 24px; y: parent.height - 124px;
+                width: parent.width - 48px; height: 32px;
+                text: root.settings-save-pending ? "Saving settings…" : root.settings-save-error != "" ? "Changes apply now, but could not be saved. Retry below." : "Saved automatically";
+                color: root.settings-save-error != "" ? #ffb0a0 : #9fb4cc;
                 font-size: 14px;
                 wrap: word-wrap;
                 vertical-alignment: center;
                 horizontal-alignment: center;
             }
             MenuButton {
-                x: 24px; y: 244px;
-                width: parent.width - 48px; height: 50px;
-                text: "Device Info  ›";
-                selected: root.sound-focus-index == 3;
-                activated => { root.device-info-open(); }
-            }
-            MenuButton {
-                x: 24px; y: parent.height - 90px;
+                x: 24px; y: parent.height - 84px;
                 width: root.settings-save-error == "" ? parent.width - 48px : (parent.width - 60px) / 2;
                 height: 48px;
                 text: "Back";
@@ -2314,19 +2407,11 @@ export component MainWindow inherits Window {
                 activated => { root.sound-visible = false; }
             }
             if root.settings-save-error != "": MenuButton {
-                x: parent.width / 2 + 6px; y: parent.height - 90px;
+                x: parent.width / 2 + 6px; y: parent.height - 84px;
                 width: (parent.width - 60px) / 2; height: 48px;
                 text: "Retry Save";
                 selected: root.sound-focus-index == 5;
                 activated => { root.sound-retry(); }
-            }
-            Text {
-                x: 24px; y: parent.height - 28px;
-                width: parent.width - 48px;
-                text: "Left / Right adjust  ·  A selects  ·  B / Esc back";
-                color: #80d8ff;
-                font-size: 13px;
-                horizontal-alignment: center;
             }
         }
     }
@@ -2334,24 +2419,13 @@ export component MainWindow inherits Window {
     if root.device-info-visible && root.sound-visible && (root.launcher-visible || root.ingame-menu-visible): Rectangle {
         init => { root.device-info-scroll-limit = info-scroll.scroll-limit; }
         width: parent.width; height: parent.height;
-        background: #050514e8;
+        background: #050514;
         TouchArea { width: parent.width; height: parent.height; }
-        Rectangle {
-            x: (parent.width - self.width) / 2;
-            y: (parent.height - self.height) / 2;
-            width: Math.min(parent.width - 24px, 760px);
-            height: Math.min(parent.height - 24px, 680px);
-            background: #101827;
-            border-color: #596273; border-width: 1px; border-radius: 8px;
-            Text {
-                x: 24px; y: 16px; text: "Device Info";
-                color: #ffffff; font-size: 26px; font-weight: 700;
-            }
-            Text {
-                x: 24px; y: 52px; width: parent.width - 48px;
-                text: root.device-info-ready ? "Read only · Refreshes every 2 seconds while open" : "Reading device information…";
-                color: #80d8ff; font-size: 14px; overflow: elide;
-            }
+        MenuPage {
+            available-width: parent.width; available-height: parent.height;
+            heading: "Device Info";
+            subtitle: root.device-info-ready ? "Read only · Refreshes every 2 seconds" : "Reading device information…";
+            hint: "D-pad scrolls · A / B / Esc back";
             info-scroll := Flickable {
                 x: 24px; y: 82px;
                 width: parent.width - 48px; height: parent.height - 180px;
@@ -2398,11 +2472,6 @@ export component MainWindow inherits Window {
                 x: parent.width - 102px; y: parent.height - 82px;
                 width: 78px; height: 48px; text: "Down";
                 activated => { root.device-info-scroll(1); }
-            }
-            Text {
-                x: 24px; y: parent.height - 24px; width: parent.width - 48px;
-                text: "D-pad scrolls · A / B / Esc back";
-                color: #80d8ff; font-size: 13px; horizontal-alignment: center;
             }
         }
     }

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -162,6 +162,8 @@ enum UiScreenArg {
     LauncherMain,
     #[value(name = "launcher.sound")]
     LauncherSound,
+    #[value(name = "launcher.info")]
+    LauncherInfo,
     #[value(name = "launcher.settings")]
     LauncherSettings,
     #[value(name = "launcher.controls")]
@@ -174,6 +176,8 @@ enum UiScreenArg {
     PauseMain,
     #[value(name = "pause.sound")]
     PauseSound,
+    #[value(name = "pause.info")]
+    PauseInfo,
     #[value(name = "pause.controls")]
     PauseControls,
     #[value(name = "pause.clock")]
@@ -188,12 +192,14 @@ impl From<UiScreenArg> for UiScreen {
             UiScreenArg::LauncherBusy => Self::LauncherBusy,
             UiScreenArg::LauncherMain => Self::LauncherMain,
             UiScreenArg::LauncherSound => Self::LauncherSound,
+            UiScreenArg::LauncherInfo => Self::LauncherInfo,
             UiScreenArg::LauncherSettings => Self::LauncherSettings,
             UiScreenArg::LauncherControls => Self::LauncherControls,
             UiScreenArg::LauncherTouchTest => Self::LauncherTouchTest,
             UiScreenArg::Gameplay => Self::Gameplay,
             UiScreenArg::PauseMain => Self::PauseMain,
             UiScreenArg::PauseSound => Self::PauseSound,
+            UiScreenArg::PauseInfo => Self::PauseInfo,
             UiScreenArg::PauseControls => Self::PauseControls,
             UiScreenArg::PauseClock => Self::PauseClock,
             UiScreenArg::GameOver => Self::GameOver,

--- a/crates/spacewars-control/src/lib.rs
+++ b/crates/spacewars-control/src/lib.rs
@@ -29,6 +29,8 @@ pub enum UiScreen {
     LauncherMain,
     #[serde(rename = "launcher.sound")]
     LauncherSound,
+    #[serde(rename = "launcher.info")]
+    LauncherInfo,
     #[serde(rename = "launcher.settings")]
     LauncherSettings,
     #[serde(rename = "launcher.controls")]
@@ -41,6 +43,8 @@ pub enum UiScreen {
     PauseMain,
     #[serde(rename = "pause.sound")]
     PauseSound,
+    #[serde(rename = "pause.info")]
+    PauseInfo,
     #[serde(rename = "pause.controls")]
     PauseControls,
     #[serde(rename = "pause.clock")]
@@ -55,12 +59,14 @@ impl UiScreen {
             Self::LauncherBusy => "launcher.busy",
             Self::LauncherMain => "launcher.main",
             Self::LauncherSound => "launcher.sound",
+            Self::LauncherInfo => "launcher.info",
             Self::LauncherSettings => "launcher.settings",
             Self::LauncherControls => "launcher.controls",
             Self::LauncherTouchTest => "launcher.touch-test",
             Self::Gameplay => "gameplay",
             Self::PauseMain => "pause.main",
             Self::PauseSound => "pause.sound",
+            Self::PauseInfo => "pause.info",
             Self::PauseControls => "pause.controls",
             Self::PauseClock => "pause.clock",
             Self::GameOver => "game-over",
@@ -73,6 +79,7 @@ impl UiScreen {
             Self::LauncherBusy
                 | Self::LauncherMain
                 | Self::LauncherSound
+                | Self::LauncherInfo
                 | Self::LauncherSettings
                 | Self::LauncherControls
                 | Self::LauncherTouchTest
@@ -555,12 +562,14 @@ mod tests {
             (UiScreen::LauncherBusy, "launcher.busy"),
             (UiScreen::LauncherMain, "launcher.main"),
             (UiScreen::LauncherSound, "launcher.sound"),
+            (UiScreen::LauncherInfo, "launcher.info"),
             (UiScreen::LauncherSettings, "launcher.settings"),
             (UiScreen::LauncherControls, "launcher.controls"),
             (UiScreen::LauncherTouchTest, "launcher.touch-test"),
             (UiScreen::Gameplay, "gameplay"),
             (UiScreen::PauseMain, "pause.main"),
             (UiScreen::PauseSound, "pause.sound"),
+            (UiScreen::PauseInfo, "pause.info"),
             (UiScreen::PauseControls, "pause.controls"),
             (UiScreen::PauseClock, "pause.clock"),
             (UiScreen::GameOver, "game-over"),

--- a/docs/device-info.md
+++ b/docs/device-info.md
@@ -1,0 +1,89 @@
+# Device Info and app navigation
+
+Both **Launcher → App Settings → Device Info** and
+**Pause → App Settings → Device Info** open the same read-only screen.
+
+- D-pad/arrow keys scroll. Touch-drag, mouse wheel, and visible Up/Down buttons
+  work too. Back stays on screen even when the content is scrolled.
+- A/Enter activates Back. B/Esc returns exactly one level to App Settings and
+  restores the Device Info selection. Back again returns to the original menu.
+- A paused scenario remains paused. Start is the explicit quick-resume shortcut
+  from paused menus; Start in launcher Info only returns to App Settings.
+- Opening Info does not save settings, restart a scenario, scan Wi-Fi, contact
+  the internet, or read network credentials.
+
+## Information and cost
+
+The Linux screen reports hostname, the compiled app version/revision and
+debug/release profile, OS/architecture, hardware model, active interface
+addresses, CPU model/core count, aggregate CPU busy percentage, available/total
+RAM, thermal-zone-0 temperature, available/total persistent storage, configuration
+directory, connected gamepads with their current player assignments, and scenario
+state. Controllers without a free player seat are labelled Unassigned. This
+does not change assignment policy; keyboard bindings remain available.
+
+CPU busy is a delta across **all cores**, normalized to 0–100%, not the app's
+per-core process percentage. The first sample says Sampling. Memory uses
+`MemAvailable`, including reclaimable memory, rather than just `MemFree`.
+Disk availability excludes blocks reserved from ordinary users. Pi installations
+report `/data/spacewars`; desktops report the config directory's filesystem.
+Missing metrics say Unavailable. Non-Linux builds retain app/controller information
+but explicitly lack the Linux system metrics.
+
+Addresses are from active local interfaces, including IPv6 and virtual adapters.
+Having an address is **not** proof of internet connectivity. No SSID/password
+or saved Wi-Fi connection profiles are read. Gameplay is paused in this menu,
+so frame/update rates are labelled paused; use **FPS Counter** during gameplay
+or `spacewars-cli status` for live rates.
+
+A single worker samples every two seconds while Info is visible. The UI never
+waits on filesystem/network-interface queries. Closing the screen stops its UI
+timer and subsequent requests; at most one already-running read may finish.
+Reopening rejects old responses and starts a fresh CPU baseline. The worker
+sleeps on a channel when not requested. Hidden Info has no instantiated item tree.
+
+The build revision comes from the **build-time** Git checkout (with `-dirty`
+when tracked files differ), not an installed machine's checkout. Archive builds
+can set `SPACEWARS_BUILD_REVISION`; otherwise the revision is explicitly unknown.
+
+## Automation
+
+No separate diagnostics transport or privileged service is required. The
+screen uses the existing structured control API:
+
+```sh
+spacewars-cli ui activate launcher.sound
+spacewars-cli ui activate settings.device-info
+spacewars-cli ui state --json
+spacewars-cli ui press down --expect-screen launcher.info
+spacewars-cli ui activate info.back
+spacewars-cli ui activate sound.back
+```
+
+Use `pause.sound` from the pause menu. Screen IDs are `launcher.info` and
+`pause.info`. `info.status` is `loading` until the first sample is ready, then
+`ready`. Read-only `info.*` controls contain the same values as the display;
+`info.scroll-up`, `info.scroll-down`, and `info.back` are the only activatable
+Info controls. `info.scroll-offset` is zero at the top and negative when scrolled.
+Metrics update UI revisions, so navigation can guard the **screen** without
+guarding a transient sample revision. Existing strict revision guards continue
+to reject stale data as usual.
+
+## Menu boundaries for future work
+
+The launcher chooses/configures scenarios. Pause handles the active session.
+**App Settings** is the shared home for application/device-wide concerns:
+current audio/FPS preferences and Device Info, with **Network** and **Controllers**
+as future sibling screens. Scenario-specific controls do not go here.
+
+Wi-Fi setup belongs in Network, not inside read-only Info. Its implementation
+will need network selection, credential entry usable without a physical keyboard,
+clear connecting/success/failure feedback, and a way back if the new connection
+fails. Network mutations and credential storage need an explicit privileged
+boundary on kiosks; this Info implementation does not grant one. Do not add
+non-working Network buttons until that workflow exists.
+
+Tests cover resource parsers, sampling throttling/stale visits, parent navigation,
+paused-scenario preservation, scrolling, and partial versus full UI repaints at
+landscape and portrait sizes. The real-process workflow is `device_info` in
+the [functional suite](functional-tests.md).

--- a/docs/device-info.md
+++ b/docs/device-info.md
@@ -3,6 +3,9 @@
 Both **Launcher → App Settings → Device Info** and
 **Pause → App Settings → Device Info** open the same read-only screen.
 
+These screens share the responsive [menu page layout](menu-layout.md), with
+an opaque background and a fixed navigation footer on both kiosk displays.
+
 - D-pad/arrow keys scroll. Touch-drag, mouse wheel, and visible Up/Down buttons
   work too. Back stays on screen even when the content is scrolled.
 - A/Enter activates Back. B/Esc returns exactly one level to App Settings and

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -56,6 +56,13 @@ tests use explicit channel gates, not storage-speed expectations, to verify
 ordered, coalesced saves and that an old completion cannot acknowledge a newer
 pending snapshot.
 
+The Device Info workflow opens the same read-only panel from launcher and pause,
+waits for a completed sample, scrolls through the public API, and verifies that
+Back restores the parent selection without resuming or replacing the scenario.
+Start explicitly resumes. Navigation guards the screen rather than a transient
+telemetry revision; CPU/network sampling must not introduce timing-sensitive
+test failures. Render tests include the Info panel at 800×480 and 480×800.
+
 Short negative Clock waits check that a paused event does not advance; they
 are not response-latency requirements. A timeout may have no snapshot if no
 reply arrived before its deadline. The UI workflows compare any returned

--- a/docs/menu-layout.md
+++ b/docs/menu-layout.md
@@ -1,0 +1,54 @@
+# Launcher and app menu layout
+
+The launcher, App Settings, and Device Info use the same `MenuPage` frame in
+`crates/engine-client/ui/main.slint`. The compact target is the HyperPixel's
+800×480 landscape display; 1024×768 Picade and 480×800 portrait layouts are
+also covered by render tests. The page is centered and capped at 760×520,
+with 48 px or larger action buttons. Larger windows add margins and roomier
+settings rows rather than scaling down text on smaller displays.
+
+## Navigation and scope
+
+- Launcher: scenario picker, Play / optional Play New World, Scenario Settings /
+  Controls / App Settings, then the separate Quit footer. Arrow/D-pad navigation
+  follows these rows. Quit remains explicit; Back never quits the root menu.
+- On the scenario picker, Left/Right browses and A/Enter confirms the displayed
+  scenario by moving focus to Play. A second confirmation launches it; Start
+  launches directly. Touch arrows continue to browse. The picker-focused hint
+  explains this distinction, and confirmation does not change the scenario or seed.
+- **Play** starts a fresh run using the current setup and seed; it is not Resume.
+  **Play New World** starts a new Space-Wars match with a new seed. The current
+  world seed is shown in Scenario Settings rather than on the main launcher.
+- Friendly scenario names are presentation only. Registry IDs, saved settings,
+  CLI arguments, and control IDs remain unchanged. Existing control indices are
+  retained, with their directional neighbors in `ui_navigation.rs` updated to
+  match the layout.
+- App Settings and Device Info are opaque pages, shared by launcher and pause.
+  Back returns one level without resuming a paused game. Existing Start/resume
+  behavior is unchanged. Scenario-specific settings and controls retain their
+  existing content/layout in this pass.
+
+## Settings content and future additions
+
+App Settings uses label/value rows: volume adjustment with a level indicator,
+On/Off toggles, and chevrons for subpages. Its body scrolls by touch or mouse
+wheel; controller/keyboard selection reveals the focused row when needed.
+Back, save status, and Retry Save stay outside the scroll area. A save failure
+does not prevent adjustment, navigation, or retrying the same settings.
+
+Future Network and Controllers pages belong beside Device Info, not in the
+scenario picker. When adding a row, update its focus mapping, body extent,
+reveal range, and stable control inventory together. Do not add non-working
+placeholder entries. Network permissions and credential entry remain separate
+work; see [Device Info and app navigation](device-info.md).
+
+## Verification
+
+`ui_render_tests` exercises partial and full repaints through menu changes at
+all three display sizes, including long names, Space-Wars, and save errors.
+Set `SPACEWARS_MENU_TEST_ARTIFACTS` to export PNGs for visual inspection.
+Keyboard/touch tests also force App Settings into a shorter window to verify
+focus reveal and the fixed Back action. The real-process functional suite
+checks launcher navigation, settings persistence/retry, and Info return paths.
+Device screenshots complement these checks; a rendered screenshot alone does
+not verify the physical touchscreen or controller wiring.


### PR DESCRIPTION
## Summary

Add a read-only Device Info screen and refine launcher/App Settings navigation for the Picade and HyperPixel displays.

### Device Info

- Available through App Settings from both the launcher and pause menu.
- Reports hostname, build revision/profile, hardware/OS, interface addresses, CPU/RAM/temperature/storage, connected controller assignments, and scenario state.
- Samples off the UI thread every two seconds while visible, with bounded requests and stale-response protection. Missing metrics are explicitly unavailable.
- Supports controller, keyboard, touch scrolling, and the existing structured control API. Back returns one level without resuming a paused game.

### Menu UX

- Share a centered, responsive menu frame across Launcher, App Settings, and Device Info, with opaque backgrounds and readable compact layouts.
- Use friendly scenario names, a prominent Play action, separate Play New World action, and a quieter Quit footer. Saved scenario IDs and existing control IDs remain stable.
- Fix scenario confirmation: Left/Right browses; A/Enter confirms the displayed scenario and focuses Play; a second press launches. Start remains the direct-launch shortcut, and touch arrows still browse.
- Give App Settings clearer volume/toggle rows and a scrolling body that reveals controller focus, while Back and save/retry feedback remain fixed.
- Document layout/navigation rules and where future Network and Controllers pages belong.

## Validation

- 287 client tests passed (one existing ignored test), including scenario confirmation, keyboard/touch input, navigation, and partial/full repaint comparisons at 800×480, 1024×768, and 480×800.
- All 37 real-process UI functional workflows passed during the menu rework; the launcher workflow was rerun successfully after the final confirmation change.
- Formatting and diff checks passed; the final ARM Yocto release build succeeded.
- Fast-deployed to both `sw-picade.local` (Pi 4 Picade) and `spacewars.local` (Pi 5 HyperPixel); inspected device screenshots and verified confirmation through the control API.
- User manually tested the final behavior on both devices and confirmed it works well.

## Scope

Device Info does not scan/configure Wi-Fi, read network credentials, or change controller assignments. Those remain future sibling settings pages. No gameplay or physics changes.
