### PR TITLE
Add sticky launcher auto-start and timed Spacewars matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ It is read-only and samples in the background only while open. See
 [Device Info and menu navigation](docs/device-info.md), including the boundary
 for future Wi-Fi setup and controller assignment screens.
 
+**App Settings → Auto-start** can run Clock or repeated two-bot Spacewars
+matches whenever the launcher is idle. Choose a delay; the preference stays
+enabled across restarts until switched Off. Any deliberate input during an
+automatic activity returns to the launcher. **Spacewars → Settings → Match
+length** controls the match's own timer: most planets wins at expiry, with
+equal ownership drawing. See [automatic activities](docs/auto-start.md).
+
 The FPS counter is off by default and saved as `video.show_fps`. When enabled,
 a small translucent, non-interactive overlay shows **FPS** (new scenario frames
 submitted to Slint) and **UPS** (simulation updates, or emulated NES frames).

--- a/crates/engine-client/src/autostart.rs
+++ b/crates/engine-client/src/autostart.rs
@@ -1,0 +1,509 @@
+//! Idle activity policy. Scenario clocks and match outcomes remain in the host.
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::rc::Rc;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use engine_common::{AutostartSettings, Settings};
+use slint::{ComponentHandle, Timer, TimerMode};
+use spacewars_control::{UiAction, UiControl};
+
+use crate::{MainWindow, UserActivity, launcher::Launcher, settings_writer::SettingsWriter};
+
+pub(crate) struct Activity {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub scenario: &'static str,
+    pub repeat_matches: bool,
+}
+
+const ACTIVITIES: [Activity; 2] = [
+    Activity {
+        id: "clock",
+        label: "Clock",
+        scenario: "clock",
+        repeat_matches: false,
+    },
+    Activity {
+        id: "spacewars-bots",
+        label: "Spacewars bots",
+        scenario: "spacewars",
+        repeat_matches: true,
+    },
+];
+const RESULT_DELAY: Duration = Duration::from_secs(8);
+
+fn activity(id: &str) -> Option<&'static Activity> {
+    ACTIVITIES.iter().find(|activity| activity.id == id)
+}
+
+#[derive(Default)]
+struct IdleCountdown {
+    deadline: Option<Instant>,
+}
+
+impl IdleCountdown {
+    fn reset(&mut self) {
+        self.deadline = None;
+    }
+
+    fn remaining(&mut self, now: Instant, eligible: bool, delay: Duration) -> Option<Duration> {
+        if !eligible {
+            self.reset();
+            return None;
+        }
+        let deadline = *self.deadline.get_or_insert(now + delay);
+        Some(deadline.saturating_duration_since(now))
+    }
+}
+
+struct Runtime {
+    idle: IdleCountdown,
+    preferences: AutostartSettings,
+    failed: bool,
+    manual_launch: Option<crate::EffectiveLaunch>,
+    result_remaining: Duration,
+    last_tick: Instant,
+    repeat_pending: Option<String>,
+    repeats: u64,
+    keys: BTreeSet<String>,
+    consumed_keys: BTreeSet<String>,
+}
+
+pub(crate) fn install(
+    window: &MainWindow,
+    launcher: Rc<Launcher>,
+    settings: Arc<RwLock<Settings>>,
+    writer: SettingsWriter,
+    catalog: crate::SharedNesRomCatalog,
+    enabled_for_process: bool,
+) -> Timer {
+    let preferences = settings.read().unwrap().autostart.normalized();
+    publish_preferences(window, &preferences);
+    let runtime = Rc::new(RefCell::new(Runtime {
+        idle: IdleCountdown::default(),
+        preferences,
+        failed: false,
+        manual_launch: None,
+        result_remaining: RESULT_DELAY,
+        last_tick: Instant::now(),
+        repeat_pending: None,
+        repeats: 0,
+        keys: BTreeSet::new(),
+        consumed_keys: BTreeSet::new(),
+    }));
+
+    let weak = window.as_weak();
+    let state = Rc::clone(&runtime);
+    window.global::<UserActivity>().on_notify(move || {
+        let Some(window) = weak.upgrade() else {
+            return false;
+        };
+        state.borrow_mut().idle.reset();
+        if window.get_autostart_running() && !window.get_ingame_menu_visible() {
+            window.invoke_autostart_return();
+            return true;
+        }
+        false
+    });
+
+    let weak = window.as_weak();
+    let state = Rc::clone(&runtime);
+    window
+        .global::<UserActivity>()
+        .on_key_event(move |key, down| {
+            let Some(window) = weak.upgrade() else {
+                return false;
+            };
+            let key = key.to_string();
+            let consumed = {
+                let mut state = state.borrow_mut();
+                state.idle.reset();
+                if down {
+                    state.keys.insert(key.clone());
+                } else {
+                    state.keys.remove(&key);
+                }
+                let consumed = state.consumed_keys.contains(&key);
+                if !down {
+                    state.consumed_keys.remove(&key);
+                }
+                consumed
+            };
+            if down && window.get_autostart_running() && !window.get_ingame_menu_visible() {
+                state.borrow_mut().consumed_keys.insert(key);
+                window.invoke_autostart_return();
+                true
+            } else {
+                consumed
+            }
+        });
+
+    let weak = window.as_weak();
+    let state = Rc::clone(&runtime);
+    window.global::<UserActivity>().on_focus_lost(move || {
+        let mut state = state.borrow_mut();
+        state.keys.clear();
+        state.consumed_keys.clear();
+        state.idle.reset();
+        if let Some(window) = weak.upgrade() {
+            window.global::<UserActivity>().set_pointer_held(false);
+        }
+    });
+
+    let weak = window.as_weak();
+    let state = Rc::clone(&runtime);
+    let return_launcher = Rc::clone(&launcher);
+    let return_settings = Arc::clone(&settings);
+    window.on_autostart_return(move || {
+        let Some(window) = weak.upgrade() else { return };
+        return_launcher.cancel_automatic();
+        window.set_autostart_running(false);
+        window.set_autostart_activity("".into());
+        window.set_autostart_caption("".into());
+        let manual = {
+            let mut state = state.borrow_mut();
+            state.idle.reset();
+            state.repeat_pending = None;
+            state.result_remaining = RESULT_DELAY;
+            state.manual_launch.take()
+        };
+        window.invoke_ingame_return_launcher();
+        if let Some(launch) = manual {
+            crate::show_launcher(&window, &launch, &return_settings.read().unwrap(), &catalog);
+        }
+    });
+
+    let weak = window.as_weak();
+    window.on_autostart_open(move || {
+        let Some(window) = weak.upgrade() else { return };
+        if window.get_sound_visible() && !window.get_launcher_busy() {
+            window.set_sound_focus_index(4);
+            window.set_autostart_focus_index(0);
+            window.set_autostart_settings_visible(true);
+        }
+    });
+
+    let weak = window.as_weak();
+    let adjust_settings = Arc::clone(&settings);
+    let state = Rc::clone(&runtime);
+    window.on_autostart_adjust(move |index, delta| {
+        let Some(window) = weak.upgrade() else { return };
+        if !window.get_autostart_settings_visible() {
+            return;
+        }
+        window.set_autostart_focus_index(index);
+        let snapshot = {
+            let mut settings = adjust_settings.write().unwrap();
+            let p = &mut settings.autostart;
+            if index == 0 {
+                let current = if !p.enabled {
+                    0
+                } else {
+                    ACTIVITIES
+                        .iter()
+                        .position(|a| a.id == p.activity)
+                        .map_or(0, |i| i + 1)
+                };
+                let next = (current as i32 + delta.signum()).rem_euclid(3) as usize;
+                p.enabled = next != 0;
+                if next != 0 {
+                    p.activity = ACTIVITIES[next - 1].id.into();
+                }
+            } else if index == 1 {
+                let stops = [5, 10, 30, 60, 120, 300, 600];
+                p.delay_seconds = if delta > 0 {
+                    stops
+                        .into_iter()
+                        .find(|&n| n > p.delay_seconds)
+                        .unwrap_or(5)
+                } else {
+                    stops
+                        .into_iter()
+                        .rev()
+                        .find(|&n| n < p.delay_seconds)
+                        .unwrap_or(600)
+                };
+            } else {
+                return;
+            }
+            settings.clone()
+        };
+        state.borrow_mut().failed = false;
+        state.borrow_mut().idle.reset();
+        publish_preferences(&window, &snapshot.autostart);
+        writer.save(snapshot);
+        window.set_settings_save_pending(true);
+        window.set_settings_save_error("".into());
+    });
+
+    let weak = window.as_weak();
+    let state = Rc::clone(&runtime);
+    let start_settings = Arc::clone(&settings);
+    let start_launcher = Rc::clone(&launcher);
+    window.on_autostart_start_now(move || {
+        let Some(window) = weak.upgrade() else { return };
+        let p = start_settings.read().unwrap().autostart.normalized();
+        if !window.get_launcher_visible()
+            || window.get_launcher_busy()
+            || window.get_settings_save_pending()
+            || !window.get_settings_save_error().is_empty()
+        {
+            return;
+        }
+        if let Some(activity) = activity(&p.activity).filter(|_| p.enabled) {
+            state.borrow_mut().failed = false;
+            begin(&window, &start_launcher, &state, activity);
+        }
+    });
+
+    let timer = Timer::default();
+    let weak = window.as_weak();
+    timer.start(TimerMode::Repeated, Duration::from_millis(100), move || {
+        let Some(window) = weak.upgrade() else { return };
+        let now = Instant::now();
+        let p = settings.read().unwrap().autostart.normalized();
+        let (elapsed, held) = {
+            let mut state = runtime.borrow_mut();
+            let elapsed = now.saturating_duration_since(state.last_tick);
+            state.last_tick = now;
+            if state.preferences != p {
+                state.preferences = p.clone();
+                state.failed = false;
+                state.idle.reset();
+            }
+            (elapsed, !state.keys.is_empty())
+        };
+        let mut phase = "inactive";
+        let mut caption = String::new();
+        if window.get_autostart_running() {
+            runtime.borrow_mut().idle.reset();
+            if !window.get_launcher_error_text().is_empty() || !window.get_scenario_error_text().is_empty() {
+                runtime.borrow_mut().failed = true;
+                phase = "failed";
+                caption = "Automatic activity stopped. Press a button to return to the menu.".into();
+            } else if window.get_launcher_busy() {
+                phase = "launching";
+            } else if window.get_ingame_menu_visible() {
+                phase = "paused";
+            } else if window.get_game_over_visible() && activity(window.get_autostart_activity().as_str()).is_some_and(|a| a.repeat_matches) {
+                phase = "result";
+                let mut state = runtime.borrow_mut();
+                state.result_remaining = state.result_remaining.saturating_sub(elapsed);
+                caption = if p.enabled {
+                    format!("Next world in {} seconds · Press a button for the menu", state.result_remaining.as_secs_f64().ceil() as u64)
+                } else {
+                    "Auto-start is Off · Press a button for the menu".into()
+                };
+                if state.result_remaining.is_zero() && state.repeat_pending.is_none() && p.enabled && !state.failed {
+                    state.repeat_pending = Some(window.get_scenario_instance().to_string());
+                    drop(state);
+                    window.invoke_ingame_new_match();
+                }
+            } else {
+                phase = "running";
+                let mut state = runtime.borrow_mut();
+                if state.repeat_pending.as_ref().is_some_and(|revision| revision != window.get_scenario_instance().as_str()) {
+                    state.repeat_pending = None;
+                    state.repeats += 1;
+                }
+                state.result_remaining = RESULT_DELAY;
+                caption = "Automatic activity · Press a button to return to the menu".into();
+            }
+        } else {
+            let eligible = enabled_for_process && p.enabled && !runtime.borrow().failed
+                && window.get_launcher_visible() && !window.get_launcher_busy()
+                && !window.get_sound_visible() && !window.get_launcher_settings_visible()
+                && !window.get_launcher_controls_visible() && !window.get_touch_test_visible()
+                && !window.get_settings_save_pending() && window.get_settings_save_error().is_empty()
+                && window.get_launcher_error_text().is_empty() && !held
+                && !window.global::<UserActivity>().get_pointer_held()
+                && !window.global::<UserActivity>().get_gamepad_held();
+            let remaining = runtime.borrow_mut().idle.remaining(now, eligible, Duration::from_secs(p.delay_seconds.into()));
+            if let Some(remaining) = remaining {
+                if let Some(activity) = activity(&p.activity) {
+                    phase = "countdown";
+                    caption = format!("{} starts in {} seconds", activity.label, remaining.as_secs_f64().ceil() as u64);
+                    if remaining.is_zero() {
+                        begin(&window, &launcher, &runtime, activity);
+                        phase = "launching";
+                        caption.clear();
+                    }
+                } else {
+                    phase = "unavailable";
+                    caption = format!("Auto-start activity unavailable: {}", p.activity);
+                }
+            } else if !p.enabled { phase = "disabled"; }
+            else if !enabled_for_process { phase = "suppressed"; }
+            else if runtime.borrow().failed {
+                phase = "failed";
+                caption = "Auto-start stopped after an error · Open Auto-start settings to retry".into();
+            }
+        }
+        window.set_autostart_caption(caption.into());
+        window.set_autostart_diagnostics(format!(
+            "autostart_enabled={}\nautostart_activity={}\nautostart_phase={}\nautostart_session={}\nautostart_repeats={}\nautostart_delay_seconds={}",
+            p.enabled, p.activity, phase, if window.get_autostart_running() { "automatic" } else { "manual" }, runtime.borrow().repeats, p.delay_seconds,
+        ).into());
+    });
+    timer
+}
+
+fn begin(
+    window: &MainWindow,
+    launcher: &Rc<Launcher>,
+    runtime: &Rc<RefCell<Runtime>>,
+    activity: &Activity,
+) {
+    let mut state = runtime.borrow_mut();
+    state.manual_launch = crate::launch_options_from_window(window).ok();
+    state.idle.reset();
+    state.result_remaining = RESULT_DELAY;
+    state.repeat_pending = None;
+    state.repeats = 0;
+    drop(state);
+    window.set_autostart_running(true);
+    window.set_autostart_activity(activity.id.into());
+    window.set_autostart_settings_visible(false);
+    window.set_sound_visible(false);
+    launcher.start_automatic(activity);
+}
+
+fn publish_preferences(window: &MainWindow, p: &AutostartSettings) {
+    window.set_autostart_choice(if !p.enabled {
+        "Off".into()
+    } else {
+        activity(&p.activity)
+            .map_or_else(
+                || format!("Unavailable: {}", p.activity),
+                |a| a.label.into(),
+            )
+            .into()
+    });
+    window.set_autostart_delay(p.delay_seconds.to_string().into());
+    window.set_autostart_start_available(p.enabled && activity(&p.activity).is_some());
+}
+
+pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
+    let index = window.get_autostart_focus_index();
+    match action {
+        UiAction::Up | UiAction::Down => {
+            window.set_autostart_focus_index(crate::ui_navigation::moved_selection(
+                index,
+                4,
+                if action == UiAction::Up { -1 } else { 1 },
+            ))
+        }
+        UiAction::Left | UiAction::Right if index <= 1 => {
+            window.invoke_autostart_adjust(index, if action == UiAction::Left { -1 } else { 1 })
+        }
+        UiAction::Confirm if index == 0 => window.invoke_autostart_adjust(0, 1),
+        UiAction::Confirm if index == 2 => window.invoke_autostart_start_now(),
+        UiAction::Back | UiAction::Controls | UiAction::Start => {
+            window.set_autostart_settings_visible(false)
+        }
+        UiAction::Confirm if index == 3 => window.set_autostart_settings_visible(false),
+        _ => {}
+    }
+}
+
+pub(crate) fn controls(window: &MainWindow) -> Vec<UiControl> {
+    let mut controls = Vec::new();
+    for (id, value) in [
+        ("activity", window.get_autostart_choice()),
+        ("delay", window.get_autostart_delay()),
+    ] {
+        for (suffix, label) in [("previous", "‹"), ("next", "›")] {
+            controls.push(
+                UiControl::new(format!("autostart.{id}.{suffix}"), label, true)
+                    .with_value(value.as_str()),
+            );
+        }
+    }
+    controls.push(UiControl::new(
+        "autostart.start-now",
+        "Start now",
+        window.get_launcher_visible()
+            && window.get_autostart_start_available()
+            && !window.get_settings_save_pending()
+            && window.get_settings_save_error().is_empty(),
+    ));
+    controls.push(UiControl::new("autostart.back", "Back", true));
+    controls.push(
+        UiControl::new("autostart.save-status", "Settings save", false).with_value(
+            if window.get_settings_save_pending() {
+                "saving"
+            } else if !window.get_settings_save_error().is_empty() {
+                "error"
+            } else {
+                "saved"
+            },
+        ),
+    );
+    controls
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_visits_require_the_whole_delay_and_input_wins_at_the_deadline() {
+        let now = Instant::now();
+        let delay = Duration::from_secs(30);
+        let mut idle = IdleCountdown::default();
+        assert_eq!(idle.remaining(now, true, delay), Some(delay));
+        assert_eq!(
+            idle.remaining(now + delay - Duration::from_nanos(1), true, delay),
+            Some(Duration::from_nanos(1))
+        );
+        idle.reset(); // Input handled before this timer poll.
+        assert_eq!(idle.remaining(now + delay, true, delay), Some(delay));
+        assert_eq!(
+            idle.remaining(now + delay * 2, true, delay),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(idle.remaining(now + delay * 3, false, delay), None);
+        assert_eq!(idle.remaining(now + delay * 9, true, delay), Some(delay));
+    }
+
+    #[test]
+    fn disabled_or_held_input_cannot_accumulate_idle_time() {
+        let now = Instant::now();
+        let delay = Duration::from_secs(5);
+        let mut idle = IdleCountdown::default();
+        for seconds in 0..100 {
+            assert_eq!(
+                idle.remaining(now + Duration::from_secs(seconds), false, delay),
+                None
+            );
+        }
+        assert_eq!(
+            idle.remaining(now + Duration::from_secs(100), true, delay),
+            Some(delay)
+        );
+    }
+
+    #[test]
+    fn invalid_timer_fields_preserve_other_preferences_and_unknown_activities() {
+        for invalid in ["-1", "true", "\"oops\"", "[]", "{}"] {
+            let text = format!(
+                "[audio]\nmaster_volume = 0.05\n[spacewars_match]\ntime_limit_seconds = {invalid}\n[autostart]\nenabled = true\nactivity = 'future-garden'\ndelay_seconds = {invalid}"
+            );
+            let settings: Settings = toml::from_str(&text).unwrap();
+            assert_eq!(settings.audio.master_volume, 0.05);
+            assert_eq!(settings.spacewars_match.time_limit_seconds, 600);
+            assert_eq!(settings.autostart.delay_seconds, 30);
+            assert!(settings.autostart.enabled);
+            assert_eq!(settings.autostart.activity, "future-garden");
+            assert!(activity(&settings.autostart.activity).is_none());
+        }
+        let settings: Settings =
+            toml::from_str("[spacewars_match]\ntime_limit_seconds=0\n[autostart]\ndelay_seconds=0")
+                .unwrap();
+        assert_eq!(settings.spacewars_match.time_limit_seconds, 0);
+        assert_eq!(settings.autostart.delay_seconds, 5);
+    }
+}

--- a/crates/engine-client/src/client_scenarios/mod.rs
+++ b/crates/engine-client/src/client_scenarios/mod.rs
@@ -320,6 +320,10 @@ pub trait ClientScenario {
         None
     }
 
+    fn runtime_diagnostics(&self) -> String {
+        String::new()
+    }
+
     fn zoom_player_in(&mut self, _player: usize) {}
     fn zoom_player_out(&mut self, _player: usize) {}
 

--- a/crates/engine-client/src/client_scenarios/surface_sortie/mission.rs
+++ b/crates/engine-client/src/client_scenarios/surface_sortie/mission.rs
@@ -75,6 +75,10 @@ fn create_with_seats(
     } else {
         SurfaceSortieScenario::init_material_travel(seed, false)
     };
+    if arena {
+        let seconds = settings.spacewars_match.normalized().time_limit_seconds;
+        state.set_match_time_limit((seconds != 0).then(|| Duration::from_secs(seconds.into())));
+    }
     state.set_asteroid_pressure(settings.material_combat.asteroids);
     Box::new(MaterialMissionClientScenario {
         sortie: SurfaceSortieClientScenario { state },
@@ -189,16 +193,27 @@ impl ClientScenario for MaterialMissionClientScenario {
         self.sortie.state.match_outcome().is_some()
     }
     fn game_over_message(&self) -> Option<String> {
-        use scenario_spacewars::surface_sortie::match_rules::MatchOutcome;
-        self.sortie
-            .state
-            .match_outcome()
-            .map(|outcome| match outcome {
-                MatchOutcome::Winner(owner) => {
-                    format!("Player {} wins / opposing pilot lost", owner.index() + 1)
-                }
-                MatchOutcome::Draw => "Draw / both pilots lost".to_owned(),
-            })
+        self.sortie.state.match_result_message()
+    }
+    fn runtime_diagnostics(&self) -> String {
+        let Some(round) = self.sortie.state.match_observation() else {
+            return String::new();
+        };
+        format!(
+            "match_player_1={}\nmatch_player_2={}\nmatch_remaining_seconds={}\nmatch_owned_planets={},{}\nmatch_finish_reason={:?}\nmatch_result={}",
+            if self.bots[0] { "rule_bot" } else { "human" },
+            if self.bots[1] { "rule_bot" } else { "human" },
+            round
+                .remaining_seconds
+                .map_or_else(|| "unlimited".into(), |n| format!("{n:.3}")),
+            round.owned_planets[0],
+            round.owned_planets[1],
+            round.reason,
+            self.sortie
+                .state
+                .match_result_message()
+                .unwrap_or_else(|| "in_progress".into()),
+        )
     }
     #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/engine-client/src/gamepad.rs
+++ b/crates/engine-client/src/gamepad.rs
@@ -7,8 +7,8 @@ use gilrs::{Axis, Button, EventType, Gamepad, GamepadId, Gilrs, Mapping};
 use slint::{ComponentHandle, SharedString, Timer, TimerMode};
 use spacewars_control::UiAction;
 
-use crate::MainWindow;
 use crate::input::{self, GameKey, GamepadSeatInput, SharedGamepadInput, SharedInput};
+use crate::{MainWindow, UserActivity};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(16);
 const UI_REPEAT_DELAY: Duration = Duration::from_millis(350);
@@ -153,7 +153,8 @@ impl GamepadPump {
                         self.gamepads.borrow_mut().disconnect_seat(seat);
                         tracing::warn!(gamepad_id = id, player = seat + 1, "gamepad disconnected.");
                         if !window.get_launcher_visible() {
-                            let was_playing = is_game_mode(window);
+                            let was_playing =
+                                is_game_mode(window) && !window.get_autostart_running();
                             if was_playing {
                                 self.input.borrow_mut().press(GameKey::ForcePause);
                             }
@@ -177,6 +178,16 @@ impl GamepadPump {
                     };
                     if is_pad_activity(event_type) {
                         self.ui_driver = Some(seat);
+                    }
+                    let deliberate = match event_type {
+                        EventType::ButtonPressed(..) | EventType::ButtonRepeated(..) => true,
+                        EventType::AxisChanged(_, value, _) => value.abs() >= UI_STICK_THRESHOLD,
+                        EventType::ButtonChanged(_, value, _) => value >= 0.5,
+                        _ => false,
+                    };
+                    if deliberate && window.global::<UserActivity>().invoke_notify() {
+                        self.begin_handoff();
+                        continue;
                     }
                     self.route_button_edge(window, seat, gamepad_id, event_type);
                 }
@@ -264,6 +275,8 @@ impl GamepadPump {
                 Some((seat, snapshot(&gamepad)))
             })
             .collect::<Vec<_>>();
+        let held = snapshots.iter().any(|(_, pad)| autostart_pad_held(pad));
+        window.global::<UserActivity>().set_gamepad_held(held);
         let snapshots = snapshots
             .into_iter()
             .map(|(seat, snapshot)| (seat, self.mode_handoff.filter(seat, snapshot)))
@@ -509,6 +522,27 @@ fn button_value(gamepad: &Gamepad<'_>, button: Button) -> f32 {
         .button_data(button)
         .map(|data| data.value())
         .unwrap_or_else(|| f32::from(gamepad.is_pressed(button)))
+}
+
+fn autostart_pad_held(pad: &GamepadSeatInput) -> bool {
+    pad.left_stick_x.abs() >= UI_STICK_THRESHOLD
+        || pad.left_stick_y.abs() >= UI_STICK_THRESHOLD
+        || pad.right_stick_x.abs() >= UI_STICK_THRESHOLD
+        || pad.right_stick_y.abs() >= UI_STICK_THRESHOLD
+        || pad.left_trigger >= 0.5
+        || pad.right_trigger >= 0.5
+        || pad.dpad_up
+        || pad.dpad_down
+        || pad.dpad_left
+        || pad.dpad_right
+        || pad.left_bumper
+        || pad.right_bumper
+        || pad.south
+        || pad.east
+        || pad.north
+        || pad.west
+        || pad.start
+        || pad.select
 }
 
 fn is_pad_activity(event: EventType) -> bool {

--- a/crates/engine-client/src/host.rs
+++ b/crates/engine-client/src/host.rs
@@ -528,6 +528,7 @@ pub fn start_scenario_loop(
     let mut paused = false;
     let mut benchmark_active = start_benchmark;
     let mut scenario_revision = next_scenario_revision();
+    window.set_scenario_instance(scenario_revision.to_string().into());
     controls
         .borrow_mut()
         .publish_clock_state(&scenario, scenario_revision, paused);
@@ -696,6 +697,7 @@ pub fn start_scenario_loop(
                 window.invoke_match_world_changed();
             }
             scenario_revision = next_scenario_revision();
+            window.set_scenario_instance(scenario_revision.to_string().into());
             performance = PerformanceStats::new(tick_model, now);
             last_realtime_emulated_frames = 0;
             last_realtime_submitted_frames = 0;
@@ -844,6 +846,10 @@ pub fn start_scenario_loop(
                 &performance,
                 &input_diagnostics,
             )));
+            let details = scenario.inner.runtime_diagnostics();
+            if !details.is_empty() {
+                window.set_runtime_diagnostics(format!("{}\n{details}", window.get_runtime_diagnostics()).into());
+            }
             window.set_performance_overlay_text(performance.overlay_text(paused, game_over).into());
             last_diagnostics_revision = diagnostics_revision;
             last_diagnostics_scenario_revision = scenario_revision;

--- a/crates/engine-client/src/input.rs
+++ b/crates/engine-client/src/input.rs
@@ -182,9 +182,13 @@ pub(crate) fn install_window_input(window: &MainWindow, input: SharedInput) {
     // `run()`. The event filter only needs the winit adapter, so install it
     // before the event loop starts.
     let keyboard_input = Rc::clone(&input);
+    let weak = window.as_weak();
     window.window().on_winit_window_event(move |_, event| {
         if matches!(event, WindowEvent::Focused(false)) {
             keyboard_input.borrow_mut().handle_focus_loss();
+            if let Some(window) = weak.upgrade() {
+                window.global::<crate::UserActivity>().invoke_focus_lost();
+            }
             return EventResult::Propagate;
         }
 

--- a/crates/engine-client/src/ipc.rs
+++ b/crates/engine-client/src/ipc.rs
@@ -430,6 +430,8 @@ fn handle_request(
             ));
             #[cfg(all(target_os = "linux", feature = "pi-kiosk"))]
             diagnostics.push_str(&i_slint_backend_linuxkms::profiling::diagnostics());
+            diagnostics.push('\n');
+            diagnostics.push_str(window.get_autostart_diagnostics().as_str());
             let launch = window.get_launcher_diagnostics();
             if !launch.is_empty() {
                 diagnostics.push('\n');
@@ -865,6 +867,7 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
         launcher_busy: window.get_launcher_busy(),
         sound: window.get_sound_visible(),
         device_info: window.get_device_info_visible(),
+        autostart: window.get_autostart_settings_visible(),
         launcher: window.get_launcher_visible(),
         launcher_controls: window.get_launcher_controls_visible(),
         launcher_settings: window.get_launcher_settings_visible(),
@@ -879,6 +882,9 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
     let inventory = inventory_for_screen(
         screen,
         &UiInventoryContext {
+            automatic: window.get_autostart_running(),
+            autostart_controls: crate::autostart::controls(window),
+            autostart_focus: window.get_autostart_focus_index(),
             device_info_controls: if matches!(screen, UiScreen::LauncherInfo | UiScreen::PauseInfo)
             {
                 crate::device_info::inventory(window)
@@ -913,6 +919,7 @@ fn ui_state(window: &MainWindow, tracker: &mut UiStateTracker) -> Result<UiState
             scenario_error: non_empty(window.get_scenario_error_text().as_str()),
             renderer: window.get_launcher_renderer().to_string(),
             raster_scale: window.get_launcher_raster_scale_text().to_string(),
+            match_length: window.get_launcher_match_length().to_string(),
             combat_break_interval: window.get_launcher_combat_break_interval().to_string(),
             combat_break_duration: window.get_launcher_combat_break_duration().to_string(),
             combat_mission: window.get_launcher_combat_mission().to_string(),

--- a/crates/engine-client/src/keyboard_tests.rs
+++ b/crates/engine-client/src/keyboard_tests.rs
@@ -95,6 +95,113 @@ fn scenario_confirmation_focuses_play_without_changing_the_selection() {
 }
 
 #[test]
+fn automatic_activity_consumes_keyboard_and_touch_before_exposing_the_launcher() {
+    slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
+    let window = MainWindow::new().unwrap();
+    window
+        .window()
+        .set_size(slint::LogicalSize::new(800.0, 480.0));
+    let directory = tempfile::tempdir().unwrap();
+    let settings = Arc::new(RwLock::new(Settings::default()));
+    let writer =
+        settings_writer::SettingsWriter::new(directory.path().join("settings.toml")).unwrap();
+    let catalog = Rc::new(RefCell::new(nes_roms::NesRomCatalog::new(directory.path())));
+    let (input, _) = input::new_shared_input();
+    let launcher = launcher::Launcher::new(
+        &window,
+        Rc::new(RefCell::new(None)),
+        host::new_scenario_controls(),
+        Rc::clone(&input),
+        Arc::clone(&settings),
+        Rc::clone(&catalog),
+        writer.clone(),
+    );
+    install_ui_navigation(&window);
+    install_keyboard_navigation(&window, input);
+    let _timer = autostart::install(&window, launcher, settings, writer, catalog, true);
+    let exits = Rc::new(Cell::new(0));
+    let exited = Rc::clone(&exits);
+    let weak = window.as_weak();
+    window.on_ingame_return_launcher(move || {
+        exited.set(exited.get() + 1);
+        let window = weak.upgrade().unwrap();
+        window.set_launcher_visible(true);
+        window.set_launcher_focus_index(1);
+    });
+    let starts = Rc::new(Cell::new(0));
+    let started = Rc::clone(&starts);
+    window.on_launcher_start_game(move || started.set(started.get() + 1));
+    window.show().unwrap();
+    window.set_launcher_visible(false);
+    window.set_autostart_running(true);
+    window.window().dispatch_event(WindowEvent::KeyPressed {
+        text: Key::Return.into(),
+    });
+    assert!(window.get_launcher_visible());
+    assert_eq!(exits.get(), 1);
+    window
+        .window()
+        .dispatch_event(WindowEvent::KeyPressRepeated {
+            text: Key::Return.into(),
+        });
+    window.window().dispatch_event(WindowEvent::KeyReleased {
+        text: Key::Return.into(),
+    });
+    assert_eq!(starts.get(), 0, "exit input must not start a manual game");
+    key(&window, Key::Return);
+    assert_eq!(starts.get(), 1, "fresh input remains usable");
+
+    // A release delivered outside the window must not leave consumed input stuck.
+    window.set_launcher_visible(false);
+    window.set_autostart_running(true);
+    window.window().dispatch_event(WindowEvent::KeyPressed {
+        text: Key::Return.into(),
+    });
+    window.global::<UserActivity>().set_pointer_held(true);
+    window.global::<UserActivity>().invoke_focus_lost();
+    assert!(!window.global::<UserActivity>().get_pointer_held());
+    key(&window, Key::Return);
+    assert_eq!(starts.get(), 2, "fresh input works after focus loss");
+
+    window.set_launcher_visible(false);
+    window.set_autostart_running(true);
+    click(&window, 400.0, 280.0);
+    assert_eq!(exits.get(), 3);
+    assert!(!window.get_autostart_running());
+    assert_eq!(
+        starts.get(),
+        2,
+        "pointer release must not click the newly exposed menu"
+    );
+
+    // The new App Settings list must reveal Auto-start below Device Info,
+    // even when a short window cannot show all rows at once.
+    window.set_sound_visible(true);
+    window.set_sound_focus_index(3);
+    window
+        .window()
+        .set_size(slint::LogicalSize::new(800.0, 360.0));
+    key(&window, Key::DownArrow);
+    assert_eq!(window.get_sound_focus_index(), 4);
+    window.window().take_snapshot().unwrap();
+    click(&window, 400.0, 190.0);
+    assert!(window.get_autostart_settings_visible());
+    assert_eq!(window.get_autostart_focus_index(), 0);
+    key(&window, Key::DownArrow);
+    key(&window, Key::RightArrow);
+    assert_eq!(window.get_autostart_delay(), "60");
+    // The child's Back action stays below its rows and returns one level.
+    click(&window, 600.0, 288.0);
+    assert!(!window.get_autostart_settings_visible());
+    assert!(window.get_sound_visible());
+    assert_eq!(window.get_sound_focus_index(), 4);
+    assert_eq!(exits.get(), 3);
+    window.window().take_snapshot().unwrap();
+    click(&window, 400.0, 288.0);
+    assert!(!window.get_sound_visible());
+}
+
+#[test]
 fn backend_neutral_keyboard_reaches_clock_settings_and_does_not_repeat_shortcuts() {
     slint::platform::set_platform(Box::new(TestPlatform)).unwrap();
     let window = MainWindow::new().unwrap();
@@ -431,7 +538,7 @@ fn sound_keyboard_touch_and_menu_actions_share_persistent_controls() {
     assert_eq!(settings.read().unwrap().audio.master_volume, 0.40);
     assert!(!window.get_settings_save_error().is_empty());
     std::fs::remove_dir(&path).unwrap();
-    window.set_sound_focus_index(5);
+    window.set_sound_focus_index(6);
     window.invoke_ui_action(UiAction::Confirm.code());
     pump_until(|| !window.get_settings_save_pending());
     assert!(window.get_settings_save_error().is_empty());

--- a/crates/engine-client/src/launcher.rs
+++ b/crates/engine-client/src/launcher.rs
@@ -65,6 +65,7 @@ struct Timings {
 }
 
 struct PendingLaunch {
+    automatic: bool,
     receiver: mpsc::Receiver<PreparationMessage>,
     launch: EffectiveLaunch,
     settings: Settings,
@@ -166,11 +167,54 @@ impl Launcher {
         }
 
         let save_needed = crate::apply_launcher_selections(&mut candidate, &selections);
-        let launch = selections.launch;
+        self.begin(selections.launch, candidate, benchmark, save_needed, false);
+    }
+
+    pub(crate) fn start_automatic(self: &Rc<Self>, activity: &crate::autostart::Activity) {
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
+        if window.get_launcher_busy() || !window.get_launcher_visible() {
+            return;
+        }
+        window.set_launcher_error_text("".into());
+        let mut effective = self.settings.read().unwrap().clone();
+        let mut launch = crate::launch_from_settings(&effective);
+        launch.scenario = activity.scenario.into();
+        if activity.repeat_matches {
+            launch.seed = crate::match_world::fresh_seed(launch.seed);
+            effective.spacewars.player_1_controller = engine_common::SpacewarsController::RuleBot;
+            effective.spacewars.player_2_controller = engine_common::SpacewarsController::RuleBot;
+        }
+        self.begin(launch, effective, false, false, true);
+    }
+
+    pub(crate) fn cancel_automatic(&self) {
+        if self.pending.borrow().as_ref().is_some_and(|p| p.automatic) {
+            self.timer.stop();
+            self.pending.borrow_mut().take();
+            if let Some(window) = self.window.upgrade() {
+                window.set_launcher_busy(false);
+            }
+        }
+    }
+
+    fn begin(
+        self: &Rc<Self>,
+        launch: EffectiveLaunch,
+        candidate: Settings,
+        benchmark: bool,
+        save_needed: bool,
+        automatic: bool,
+    ) {
+        let Some(window) = self.window.upgrade() else {
+            return;
+        };
         let catalog = self.catalog.borrow().clone();
         let (sender, receiver) = mpsc::channel();
         let started_at = Instant::now();
         let pending = PendingLaunch {
+            automatic,
             receiver,
             launch: launch.clone(),
             settings: candidate.clone(),
@@ -258,7 +302,9 @@ impl Launcher {
                     }
                     // A successful save stays committed even if the selected
                     // cartridge subsequently fails to load.
-                    *self.settings.write().unwrap() = pending.settings.clone();
+                    if !pending.automatic {
+                        *self.settings.write().unwrap() = pending.settings.clone();
+                    }
                 }
                 Ok(PreparationMessage::Ready(result, duration)) => {
                     pending.timings.load = duration;

--- a/crates/engine-client/src/main.rs
+++ b/crates/engine-client/src/main.rs
@@ -4,6 +4,7 @@
 //! Lab, Spaceling Lab, Terrain Lab, and Spacewars, with Null retained as a hidden test
 //! scenario.
 
+mod autostart;
 mod client_scenarios;
 mod clock_controls;
 mod device_info;
@@ -433,7 +434,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (input, gamepad_input) = input::new_shared_input();
     input::install_window_input(&window, Rc::clone(&input));
     let render_timer = Rc::new(RefCell::new(None));
-    install_launcher_callbacks(
+    let launcher = install_launcher_callbacks(
         &window,
         Rc::clone(&render_timer),
         Rc::clone(&scenario_controls),
@@ -472,6 +473,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or(Path::new("."))
             .to_path_buf(),
     )?;
+    let _autostart = autostart::install(
+        &window,
+        launcher,
+        Arc::clone(&settings),
+        settings_writer.clone(),
+        Rc::clone(&rom_catalog),
+        !launch_directly && !args.uses_debug_render() && !args.uses_benchmark() && !args.touch_test,
+    );
     apply_video_settings(&window, &args, &settings.read().unwrap());
     let _gamepad_timer = gamepad::start_gamepad_pump(&window, Rc::clone(&input), gamepad_input);
 
@@ -719,6 +728,9 @@ fn show_launcher(
     window.set_launcher_combat_break_duration(SharedString::from(
         breaks.duration_seconds.to_string(),
     ));
+    window.set_launcher_match_length(
+        match_world::length_label(settings.spacewars_match.normalized().time_limit_seconds).into(),
+    );
     let setup = settings.spacewars.normalized();
     window.set_launcher_spacewars_preset(SharedString::from(preset_label_for_setup(&setup)));
     window.set_launcher_universe_radius_text(SharedString::from(setup.universe_radius.to_string()));
@@ -918,7 +930,7 @@ fn install_launcher_callbacks(
     settings: Arc<RwLock<Settings>>,
     rom_catalog: SharedNesRomCatalog,
     settings_writer: settings_writer::SettingsWriter,
-) {
+) -> Rc<launcher::Launcher> {
     let launcher = launcher::Launcher::new(
         window,
         render_timer,
@@ -938,8 +950,9 @@ fn install_launcher_callbacks(
         new_world_launcher.start(launcher::StartMode::NewMatch);
     });
 
+    let benchmark_launcher = Rc::clone(&launcher);
     window.on_launcher_start_benchmark(move || {
-        launcher.start(launcher::StartMode::Benchmark);
+        benchmark_launcher.start(launcher::StartMode::Benchmark);
     });
 
     let weak = window.as_weak();
@@ -988,6 +1001,7 @@ fn install_launcher_callbacks(
             tracing::error!(error = %err, "failed to quit event loop.");
         }
     });
+    launcher
 }
 
 fn install_ingame_menu_callbacks(
@@ -1020,6 +1034,9 @@ fn install_ingame_menu_callbacks(
         let Some(window) = weak.upgrade() else {
             return;
         };
+        if window.get_autostart_running() {
+            return;
+        }
         let mut settings = world_settings.write().unwrap();
         settings.launch.scenario = "spacewars".into();
         settings.last_scenario = Some("spacewars".into());
@@ -1129,10 +1146,15 @@ fn install_keyboard_navigation(window: &MainWindow, input: input::SharedInput) {
 }
 
 fn handle_ui_action(window: &MainWindow, action: UiAction) {
+    if window.global::<UserActivity>().invoke_notify() {
+        return;
+    }
     if window.get_launcher_busy() {
         return;
     }
-    if window.get_device_info_visible() && window.get_sound_visible() {
+    if window.get_autostart_settings_visible() && window.get_sound_visible() {
+        autostart::handle_action(window, action);
+    } else if window.get_device_info_visible() && window.get_sound_visible() {
         device_info::handle_action(window, action);
     } else if window.get_sound_visible() {
         sound_controls::handle_action(window, action);
@@ -1370,7 +1392,7 @@ fn cycle_launcher_scenario(window: &MainWindow, delta: i32) {
 
 fn launcher_settings_item_count(window: &MainWindow) -> i32 {
     match window.get_launcher_scenario().as_str() {
-        "spacewars" => 9,
+        "spacewars" => 10,
         "spacewars-classic" => 8,
         "pizza" => 5,
         "spacewars-terrain-combat" | "spacewars-terrain-duel" => 8,
@@ -1509,6 +1531,14 @@ fn adjust_material_match_launcher_setting(window: &MainWindow, focus: i32, delta
             &["Light", "Mixed", "Heavy"],
             delta,
         ))),
+        8 => window.set_launcher_match_length(
+            cycle_label(
+                window.get_launcher_match_length().as_str(),
+                &["5 min", "10 min", "15 min", "Unlimited"],
+                delta,
+            )
+            .into(),
+        ),
         _ => {}
     }
 }
@@ -1674,6 +1704,10 @@ fn handle_return_to_launcher(
         return;
     };
 
+    if window.get_autostart_running() {
+        window.invoke_autostart_return();
+        return;
+    }
     if let Some(timer) = render_timer.borrow_mut().take() {
         timer.stop();
     }
@@ -1774,6 +1808,7 @@ fn clear_runtime_diagnostics(window: &MainWindow) {
 }
 
 fn hide_launcher_surfaces(window: &MainWindow) {
+    window.set_autostart_settings_visible(false);
     window.set_sound_visible(false);
     window.set_launcher_visible(false);
     window.set_launcher_settings_visible(false);
@@ -1787,6 +1822,7 @@ fn hide_launcher_surfaces(window: &MainWindow) {
 
 #[derive(Debug, Clone, PartialEq)]
 struct LauncherSelections {
+    spacewars_match: engine_common::MatchSettings,
     launch: EffectiveLaunch,
     nes_rom_id: Option<String>,
     clock: ClockSettings,
@@ -1806,6 +1842,10 @@ fn apply_launcher_selections(settings: &mut Settings, selections: &LauncherSelec
     let clock = selections.clock;
     let nes_rom_id = selections.nes_rom_id.clone();
     let mut changed = false;
+    if settings.spacewars_match != selections.spacewars_match {
+        settings.spacewars_match = selections.spacewars_match;
+        changed = true;
+    }
 
     if settings.launch.scenario != launch.scenario {
         settings.launch.scenario = launch.scenario.clone();
@@ -2100,7 +2140,17 @@ fn launcher_selections_from_window(
     } else {
         current_settings.material_combat
     };
+    let spacewars_match = if launch.scenario == "spacewars" {
+        engine_common::MatchSettings {
+            time_limit_seconds: match_world::parse_length(
+                window.get_launcher_match_length().as_str(),
+            )?,
+        }
+    } else {
+        current_settings.spacewars_match
+    };
     Ok(LauncherSelections {
+        spacewars_match,
         material_combat,
         combat_breaks,
         surface_expedition,
@@ -2952,6 +3002,7 @@ mod tests {
         let path = dir.path().join("settings.toml");
         let settings = Arc::new(RwLock::new(Settings::default()));
         let selections = LauncherSelections {
+            spacewars_match: engine_common::MatchSettings::default(),
             material_combat: engine_common::MaterialCombatSettings {
                 mission: engine_common::MaterialCombatMission::Capture,
                 asteroids: engine_common::MaterialAsteroidSettings {

--- a/crates/engine-client/src/match_world.rs
+++ b/crates/engine-client/src/match_world.rs
@@ -11,3 +11,32 @@ pub(crate) fn fresh_seed(current: u64) -> u64 {
         candidate
     }
 }
+
+pub(crate) fn length_label(seconds: u32) -> String {
+    if seconds == 0 {
+        "Unlimited".into()
+    } else if seconds.is_multiple_of(60) {
+        format!("{} min", seconds / 60)
+    } else {
+        format!("{seconds} s")
+    }
+}
+
+pub(crate) fn parse_length(label: &str) -> Result<u32, String> {
+    if label == "Unlimited" {
+        return Ok(0);
+    }
+    let (number, multiplier) = if let Some(n) = label.strip_suffix(" min") {
+        (n, 60)
+    } else if let Some(n) = label.strip_suffix(" s") {
+        (n, 1)
+    } else {
+        return Err("Match length must be minutes, seconds, or Unlimited.".into());
+    };
+    number
+        .parse::<u32>()
+        .ok()
+        .and_then(|n| n.checked_mul(multiplier))
+        .filter(|&n| (1..=3600).contains(&n))
+        .ok_or_else(|| "Match length must be between one second and one hour.".into())
+}

--- a/crates/engine-client/src/sound_controls.rs
+++ b/crates/engine-client/src/sound_controls.rs
@@ -78,7 +78,7 @@ pub(crate) fn install(
         writer.save(snapshot);
         window.set_settings_save_pending(true);
         window.set_settings_save_error("".into());
-        window.set_sound_focus_index(4);
+        window.set_sound_focus_index(5);
     });
 }
 
@@ -123,9 +123,9 @@ fn adjusted(audio: AudioSettings, index: i32, delta: i32) -> AudioSettings {
 pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
     let index = window.get_sound_focus_index();
     let count = if window.get_settings_save_error().is_empty() {
-        5
-    } else {
         6
+    } else {
+        7
     };
     match action {
         UiAction::Up | UiAction::Down => {
@@ -138,14 +138,15 @@ pub(crate) fn handle_action(window: &MainWindow, action: UiAction) {
         UiAction::Left | UiAction::Right if index <= 2 => {
             window.invoke_sound_adjust(index, if action == UiAction::Left { -1 } else { 1 })
         }
-        UiAction::Left | UiAction::Right if count == 6 && index >= 4 => {
-            window.set_sound_focus_index(if index == 4 { 5 } else { 4 })
+        UiAction::Left | UiAction::Right if count == 7 && index >= 5 => {
+            window.set_sound_focus_index(if index == 5 { 6 } else { 5 })
         }
         UiAction::Confirm if index == 1 || index == 2 => window.invoke_sound_adjust(index, 0),
         UiAction::Confirm if index == 3 => window.invoke_device_info_open(),
-        UiAction::Confirm if index == 5 && count == 6 => window.invoke_sound_retry(),
+        UiAction::Confirm if index == 4 => window.invoke_autostart_open(),
+        UiAction::Confirm if index == 6 && count == 7 => window.invoke_sound_retry(),
         UiAction::Back | UiAction::Controls | UiAction::Confirm
-            if action != UiAction::Confirm || index == 4 =>
+            if action != UiAction::Confirm || index == 5 =>
         {
             window.set_sound_visible(false)
         }

--- a/crates/engine-client/src/ui_activation.rs
+++ b/crates/engine-client/src/ui_activation.rs
@@ -13,6 +13,7 @@ enum ActivationFocus {
     PauseMain(i32),
     PauseSound,
     Sound(i32),
+    Autostart(i32),
     DeviceInfo,
     PauseControls,
     PauseClock(i32),
@@ -60,6 +61,7 @@ pub(crate) fn activate(window: &MainWindow, control_id: &str) -> bool {
             ),
         ),
         ActivationFocus::Sound(index) => window.set_sound_focus_index(index),
+        ActivationFocus::Autostart(index) => window.set_autostart_focus_index(index),
         ActivationFocus::PauseClock(index) => window.set_ingame_clock_focus_index(index),
         ActivationFocus::GameOver(index) => window.set_game_over_focus_index(index),
     }
@@ -99,8 +101,33 @@ fn activation_target(
         "sound.mute" => sound(1, UiAction::Confirm),
         "settings.fps-counter" => sound(2, UiAction::Confirm),
         "settings.device-info" => sound(3, UiAction::Confirm),
-        "sound.back" => sound(4, UiAction::Confirm),
-        "sound.retry" => sound(5, UiAction::Confirm),
+        "settings.autostart" => sound(4, UiAction::Confirm),
+        "sound.back" => sound(5, UiAction::Confirm),
+        "sound.retry" => sound(6, UiAction::Confirm),
+        "autostart.activity.previous" => ActivationTarget {
+            focus: ActivationFocus::Autostart(0),
+            action: UiAction::Left,
+        },
+        "autostart.activity.next" => ActivationTarget {
+            focus: ActivationFocus::Autostart(0),
+            action: UiAction::Right,
+        },
+        "autostart.delay.previous" => ActivationTarget {
+            focus: ActivationFocus::Autostart(1),
+            action: UiAction::Left,
+        },
+        "autostart.delay.next" => ActivationTarget {
+            focus: ActivationFocus::Autostart(1),
+            action: UiAction::Right,
+        },
+        "autostart.start-now" => ActivationTarget {
+            focus: ActivationFocus::Autostart(2),
+            action: UiAction::Confirm,
+        },
+        "autostart.back" => ActivationTarget {
+            focus: ActivationFocus::Autostart(3),
+            action: UiAction::Confirm,
+        },
         "info.back" => ActivationTarget {
             focus: ActivationFocus::DeviceInfo,
             action: UiAction::Back,
@@ -199,7 +226,7 @@ fn launcher_setting_target(control_id: &str) -> Option<ActivationTarget> {
         | "launcher.settings.match.asteroid-interval"
         | "launcher.settings.clock.color-cycle" => 6,
         "launcher.settings.match.asteroid-strength" | "launcher.settings.clock.meltdown" => 7,
-        "launcher.settings.clock.duck" => 8,
+        "launcher.settings.clock.duck" | "launcher.settings.match.length" => 8,
         "launcher.settings.clock.marquee" => 9,
         "launcher.settings.clock.marquee-preset" => 10,
         _ => return None,

--- a/crates/engine-client/src/ui_inventory.rs
+++ b/crates/engine-client/src/ui_inventory.rs
@@ -4,6 +4,7 @@ use spacewars_control::{UiAction, UiControl, UiScreen};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct ScreenVisibility {
+    pub(crate) autostart: bool,
     pub(crate) launcher_busy: bool,
     pub(crate) sound: bool,
     pub(crate) device_info: bool,
@@ -23,7 +24,9 @@ pub(crate) fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
     } else if visibility.touch_test {
         UiScreen::LauncherTouchTest
     } else if visibility.launcher {
-        if visibility.sound && visibility.device_info {
+        if visibility.sound && visibility.autostart {
+            UiScreen::LauncherAutostart
+        } else if visibility.sound && visibility.device_info {
             UiScreen::LauncherInfo
         } else if visibility.sound {
             UiScreen::LauncherSound
@@ -36,6 +39,8 @@ pub(crate) fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
         }
     } else if visibility.game_over {
         UiScreen::GameOver
+    } else if visibility.ingame_menu && visibility.sound && visibility.autostart {
+        UiScreen::PauseAutostart
     } else if visibility.ingame_menu && visibility.sound && visibility.device_info {
         UiScreen::PauseInfo
     } else if visibility.ingame_menu && visibility.sound {
@@ -53,6 +58,9 @@ pub(crate) fn classify_screen(visibility: ScreenVisibility) -> UiScreen {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct UiInventoryContext {
+    pub(crate) automatic: bool,
+    pub(crate) autostart_controls: Vec<UiControl>,
+    pub(crate) autostart_focus: i32,
     pub(crate) device_info_controls: Vec<UiControl>,
     pub(crate) launcher_busy_stage: String,
     pub(crate) launcher_busy_elapsed: String,
@@ -79,6 +87,7 @@ pub(crate) struct UiInventoryContext {
     pub(crate) scenario_error: Option<String>,
     pub(crate) renderer: String,
     pub(crate) raster_scale: String,
+    pub(crate) match_length: String,
     pub(crate) combat_break_interval: String,
     pub(crate) combat_break_duration: String,
     pub(crate) combat_mission: String,
@@ -133,6 +142,20 @@ pub(crate) fn inventory_for_screen(screen: UiScreen, context: &UiInventoryContex
             controls: context.device_info_controls.clone(),
             actions: UiAction::ALL.to_vec(),
             error: None,
+        },
+        UiScreen::LauncherAutostart | UiScreen::PauseAutostart => UiInventory {
+            selected_control: selected_from_index(
+                &[
+                    "autostart.activity",
+                    "autostart.delay",
+                    "autostart.start-now",
+                    "autostart.back",
+                ],
+                context.autostart_focus,
+            ),
+            controls: context.autostart_controls.clone(),
+            actions: UiAction::ALL.to_vec(),
+            error: context.settings_save_error.clone(),
         },
         UiScreen::LauncherSettings => launcher_settings_inventory(context),
         UiScreen::LauncherControls => launcher_controls_inventory(context),
@@ -194,6 +217,18 @@ fn world_control(
 }
 
 fn game_over_inventory(context: &UiInventoryContext) -> UiInventory {
+    if context.automatic {
+        return UiInventory {
+            selected_control: Some("game-over.return-to-launcher".into()),
+            controls: vec![
+                UiControl::new("game-over.return-to-launcher", "Launcher", true),
+                UiControl::new("game-over.world-seed", "World seed", false)
+                    .with_value(context.world_seed.clone()),
+            ],
+            actions: UiAction::ALL.to_vec(),
+            error: context.scenario_error.clone(),
+        };
+    }
     let mut ids = vec!["game-over.play-again"];
     let mut controls = vec![world_control(
         "game-over.play-again",
@@ -312,6 +347,10 @@ fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
                     "launcher.settings.match.asteroid-strength",
                     context.combat_asteroid_strength.clone(),
                 ),
+                (
+                    "launcher.settings.match.length",
+                    context.match_length.clone(),
+                ),
             ] {
                 push_choice(&mut controls, id, &value);
             }
@@ -324,6 +363,7 @@ fn launcher_settings_inventory(context: &UiInventoryContext) -> UiInventory {
                 "launcher.settings.match.break-duration",
                 "launcher.settings.match.asteroid-interval",
                 "launcher.settings.match.asteroid-strength",
+                "launcher.settings.match.length",
                 "launcher.settings.back",
             ]
         }
@@ -717,12 +757,14 @@ fn sound_inventory(context: &UiInventoryContext) -> UiInventory {
         ),
     );
     controls.push(UiControl::new("settings.device-info", "Device Info", true));
+    controls.push(UiControl::new("settings.autostart", "Auto-start", true));
     controls.push(UiControl::new("sound.back", "Back", true));
     let mut ids = vec![
         "sound.volume",
         "sound.mute",
         "settings.fps-counter",
         "settings.device-info",
+        "settings.autostart",
         "sound.back",
     ];
     if context.settings_save_error.is_some() {
@@ -1013,6 +1055,7 @@ mod tests {
                 launcher_busy: false,
                 sound: false,
                 device_info: false,
+                autostart: false,
                 launcher: true,
                 launcher_controls: true,
                 launcher_settings: true,
@@ -1094,7 +1137,7 @@ mod tests {
     #[test]
     fn settings_inventory_matches_each_scenario() {
         let cases = [
-            ("spacewars", 18, "launcher.settings.match.player-2"),
+            ("spacewars", 20, "launcher.settings.match.player-2"),
             (
                 "spacewars-classic",
                 16,

--- a/crates/engine-client/src/ui_render_tests.rs
+++ b/crates/engine-client/src/ui_render_tests.rs
@@ -139,6 +139,11 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_launcher_visible(true);
             ui.set_launcher_settings_visible(true);
         }),
+        ("launcher-match-settings", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_launcher_scenario("spacewars".into());
+            ui.set_launcher_settings_visible(true);
+        }),
         ("launcher-controls", |ui| {
             ui.set_launcher_visible(true);
             ui.set_launcher_controls_visible(true);

--- a/crates/engine-client/src/ui_render_tests.rs
+++ b/crates/engine-client/src/ui_render_tests.rs
@@ -30,6 +30,9 @@ fn reset_panels(ui: &MainWindow) {
     ui.set_ingame_controls_visible(false);
     ui.set_ingame_clock_visible(false);
     ui.set_game_over_visible(false);
+    ui.set_autostart_settings_visible(false);
+    ui.set_autostart_running(false);
+    ui.set_autostart_caption("".into());
     ui.set_controller_disconnected_visible(false);
     ui.set_scenario_error_text("".into());
     ui.set_touch_test_visible(false);
@@ -116,6 +119,10 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_launcher_visible(true);
             ui.set_launcher_focus_index(1);
         }),
+        ("launcher-countdown", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_autostart_caption("Spacewars bots starts in 30 seconds".into());
+        }),
         ("launcher-spacewars", |ui| {
             ui.set_launcher_scenario("spacewars".into());
             ui.set_launcher_scenario_title("Space-Wars".into());
@@ -145,6 +152,24 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_launcher_visible(true);
             ui.set_sound_visible(true);
         }),
+        ("launcher-autostart", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_sound_visible(true);
+            ui.set_autostart_settings_visible(true);
+            ui.set_autostart_choice("Spacewars bots".into());
+            ui.set_autostart_start_available(true);
+        }),
+        ("launcher-sound-autostart", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_sound_visible(true);
+            ui.set_sound_focus_index(4);
+        }),
+        ("launcher-autostart-save-error", |ui| {
+            ui.set_launcher_visible(true);
+            ui.set_sound_visible(true);
+            ui.set_autostart_settings_visible(true);
+            ui.set_settings_save_error("Storage is not writable".into());
+        }),
         ("launcher-info", |ui| {
             ui.set_launcher_visible(true);
             ui.set_sound_visible(true);
@@ -154,7 +179,7 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_launcher_visible(true);
             ui.set_sound_visible(true);
             ui.set_settings_save_error("Storage is not writable".into());
-            ui.set_sound_focus_index(5);
+            ui.set_sound_focus_index(6);
         }),
         ("busy", |ui| {
             ui.set_launcher_visible(true);
@@ -177,6 +202,11 @@ fn menu_lifecycles_match_full_repaints_and_preserve_root_state() {
             ui.set_ingame_menu_visible(true);
             ui.set_sound_visible(true);
             ui.set_device_info_visible(true);
+        }),
+        ("pause-autostart", |ui| {
+            ui.set_ingame_menu_visible(true);
+            ui.set_sound_visible(true);
+            ui.set_autostart_settings_visible(true);
         }),
         ("disconnected", |ui| {
             ui.set_controller_disconnected_visible(true)

--- a/crates/engine-client/tests/ui_control_functional.rs
+++ b/crates/engine-client/tests/ui_control_functional.rs
@@ -44,6 +44,9 @@ mod terrain_lab;
 #[path = "ui_control_functional/spacewars_terrain.rs"]
 mod spacewars_terrain;
 
+#[path = "ui_control_functional/autostart.rs"]
+mod autostart;
+
 #[path = "ui_control_functional/spacewars_match.rs"]
 mod spacewars_match;
 
@@ -117,6 +120,8 @@ fn launcher_navigation_uses_the_public_control_api() {
                 "launcher.settings.match.asteroid-interval.next",
                 "launcher.settings.match.asteroid-strength.previous",
                 "launcher.settings.match.asteroid-strength.next",
+                "launcher.settings.match.length.previous",
+                "launcher.settings.match.length.next",
                 "launcher.settings.back",
                 "launcher.settings.start",
             ]
@@ -523,6 +528,15 @@ struct FunctionalHarness {
 
 impl FunctionalHarness {
     fn spawn(test_name: &'static str, backend: &'static str, seed: u64) -> Result<Self, String> {
+        Self::spawn_configured(test_name, backend, seed, None)
+    }
+
+    fn spawn_configured(
+        test_name: &'static str,
+        backend: &'static str,
+        seed: u64,
+        settings: Option<engine_common::Settings>,
+    ) -> Result<Self, String> {
         let artifact_root = workspace_root().join("target/functional-test-artifacts");
         fs::create_dir_all(&artifact_root).map_err(|error| {
             format!(
@@ -537,6 +551,13 @@ impl FunctionalHarness {
         let config_directory = run_directory.path().join("config");
         fs::create_dir(&config_directory)
             .map_err(|error| format!("could not create isolated config directory: {error}"))?;
+        if let Some(settings) = settings {
+            fs::write(
+                config_directory.join("settings.toml"),
+                toml::to_string_pretty(&settings).unwrap(),
+            )
+            .map_err(|error| error.to_string())?;
+        }
 
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/engine-client/tests/ui_control_functional/autostart.rs
+++ b/crates/engine-client/tests/ui_control_functional/autostart.rs
@@ -1,0 +1,211 @@
+use super::*;
+
+fn run(
+    name: &'static str,
+    settings: engine_common::Settings,
+    test: impl FnOnce(&mut FunctionalHarness),
+) {
+    let mut settings = settings;
+    settings.launch.renderer = engine_common::RendererSetting::Raster;
+    settings.launch.raster_scale = 2.0;
+    settings.video.width = 800;
+    settings.video.height = 480;
+    let mut h =
+        FunctionalHarness::spawn_configured(name, "winit-software", 4242, Some(settings)).unwrap();
+    if let Err(payload) = catch_unwind(AssertUnwindSafe(|| test(&mut h))) {
+        h.failure = Some(panic_message(payload.as_ref()));
+        drop(h);
+        resume_unwind(payload);
+    }
+}
+
+fn wait_screen(h: &mut FunctionalHarness, screen: UiScreen) -> UiState {
+    h.wait_for(
+        UiStatePredicate {
+            screen: Some(screen),
+            ..Default::default()
+        },
+        TRANSITION_TIMEOUT,
+    )
+}
+
+fn status(h: &FunctionalHarness) -> String {
+    h.client.request("status\n").unwrap()
+}
+
+fn saved(h: &FunctionalHarness) -> engine_common::Settings {
+    toml::from_str(&fs::read_to_string(h.run_path().join("config/settings.toml")).unwrap()).unwrap()
+}
+
+fn assert_stays(h: &mut FunctionalHarness, screen: UiScreen, duration: Duration) {
+    let until = Instant::now() + duration;
+    while Instant::now() < until {
+        assert_eq!(h.state().screen, screen);
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn preferences(h: &mut FunctionalHarness, root: &UiState) -> UiState {
+    let app = h.activate_guarded("launcher.sound", root);
+    h.activate_guarded("settings.autostart", &app)
+}
+
+fn wait_saved(h: &mut FunctionalHarness) -> UiState {
+    let deadline = Instant::now() + TRANSITION_TIMEOUT;
+    loop {
+        let state = h.state();
+        if control_value(&state, "autostart.save-status") == Some("saved") {
+            return state;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "auto-start settings failed to save"
+        );
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn back(h: &mut FunctionalHarness, settings: &UiState) -> UiState {
+    h.activate_guarded("autostart.back", settings);
+    let app = h.wait_sound_save("saved");
+    assert_eq!(app.screen, UiScreen::LauncherSound);
+    h.activate_guarded("sound.back", &app)
+}
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn autostart_clock_is_sticky_preserves_preferences_and_yields_without_click_through() {
+    let mut settings = engine_common::Settings::default();
+    settings.audio.master_volume = 0.05;
+    settings.audio.muted = true;
+    run("autostart-clock", settings, |h| {
+        let root = h.wait_until_ready();
+        let before = saved(h);
+        let mut p = preferences(h, &root);
+        assert_eq!(control_value(&p, "autostart.activity.next"), Some("Off"));
+        h.activate_guarded("autostart.activity.next", &p);
+        p = wait_saved(h);
+        for _ in 0..2 {
+            h.activate_guarded("autostart.delay.previous", &p);
+            p = wait_saved(h);
+        }
+        assert_eq!(control_value(&p, "autostart.delay.next"), Some("5"));
+        h.capture_screenshot("autostart-settings.png");
+        assert_stays(h, UiScreen::LauncherAutostart, Duration::from_secs(6));
+        p = h.state();
+        let root = back(h, &p);
+        // Countdown text is telemetry, so observation must not invalidate controls.
+        assert_stays(h, UiScreen::LauncherMain, Duration::from_secs(3));
+        assert_eq!(h.state().revision, root.revision);
+        h.press_guarded(UiAction::Down, &root);
+        assert_stays(h, UiScreen::LauncherMain, Duration::from_secs(3));
+        let game = wait_screen(h, UiScreen::Gameplay);
+        assert_eq!(game.active_scenario.as_deref(), Some("clock"));
+        h.capture_screenshot("automatic-clock.png");
+        h.pause_guarded(&game);
+        let pause = wait_screen(h, UiScreen::PauseMain);
+        assert_stays(h, UiScreen::PauseMain, Duration::from_secs(6));
+        let root = h.activate_guarded("pause.return-to-launcher", &pause);
+        assert_eq!(root.screen, UiScreen::LauncherMain);
+        assert!(saved(h).autostart.enabled);
+        assert_eq!(saved(h).spacewars, before.spacewars);
+        assert_eq!(saved(h).launch, before.launch);
+        assert_eq!(saved(h).last_scenario, before.last_scenario);
+        assert_eq!(saved(h).audio, before.audio);
+        // Exit gracefully, then relaunch the same preferences in a new process.
+        h.activate_guarded("launcher.quit", &root);
+        let deadline = Instant::now() + TRANSITION_TIMEOUT;
+        while h.child.0.try_wait().unwrap().is_none() {
+            assert!(Instant::now() < deadline);
+            thread::sleep(POLL_INTERVAL);
+        }
+        let log = File::create(h.run_path().join("restarted-client.log")).unwrap();
+        h.child = OwnedChild(
+            Command::new(env!("CARGO_BIN_EXE_engine-client"))
+                .arg("--config-dir")
+                .arg(h.run_path().join("config"))
+                .env("SPACEWARS_CONTROL_SOCKET", &h._socket_path.0)
+                .env("SLINT_BACKEND", "winit-software")
+                .env_remove("WAYLAND_DISPLAY")
+                .stdin(Stdio::null())
+                .stdout(Stdio::from(log.try_clone().unwrap()))
+                .stderr(Stdio::from(log))
+                .spawn()
+                .unwrap(),
+        );
+        h.wait_until_ready();
+        let game = wait_screen(h, UiScreen::Gameplay);
+        assert_eq!(game.active_scenario.as_deref(), Some("clock"));
+        h.pause_guarded(&game);
+        let pause = wait_screen(h, UiScreen::PauseMain);
+        let root = h.activate_guarded("pause.return-to-launcher", &pause);
+        let mut p = preferences(h, &root);
+        h.activate_guarded("autostart.activity.previous", &p);
+        p = wait_saved(h);
+        assert_eq!(control_value(&p, "autostart.activity.next"), Some("Off"));
+        back(h, &p);
+        assert_stays(h, UiScreen::LauncherMain, Duration::from_secs(6));
+        assert!(!saved(h).autostart.enabled);
+    });
+}
+
+#[test]
+#[ignore = "requires an explicit display; CI runs this test under Xvfb"]
+fn autostart_bot_matches_use_match_results_repeat_fresh_worlds_and_preserve_humans() {
+    let mut settings = engine_common::Settings::default();
+    settings.audio.muted = true;
+    settings.autostart.enabled = true;
+    settings.autostart.activity = "spacewars-bots".into();
+    settings.autostart.delay_seconds = 5;
+    settings.spacewars_match.time_limit_seconds = 3;
+    run("autostart-bots", settings, |h| {
+        h.wait_until_ready();
+        let before = saved(h);
+        let first = wait_screen(h, UiScreen::Gameplay);
+        h.pause_guarded(&first);
+        wait_screen(h, UiScreen::PauseMain);
+        let paused = status(h);
+        assert!(paused.contains("match_player_1=rule_bot"));
+        assert!(paused.contains("match_player_2=rule_bot"));
+        let remaining = paused
+            .lines()
+            .find(|line| line.starts_with("match_remaining_seconds="))
+            .unwrap()
+            .to_owned();
+        assert_stays(h, UiScreen::PauseMain, Duration::from_secs(4));
+        assert!(status(h).contains(&remaining));
+        // Host resume is an explicit control operation, without simulated player input.
+        let pause = h.state();
+        h.activate_guarded("pause.resume", &pause);
+        let mut instances = BTreeSet::new();
+        let mut worlds = BTreeSet::new();
+        for round in 0..3 {
+            let result = wait_screen(h, UiScreen::GameOver);
+            assert!(instances.insert(result.scenario_revision.unwrap()));
+            let diagnostics = status(h);
+            assert!(diagnostics.contains("match_finish_reason=Some(TimeLimit)"));
+            h.capture_screenshot(&format!("result-{round}.png"));
+            let value = control_value(&result, "game-over.world-seed").unwrap();
+            assert!(worlds.insert(value.to_owned()));
+            assert_eq!(saved(h).spacewars, before.spacewars);
+            assert_eq!(saved(h).launch, before.launch);
+            assert_eq!(saved(h).spacewars_match, before.spacewars_match);
+            if round < 2 {
+                // Wait for the next running instance before looking for its result.
+                wait_screen(h, UiScreen::Gameplay);
+            } else {
+                assert!(diagnostics.contains("autostart_repeats=2"));
+                let root = h.press_guarded(UiAction::Start, &result);
+                assert_eq!(root.screen, UiScreen::LauncherMain);
+                assert_stays(h, UiScreen::LauncherMain, Duration::from_secs(2));
+            }
+        }
+        let root = h.state();
+        let p = preferences(h, &root);
+        h.activate_guarded("autostart.activity.next", &p);
+        let p = wait_saved(h);
+        back(h, &p);
+        assert_stays(h, UiScreen::LauncherMain, Duration::from_secs(6));
+        assert!(!saved(h).autostart.enabled);
+    });
+}

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -2,6 +2,14 @@
 
 export struct DeviceInfoRow { id: string, label: string, value: string }
 
+export global UserActivity {
+    callback notify() -> bool;
+    callback key-event(string, bool) -> bool;
+    callback focus-lost();
+    in-out property <bool> pointer-held: false;
+    in-out property <bool> gamepad-held: false;
+}
+
 export enum PrimitiveKind {
     path,
     text,
@@ -146,8 +154,17 @@ component MenuButton inherits Rectangle {
         width: parent.width;
         height: parent.height;
         mouse-cursor: pointer;
+        pointer-event(event) => {
+            if (event.kind == PointerEventKind.down) {
+                UserActivity.pointer-held = true;
+                UserActivity.notify();
+            } else if (event.kind == PointerEventKind.up || event.kind == PointerEventKind.cancel) {
+                UserActivity.pointer-held = false;
+                UserActivity.notify();
+            }
+        }
         clicked => {
-            root.activated();
+            if (!UserActivity.notify()) { root.activated(); }
         }
     }
 }
@@ -418,6 +435,21 @@ export component MainWindow inherits Window {
     in property <[string]> clock-event-labels;
     in-out property <bool> clock-controls-pending: false;
     in property <string> clock-settings-error: "";
+    in-out property <string> launcher-match-length: "10 min";
+    in-out property <bool> autostart-settings-visible: false;
+    in-out property <int> autostart-focus-index: 0;
+    in property <string> autostart-choice: "Off";
+    in property <string> autostart-delay: "30";
+    in property <bool> autostart-start-available: false;
+    in-out property <bool> autostart-running: false;
+    in-out property <string> autostart-activity: "";
+    in-out property <string> autostart-caption: "";
+    in-out property <string> autostart-diagnostics: "";
+    in-out property <string> scenario-instance: "";
+    callback autostart-open();
+    callback autostart-adjust(int, int);
+    callback autostart-start-now();
+    callback autostart-return();
     in-out property <bool> sound-visible: false;
     in-out property <bool> device-info-visible: false;
     in property <bool> device-info-ready: false;
@@ -1269,13 +1301,14 @@ export component MainWindow inherits Window {
                 x: 24px;
                 y: 140px;
                 width: parent.width - 48px;
-                text: "A selects  ·  Start rematches  ·  B returns to launcher";
+                text: root.autostart-running ? "Automatic match · Press a button for the launcher" : "A selects  ·  Start rematches  ·  B returns to launcher";
                 color: #80d8ff;
                 font-size: 13px;
                 horizontal-alignment: center;
             }
 
             MenuButton {
+                visible: !root.autostart-running;
                 x: 24px;
                 y: root.launcher-material-match ? 180px : 150px;
                 width: root.launcher-material-match ? (parent.width - 68px) / 3 : (parent.width - 58px) / 2;
@@ -1289,7 +1322,7 @@ export component MainWindow inherits Window {
             }
 
             MenuButton {
-                visible: root.launcher-material-match;
+                visible: root.launcher-material-match && !root.autostart-running;
                 x: 24px + (parent.width - 38px) / 3;
                 y: 180px;
                 width: (parent.width - 68px) / 3;
@@ -1303,12 +1336,12 @@ export component MainWindow inherits Window {
             }
 
             MenuButton {
-                x: root.launcher-material-match ? 24px + 2 * (parent.width - 38px) / 3 : parent.width / 2 + 5px;
+                x: root.autostart-running ? (parent.width - self.width) / 2 : root.launcher-material-match ? 24px + 2 * (parent.width - 38px) / 3 : parent.width / 2 + 5px;
                 y: root.launcher-material-match ? 180px : 150px;
                 width: root.launcher-material-match ? (parent.width - 68px) / 3 : (parent.width - 58px) / 2;
                 height: 64px;
                 text: "Launcher";
-                selected: root.game-over-focus-index == (root.launcher-material-match ? 2 : 1);
+                selected: root.autostart-running || root.game-over-focus-index == (root.launcher-material-match ? 2 : 1);
                 activated => {
                     root.game-over-focus-index = root.launcher-material-match ? 2 : 1;
                     root.ingame-return-launcher();
@@ -1324,7 +1357,12 @@ export component MainWindow inherits Window {
         focus-on-click: true;
         focus-on-tab-navigation: false;
 
+        capture-key-released(event) => {
+            if (UserActivity.key-event(event.text, false)) { return accept; }
+            return reject;
+        }
         capture-key-pressed(event) => {
+            if (UserActivity.key-event(event.text, true)) { return accept; }
             if (root.launcher-busy) { return accept; }
             if (event.text == Key.Escape) {
                 root.keyboard-action(5, event.repeat);
@@ -1384,13 +1422,25 @@ export component MainWindow inherits Window {
             width: parent.width;
             height: parent.height;
             background: #050514;
+            TouchArea {
+                width: parent.width; height: parent.height;
+                pointer-event(event) => {
+                    if (event.kind == PointerEventKind.down) {
+                        UserActivity.pointer-held = true;
+                        UserActivity.notify();
+                    } else if (event.kind == PointerEventKind.up || event.kind == PointerEventKind.cancel) {
+                        UserActivity.pointer-held = false;
+                        UserActivity.notify();
+                    }
+                }
+            }
 
             MenuPage {
                 available-width: parent.width; available-height: parent.height;
                 // Scenario-specific forms retain their existing geometry in this pass.
                 height: Math.min(parent.height - 24px, root.launcher-controls-visible || root.launcher-settings-visible ? 440px : 520px);
                 heading: root.launcher-settings-visible ? "Scenario Settings" : root.launcher-controls-visible ? "Controls" : "Space-Wars";
-                subtitle: root.launcher-error-text != "" ? root.launcher-error-text : root.launcher-settings-visible && root.launcher-material-match ? "World seed: " + root.launcher-seed-text : root.launcher-controls-visible || root.launcher-settings-visible ? root.launcher-scenario-title : "Choose a scenario";
+                subtitle: root.launcher-error-text != "" ? root.launcher-error-text : root.launcher-settings-visible && root.launcher-material-match ? "World seed: " + root.launcher-seed-text : root.launcher-controls-visible || root.launcher-settings-visible ? root.launcher-scenario-title : root.autostart-caption != "" ? root.autostart-caption : "Choose a scenario";
                 error: root.launcher-error-text != "";
                 hint: root.launcher-controls-visible || root.launcher-settings-visible ? "" : root.launcher-focus-index == 0 ? (self.width < 600px ? "Left / Right browse · A confirm" : "Left / Right browse · A / Enter confirm · Start plays") : self.width < 600px ? "D-pad move · A select · Tap to choose" : "D-pad / arrows move · A / Enter selects · Tap to choose";
 
@@ -2006,13 +2056,24 @@ export component MainWindow inherits Window {
                         vertical-alignment: center;
                     }
 
+                    if root.launcher-material-match: ChoiceRow {
+                        y: 208px;
+                        width: parent.width;
+                        height: 48px;
+                        label: "Match length";
+                        value: root.launcher-match-length;
+                        selected: root.launcher-settings-focus-index == 8;
+                        previous => { root.launcher-settings-focus-index = 8; root.ui-action(2); }
+                        next => { root.launcher-settings-focus-index = 8; root.ui-action(3); }
+                    }
+
                     MenuButton {
                         x: 0px;
-                        y: root.launcher-scenario == "clock" ? 314px : root.launcher-material-combat ? 270px : root.launcher-spacewars-settings || root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
+                        y: root.launcher-scenario == "clock" ? 314px : root.launcher-material-combat || root.launcher-material-match ? 270px : root.launcher-spacewars-settings || root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
                         width: 150px;
                         height: 44px;
                         text: "Back";
-                        selected: root.launcher-settings-focus-index == (root.launcher-material-match ? 8 : root.launcher-classic-spacewars ? 7 : root.launcher-scenario == "clock" ? 11 : root.launcher-material-combat ? 7 : root.launcher-material-travel ? 4 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : (root.launcher-scenario == "surface-expedition" || root.launcher-scenario == "spacewars-terrain") ? 3 : 2);
+                        selected: root.launcher-settings-focus-index == (root.launcher-material-match ? 9 : root.launcher-classic-spacewars ? 7 : root.launcher-scenario == "clock" ? 11 : root.launcher-material-combat ? 7 : root.launcher-material-travel ? 4 : root.launcher-scenario == "pizza" ? 4 : root.launcher-scenario == "falling" ? 0 : root.launcher-scenario == "nes" ? 1 : (root.launcher-scenario == "surface-expedition" || root.launcher-scenario == "spacewars-terrain") ? 3 : 2);
                         activated => {
                             root.launcher-settings-visible = false;
                         }
@@ -2020,7 +2081,7 @@ export component MainWindow inherits Window {
 
                     MenuButton {
                         x: parent.width - 180px;
-                        y: root.launcher-scenario == "clock" ? 314px : root.launcher-material-combat ? 270px : root.launcher-spacewars-settings || root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
+                        y: root.launcher-scenario == "clock" ? 314px : root.launcher-material-combat || root.launcher-material-match ? 270px : root.launcher-spacewars-settings || root.launcher-scenario == "pizza" ? 218px : root.launcher-scenario == "falling" ? 114px : 166px;
                         width: 180px;
                         height: 44px;
                         text: root.launcher-material-match ? "Play World" : "Start Game";
@@ -2314,7 +2375,7 @@ export component MainWindow inherits Window {
         }
     }
 
-    if root.sound-visible && !root.device-info-visible && (root.launcher-visible || root.ingame-menu-visible): Rectangle {
+    if root.sound-visible && !root.device-info-visible && !root.autostart-settings-visible && (root.launcher-visible || root.ingame-menu-visible): Rectangle {
         width: parent.width;
         height: parent.height;
         background: #050514;
@@ -2335,7 +2396,7 @@ export component MainWindow inherits Window {
                 property <length> row-height: parent.row-height;
                 property <length> scroll-limit: Math.max(0px, self.viewport-height - self.height);
                 function reveal-focus() {
-                    if self.focused-item >= 0 && self.focused-item < 4 {
+                    if self.focused-item >= 0 && self.focused-item < 5 {
                         let top = self.focused-item * (self.row-height + 10px);
                         let bottom = top + self.row-height;
                         if -self.viewport-y > top { self.viewport-y = -top; }
@@ -2348,7 +2409,7 @@ export component MainWindow inherits Window {
                 init => { self.reveal-focus(); }
                 settings-body := Rectangle {
                     x: 0px; y: 0px;
-                    width: settings-scroll.width; height: 4 * settings-scroll.row-height + 30px;
+                    width: settings-scroll.width; height: 5 * settings-scroll.row-height + 40px;
                     VolumeRow {
                         x: 0px; y: 0px;
                         width: parent.width; height: settings-scroll.row-height;
@@ -2373,6 +2434,12 @@ export component MainWindow inherits Window {
                         width: parent.width; height: settings-scroll.row-height;
                         label: "Device Info"; navigation: true; selected: root.sound-focus-index == 3;
                         activated => { root.device-info-open(); }
+                    }
+                    SettingsRow {
+                        y: 4 * (settings-scroll.row-height + 10px);
+                        width: parent.width; height: settings-scroll.row-height;
+                        label: "Auto-start"; navigation: true; selected: root.sound-focus-index == 4;
+                        activated => { root.autostart-open(); }
                     }
                 }
             }
@@ -2403,14 +2470,14 @@ export component MainWindow inherits Window {
                 width: root.settings-save-error == "" ? parent.width - 48px : (parent.width - 60px) / 2;
                 height: 48px;
                 text: "Back";
-                selected: root.sound-focus-index == 4;
+                selected: root.sound-focus-index == 5;
                 activated => { root.sound-visible = false; }
             }
             if root.settings-save-error != "": MenuButton {
                 x: parent.width / 2 + 6px; y: parent.height - 84px;
                 width: (parent.width - 60px) / 2; height: 48px;
                 text: "Retry Save";
-                selected: root.sound-focus-index == 5;
+                selected: root.sound-focus-index == 6;
                 activated => { root.sound-retry(); }
             }
         }
@@ -2552,6 +2619,66 @@ export component MainWindow inherits Window {
                 color: #a7b4c8;
                 font-size: 13px;
                 horizontal-alignment: center;
+            }
+        }
+    }
+
+    if root.autostart-settings-visible && root.sound-visible: Rectangle {
+        width: parent.width; height: parent.height;
+        background: #050514;
+        TouchArea { width: parent.width; height: parent.height; }
+        MenuPage {
+            available-width: parent.width; available-height: parent.height;
+            heading: "Auto-start";
+            subtitle: "Runs when the launcher is idle";
+            hint: self.width < 600px ? "← / → adjust · A select · B / Esc back" : "Left / Right adjust · A / Enter selects · B / Esc back";
+            property <length> row-height: self.height >= 500px ? 64px : 52px;
+            ChoiceRow {
+                x: 24px; y: 82px; width: parent.width - 48px; height: parent.row-height;
+                label: "Activity"; value: root.autostart-choice; label-fraction: 0.3;
+                selected: root.autostart-focus-index == 0;
+                previous => { root.autostart-adjust(0, -1); }
+                next => { root.autostart-adjust(0, 1); }
+            }
+            ChoiceRow {
+                x: 24px; y: 92px + parent.row-height; width: parent.width - 48px; height: parent.row-height;
+                label: "Start after"; value: root.autostart-delay + " s";
+                selected: root.autostart-focus-index == 1;
+                previous => { root.autostart-adjust(1, -1); }
+                next => { root.autostart-adjust(1, 1); }
+            }
+            Text {
+                x: 24px; y: parent.height - 124px; width: parent.width - 48px; height: 32px;
+                text: root.settings-save-error != "" ? "Could not save. Back to App Settings to retry." : root.settings-save-pending ? "Saving…" : "Saved · Stays enabled until switched off";
+                color: root.settings-save-error != "" ? #ffb0a0 : #9fb4cc;
+                wrap: word-wrap; font-size: 14px;
+                vertical-alignment: center; horizontal-alignment: center;
+            }
+            MenuButton {
+                x: 24px; y: parent.height - 84px; width: (parent.width - 60px) / 2; height: 48px;
+                text: "Start now"; selected: root.autostart-focus-index == 2;
+                enabled: root.launcher-visible && root.autostart-start-available && !root.settings-save-pending && root.settings-save-error == "";
+                activated => { root.autostart-start-now(); }
+            }
+            MenuButton {
+                x: parent.width / 2 + 6px; y: parent.height - 84px; width: (parent.width - 60px) / 2; height: 48px;
+                text: "Back"; selected: root.autostart-focus-index == 3;
+                activated => { root.autostart-settings-visible = false; }
+            }
+        }
+    }
+    if root.autostart-running && !root.ingame-menu-visible: Rectangle {
+        width: parent.width; height: parent.height;
+        background: transparent;
+        Text {
+            x: 12px; y: parent.height - 24px; width: parent.width - 24px;
+            text: root.autostart-caption; color: #ffffff; font-size: 12px;
+            horizontal-alignment: center;
+        }
+        TouchArea {
+            width: parent.width; height: parent.height;
+            pointer-event(event) => {
+                if (event.kind == PointerEventKind.down) { UserActivity.notify(); }
             }
         }
     }

--- a/crates/engine-client/ui/main.slint
+++ b/crates/engine-client/ui/main.slint
@@ -2631,7 +2631,7 @@ export component MainWindow inherits Window {
             available-width: parent.width; available-height: parent.height;
             heading: "Auto-start";
             subtitle: "Runs when the launcher is idle";
-            hint: self.width < 600px ? "← / → adjust · A select · B / Esc back" : "Left / Right adjust · A / Enter selects · B / Esc back";
+            hint: self.width < 600px ? "Left / Right adjust · A select · B / Esc back" : "Left / Right adjust · A / Enter selects · B / Esc back";
             property <length> row-height: self.height >= 500px ? 64px : 52px;
             ChoiceRow {
                 x: 24px; y: 82px; width: parent.width - 48px; height: parent.row-height;

--- a/crates/engine-common/src/activity_settings.rs
+++ b/crates/engine-common/src/activity_settings.rs
@@ -1,0 +1,78 @@
+//! Persistent match and unattended-activity preferences.
+
+use serde::{Deserialize, Deserializer, Serialize, de::IgnoredAny};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MatchSettings {
+    /// Zero permits an unlimited match. Positive values are gameplay seconds.
+    #[serde(deserialize_with = "match_seconds")]
+    pub time_limit_seconds: u32,
+}
+
+impl Default for MatchSettings {
+    fn default() -> Self {
+        Self {
+            time_limit_seconds: 600,
+        }
+    }
+}
+
+impl MatchSettings {
+    pub fn normalized(self) -> Self {
+        Self {
+            time_limit_seconds: self.time_limit_seconds.min(3600),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AutostartSettings {
+    pub enabled: bool,
+    /// Stable catalog ID; retain unknown IDs so unavailable activities are visible.
+    pub activity: String,
+    #[serde(deserialize_with = "idle_seconds")]
+    pub delay_seconds: u32,
+}
+
+impl Default for AutostartSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            activity: "clock".into(),
+            delay_seconds: 30,
+        }
+    }
+}
+
+impl AutostartSettings {
+    pub fn normalized(&self) -> Self {
+        Self {
+            delay_seconds: self.delay_seconds.clamp(5, 600),
+            ..self.clone()
+        }
+    }
+}
+
+// Invalid individual timer fields must not discard unrelated saved preferences.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Seconds {
+    Valid(u32),
+    Invalid(IgnoredAny),
+}
+
+fn match_seconds<'de, D: Deserializer<'de>>(d: D) -> Result<u32, D::Error> {
+    Ok(match Seconds::deserialize(d)? {
+        Seconds::Valid(n) => n.min(3600),
+        Seconds::Invalid(_) => MatchSettings::default().time_limit_seconds,
+    })
+}
+
+fn idle_seconds<'de, D: Deserializer<'de>>(d: D) -> Result<u32, D::Error> {
+    Ok(match Seconds::deserialize(d)? {
+        Seconds::Valid(n) => n.clamp(5, 600),
+        Seconds::Invalid(_) => AutostartSettings::default().delay_seconds,
+    })
+}

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -10,7 +10,9 @@ use serde::{
     de::{IgnoredAny, MapAccess, SeqAccess, Visitor},
 };
 
+mod activity_settings;
 mod clock_message;
+pub use activity_settings::{AutostartSettings, MatchSettings};
 pub mod render;
 
 pub use clock_message::{ClockMarqueeMessage, ClockMessageError, MAX_CLOCK_MESSAGE_BYTES};
@@ -121,6 +123,8 @@ impl std::error::Error for SimError {}
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
+    pub autostart: AutostartSettings,
+    pub spacewars_match: MatchSettings,
     pub video: VideoSettings,
     pub audio: AudioSettings,
     pub controls: ControlBindings,

--- a/crates/spacewars-cli/src/main.rs
+++ b/crates/spacewars-cli/src/main.rs
@@ -164,6 +164,8 @@ enum UiScreenArg {
     LauncherSound,
     #[value(name = "launcher.info")]
     LauncherInfo,
+    #[value(name = "launcher.autostart")]
+    LauncherAutostart,
     #[value(name = "launcher.settings")]
     LauncherSettings,
     #[value(name = "launcher.controls")]
@@ -178,6 +180,8 @@ enum UiScreenArg {
     PauseSound,
     #[value(name = "pause.info")]
     PauseInfo,
+    #[value(name = "pause.autostart")]
+    PauseAutostart,
     #[value(name = "pause.controls")]
     PauseControls,
     #[value(name = "pause.clock")]
@@ -193,6 +197,7 @@ impl From<UiScreenArg> for UiScreen {
             UiScreenArg::LauncherMain => Self::LauncherMain,
             UiScreenArg::LauncherSound => Self::LauncherSound,
             UiScreenArg::LauncherInfo => Self::LauncherInfo,
+            UiScreenArg::LauncherAutostart => Self::LauncherAutostart,
             UiScreenArg::LauncherSettings => Self::LauncherSettings,
             UiScreenArg::LauncherControls => Self::LauncherControls,
             UiScreenArg::LauncherTouchTest => Self::LauncherTouchTest,
@@ -200,6 +205,7 @@ impl From<UiScreenArg> for UiScreen {
             UiScreenArg::PauseMain => Self::PauseMain,
             UiScreenArg::PauseSound => Self::PauseSound,
             UiScreenArg::PauseInfo => Self::PauseInfo,
+            UiScreenArg::PauseAutostart => Self::PauseAutostart,
             UiScreenArg::PauseControls => Self::PauseControls,
             UiScreenArg::PauseClock => Self::PauseClock,
             UiScreenArg::GameOver => Self::GameOver,

--- a/crates/spacewars-control/src/lib.rs
+++ b/crates/spacewars-control/src/lib.rs
@@ -31,6 +31,8 @@ pub enum UiScreen {
     LauncherSound,
     #[serde(rename = "launcher.info")]
     LauncherInfo,
+    #[serde(rename = "launcher.autostart")]
+    LauncherAutostart,
     #[serde(rename = "launcher.settings")]
     LauncherSettings,
     #[serde(rename = "launcher.controls")]
@@ -45,6 +47,8 @@ pub enum UiScreen {
     PauseSound,
     #[serde(rename = "pause.info")]
     PauseInfo,
+    #[serde(rename = "pause.autostart")]
+    PauseAutostart,
     #[serde(rename = "pause.controls")]
     PauseControls,
     #[serde(rename = "pause.clock")]
@@ -60,6 +64,7 @@ impl UiScreen {
             Self::LauncherMain => "launcher.main",
             Self::LauncherSound => "launcher.sound",
             Self::LauncherInfo => "launcher.info",
+            Self::LauncherAutostart => "launcher.autostart",
             Self::LauncherSettings => "launcher.settings",
             Self::LauncherControls => "launcher.controls",
             Self::LauncherTouchTest => "launcher.touch-test",
@@ -67,6 +72,7 @@ impl UiScreen {
             Self::PauseMain => "pause.main",
             Self::PauseSound => "pause.sound",
             Self::PauseInfo => "pause.info",
+            Self::PauseAutostart => "pause.autostart",
             Self::PauseControls => "pause.controls",
             Self::PauseClock => "pause.clock",
             Self::GameOver => "game-over",
@@ -80,6 +86,7 @@ impl UiScreen {
                 | Self::LauncherMain
                 | Self::LauncherSound
                 | Self::LauncherInfo
+                | Self::LauncherAutostart
                 | Self::LauncherSettings
                 | Self::LauncherControls
                 | Self::LauncherTouchTest

--- a/docs/auto-start.md
+++ b/docs/auto-start.md
@@ -1,0 +1,77 @@
+# Automatic activities
+
+Open **App Settings → Auto-start** from the launcher or a paused scenario.
+Choose **Off**, **Clock**, or **Spacewars bots**, then choose the idle delay.
+The default is Off with a 30-second delay. Controller stops are 5, 10, 30,
+60, 120, 300, and 600 seconds. **Start now** previews an enabled activity
+from the launcher after its settings have saved.
+
+The preference stays enabled across client/device restarts until switched Off.
+Only the root launcher counts as idle. Input resets its countdown; held
+controls prevent expiry. Settings, Info, Controls, paused sessions, and manual
+games suspend it. Returning to the root launcher starts the full delay again.
+
+Clock uses the saved Clock configuration. Spacewars bots starts the ordinary
+destructible match with two rule bots and a fresh world. Each result remains
+visible for eight seconds before another fresh world starts. The match's own
+time-limit rule applies; automatic play adds no separate deadline. Unlimited
+matches can therefore continue indefinitely until a pilot dies.
+
+Press a key/gamepad button or touch a running automatic activity to return to
+the launcher. That input is consumed before the menu is exposed. The idle
+countdown then starts again. A session deliberately paused through the host
+API uses the normal pause menu: Resume continues automatic play; returning to
+the launcher ends it. Controller disconnection does not pause unattended
+activities, while manual play retains its disconnection protection.
+
+Automatic controllers, world seeds, and scenario choices are temporary. They
+do not overwrite saved human-player choices, manual launch defaults, or audio.
+Read-only status queries and screenshots do not reset the countdown.
+
+Explicit direct launches (`--scenario`, `--rom`, `--kiosk`), benchmarks, render
+probes, and touch diagnostics suppress idle auto-start for that process.
+Launch/restart errors suppress further automatic attempts until an explicit
+Start now/retry, an auto-start settings change, or a client restart. Off and
+unavailable activities never launch silently.
+
+## Saved settings and automation
+
+```toml
+[autostart]
+enabled = true
+activity = "clock" # or "spacewars-bots"
+delay_seconds = 30
+
+[spacewars_match]
+time_limit_seconds = 600 # 0 means Unlimited
+```
+
+The file accepts idle delays from 5–600 seconds and finite match lengths from
+1–3600 seconds. The UI offers common minute choices for matches. Old files
+receive defaults; invalid timer fields fall back individually. Unknown
+activity IDs are retained and shown as unavailable.
+
+Use the existing structured UI API:
+
+```sh
+spacewars-cli ui activate launcher.sound
+spacewars-cli ui activate settings.autostart
+spacewars-cli ui state --json
+spacewars-cli ui activate autostart.activity.next
+spacewars-cli ui activate autostart.delay.previous
+spacewars-cli ui activate autostart.back
+spacewars-cli ui activate sound.back
+spacewars-cli status
+```
+
+Screens are `launcher.autostart` and `pause.autostart`. Read
+`autostart.save-status` before sending another guarded edit or starting a
+preview: saving can change control availability and therefore the UI revision.
+Countdown display updates alone do not change actionable UI revisions.
+
+`status` reports the activity, phase, session kind, delay, and repeat count.
+Spacewars diagnostics additionally report the effective controllers, remaining
+gameplay seconds, ownership counts, and finish reason/result.
+
+The [design and extension plan](design/auto-start-activities.md) describes the
+small activity catalog and future screen, simulation, and training adapters.

--- a/docs/auto-start.md
+++ b/docs/auto-start.md
@@ -1,7 +1,9 @@
 # Automatic activities
 
 Open **App Settings → Auto-start** from the launcher or a paused scenario.
-Choose **Off**, **Clock**, or **Spacewars bots**, then choose the idle delay.
+Auto-start is below Device Info in the scrolling list; D-pad/arrow navigation
+reveals the selected row. Choose **Off**, **Clock**, or **Spacewars bots**, then
+choose the idle delay.
 The default is Off with a 30-second delay. Controller stops are 5, 10, 30,
 60, 120, 300, and 600 seconds. **Start now** previews an enabled activity
 from the launcher after its settings have saved.

--- a/docs/design/auto-start-activities.md
+++ b/docs/design/auto-start-activities.md
@@ -1,6 +1,6 @@
 # Automatic activities
 
-Status: first implementation desktop-validated, 2026-09-11, on
+Status: first implementation validated and deployed to `sw-picade`, 2026-09-11, on
 `auto-start-activities`. Includes merged main `4f8894e` and the committed
 Device Info change `2e6791f`. See [the user guide](../auto-start.md) for current
 controls and saved settings.
@@ -314,3 +314,24 @@ consider rotation/playlists and time-of-day schedules only when requested.
 The numbered verification plan above also lists useful future fault-injection
 cases. It is not a claim that every error, stale callback, or direct-launch
 combination has a dedicated end-to-end test.
+
+### Cabinet check
+
+Deployed application/CLI build `8041b952ac4c` to `sw-picade.local` using the
+restricted fast updater. Its runtime fingerprint matched the installed image;
+binary hashes matched the bundle after deployment, and the kiosk kept one
+healthy process with zero restarts throughout the checks. Device Info confirmed
+the build, cabinet controls as Player 1, and Xbox 360 controller as Player 2.
+
+Through the structured UI API, Clock remained in Auto-start settings beyond
+the configured five-second delay, launched after returning to the launcher,
+and returned to the menu on an available input action. Spacewars then launched
+with both effective rule bots and its ordinary ten-minute timer counting down.
+Host pause/return ended the automatic match cleanly. Every pre-existing saved
+setting compared equal afterward, including audio and controller choices.
+
+Left the cabinet on Auto-start settings with **Off**, a **30-second** delay,
+and the default **10-minute** match limit. Captured real device screenshots of
+Clock, bot play, and the settings screen. The three completed repeat rounds
+were verified in desktop full-client tests; this cabinet smoke check did not
+wait for three full ten-minute rounds or simulate physical gamepad presses.

--- a/docs/design/auto-start-activities.md
+++ b/docs/design/auto-start-activities.md
@@ -2,9 +2,9 @@
 
 Status: updated against merged main `07b9dc0` (Device Info and responsive kiosk
 menus, PR #70) on `auto-start-activities`, now checked out directly in
-`/home/data/workspace/space-wars2`. The earlier cabinet validation described
-below used build `8041b952ac4c`; this layout integration has not been deployed
-as part of this update. See [the user guide](../auto-start.md) for controls and settings.
+`/home/data/workspace/space-wars2`. Build `d12853e12f73`, including the layout
+integration, is deployed to both `sw-picade.local` and `sw-picade-2.local`.
+See [the user guide](../auto-start.md) for controls and settings.
 
 ## Goal and first slice
 
@@ -356,5 +356,34 @@ launcher navigation, saved sound settings, manual controller choices, and
 rematches/new worlds. Rendering comparisons cover 800×480, 1024×768, and
 480×800, including Auto-start, save errors, and match settings.
 
-No PR was open for the auto-start branch at this point. The updated branch is
-local; this integration does not publish a PR or redeploy the cabinet.
+No PR was open for the auto-start branch at this point. The updated branch
+remained local; cabinet deployment followed below.
+
+### Both cabinets — responsive-menu build
+
+Deployed application and CLI build `d12853e12f73` to `sw-picade.local` and
+`sw-picade-2.local` using the restricted fast updater, with an application
+restart and no reboot. The second cabinet's actual hostname contains the
+hyphen before `2`; `sw-picade2.local` did not resolve. Both installed runtime
+fingerprints matched the bundle, and both installed binary hashes matched its
+manifest. The cross-build compiled from the primary `space-wars2` checkout.
+
+On each cabinet, Device Info reported the expected revision, the kiosk stayed
+active with zero restarts during verification, and structured UI navigation
+reached the fifth App Settings row and opened Auto-start. Real screenshots
+confirmed the focused row and the Auto-start layout. `sw-picade` reported its
+cabinet controls as Player 1 and the Xbox 360 controller as Player 2;
+`sw-picade-2` reported cabinet controls as Player 1 only.
+
+Every pre-existing saved preference compared equal before and after deployment.
+The settings loader filled missing fields with their documented defaults:
+Auto-start Off, delay 30 seconds, and match limit 600 seconds on both cabinets;
+the older second cabinet also gained explicit default Player 1, combat-break,
+and material-combat fields. Both were left on Auto-start settings with Off and
+a 30-second delay. Physical button testing and full-duration unattended rounds
+remain playtest follow-ups; the desktop lifecycle checks above cover repeat
+rounds and persistence.
+
+Build/deploy logs, the bundle manifest, before/after settings, Device Info,
+service checks, and screenshots are archived locally under
+`/home/oldman/.codex/visualizations/2026/09/11/two-picade-autostart-deploy/`.

--- a/docs/design/auto-start-activities.md
+++ b/docs/design/auto-start-activities.md
@@ -1,0 +1,316 @@
+# Automatic activities
+
+Status: first implementation desktop-validated, 2026-09-11, on
+`auto-start-activities`. Includes merged main `4f8894e` and the committed
+Device Info change `2e6791f`. See [the user guide](../auto-start.md) for current
+controls and saved settings.
+
+## Goal and first slice
+
+Let each cabinet choose what to run unattended after a configurable delay:
+Clock or repeated two-bot matches in the ordinary destructible `spacewars`
+scenario. Keep a small common lifecycle so future targets can include Device
+Info, a gardening simulation, or a training activity.
+
+The confirmed trigger is **launcher inactivity**, including after device
+startup. Auto-start is sticky: once enabled, the saved activity and delay
+remain in effect across launcher visits and device restarts until the user
+turns it off. Each eligible launcher visit starts a full countdown; deliberate
+interaction resets it. The countdown starts when the launcher is ready,
+not during OS boot or asset loading. Default to disabled on existing and new
+installations until explicitly enabled.
+
+First implementation:
+
+- App Settings has an **Auto-start** child screen next to Device Info.
+- **Activity:** Off / Clock / Spacewars bots.
+- **Start after:** configurable idle delay; 30 seconds by default,
+  accepting 5–600 seconds, with controller stops of
+  5, 10, 30, 60, 120, 300, and 600 seconds.
+- **Start now:** previews the configured automatic activity using the same
+  launch path as timeout expiry.
+- The root launcher shows, for example, “Clock starts in 24 seconds.”
+- Clock runs continuously with its saved Clock configuration.
+- Spacewars starts a fresh world with both seats using the existing rule bot.
+  After a finished round, show its actual result for 8 seconds, then start
+  another fresh world. It uses the ordinary match's time-limit setting and
+  completion result. The 8-second result display is activity policy; the
+  match duration belongs to Spacewars rules and settings.
+
+## Match time limit
+
+The time limit belongs to the match itself, as requested by the user. The
+implementation extends `MatchRound` in
+[`match_rules.rs`](../../scenarios/spacewars/src/surface_sortie/match_rules.rs)
+with duration, elapsed time, and a finish reason. Before this change, two living
+pilots could continue indefinitely. Three-minute simulation test budgets are
+still distinct from gameplay deadlines.
+
+**Match length** is a Spacewars scenario setting shared by human-versus-human,
+human-versus-bot, and bot-versus-bot matches. The UI offers 5, 10, or 15 minutes
+and Unlimited, defaulting to 10 minutes. The saved seconds field also supports
+short controlled fixtures without adding a demo-only deadline.
+
+The scenario owns configured duration, elapsed/remaining gameplay time, and
+the final result. Advance its clock using simulation time, freeze it when the
+match is paused or finished, and reset it for both rematches and fresh worlds.
+Show the remaining time in the HUD and expose it in match observations. This
+keeps the rule deterministic in headless tests and consistent with the rest
+of the simulation; ten gameplay minutes can take longer on a device whose
+simulation is running slowly.
+
+At the deadline, process that step's damage before evaluating expiry so a
+pilot death on the final step retains the existing elimination result.
+The confirmed expiry rule with both pilots alive is **most planets owned
+wins; equal ownership draws**. Count current surviving claims at the final
+step, including flags destroyed or neutralized during that step. Neutral
+planets score for neither player; owning zero planets each is a draw. Do not
+add other hidden tie-breakers or count past ownership.
+
+Record a finish reason independently of winner/draw so HUD, results, and
+diagnostics can distinguish pilot death, simultaneous deaths, and time expiry.
+Both the client result message and scenario-rendered result currently describe
+pilot deaths, so update both to use the actual reason. An expired match freezes
+through the existing match-completion path; its pilots need not be marked dead.
+
+The auto-start controller has no separate match deadline. It observes ordinary
+completion, displays the result, and requests a fresh world. It preserves the
+saved match length along with the other Spacewars preferences. Unlimited also
+means an unattended round can continue until elimination; there is no hidden
+demo cutoff. Historical labs/endurance fixtures without match rules remain
+unlimited unless they explicitly opt into a timed match.
+
+A finite match length also bounds stalemates such as the long landing/search
+stalls in [the investigation guide](../landing-investigation-guide.md) and
+[fresh-world survey](../fresh-world-survey.md). It is a gameplay rule for every
+match, independent of automatic repetition.
+
+## When the device yields to a person
+
+Only the idle root launcher can start an activity automatically. Settings,
+Controls, Device Info, loading, save errors, paused sessions, match results
+from manual play, and running manual scenarios are ineligible. Opening a
+submenu or choosing manual play suspends auto-start without disabling the
+saved preference. Returning to the root launcher starts a full new delay;
+time spent elsewhere does not count toward it.
+
+Keyboard/gamepad presses and deliberate pointer interaction reset the launcher
+countdown. Held controls keep the launcher active; the full idle delay starts
+after they are released. Capture interaction during initialization so held
+input before the launcher is ready cannot be forgotten. Ignore neutral
+controller polling, small stick drift, connection announcements, animation,
+and telemetry. Use the existing controller thresholds and handoff machinery
+where applicable.
+
+During an automatically started Clock or bot demo, an intentional input exits
+to the launcher and begins a fresh idle delay. Display a short “Press a button
+to return to the menu” hint. Consume that input and clear held actions before exposing
+the menu, so the same press cannot also start a game. Human takeover of a bot's
+ship is separate future work.
+
+Remote read-only inspection, including screenshots and status, does not count
+as activity. Mutating UI controls count as operator interaction. Host pause
+suspends automatic transitions and timing. A deliberately paused automatic
+session uses the ordinary pause menus; Resume continues the automatic session. Returning
+to the launcher ends it. These rules also make remote testing predictable.
+
+Automatic activities do not require a connected gamepad. The existing
+disconnect-to-pause protection must continue for manual play but must not
+strand an unattended Clock or two-bot session when a controller disconnects.
+
+Keep launcher idle eligibility separate from the running activity's lifecycle.
+Once a bot session starts, normal match completion continues its repeat loop
+without visiting the launcher. Interrupting the activity ends that loop while
+leaving the saved auto-start preference enabled. Changing Auto-start preferences
+applies when the user returns to the launcher, with a full delay. **Start now**
+remains an explicit way to preview the chosen activity immediately. Choosing
+Off disables future automatic starts and repeats until enabled again.
+
+A kiosk process restart reads the same saved preference and starts a fresh
+launcher countdown. No per-boot consumption marker or startup-only gate is
+needed. Both Pi and desktop use the same idle controller.
+
+## Reuse and required boundaries
+
+The current app already provides:
+
+- Safely persisted settings in `engine-common::Settings`, with background
+  writes and visible retry status in `settings_writer.rs` and
+  `sound_controls.rs`.
+- A single asynchronous launcher in `launcher.rs`, which prepares assets and
+  starts scenarios through the existing host.
+- `ScenarioControlRequest::NewMatch` in `host.rs`, which replaces a Spacewars
+  world, clears held input, and selects a fresh seed.
+- Host game-over state and scenario revisions, plus public UI/host control
+  APIs and real-process functional tests.
+- An existing Pi service command that shows the launcher. No service restart
+  loop, OS scheduling change, or additional simulation process is needed.
+
+Two existing persistence paths need explicit treatment. Manual launcher
+starts commit their selections; `on_match_world_changed` also saves the new
+seed and launch scenario. Automatic launches and repeats must bypass those
+manual preference writes. `handle_return_to_launcher` currently also carries
+the active Spacewars seed back to the launcher, so automatic exit must restore
+the manual selection instead.
+
+The client distinguishes automatic sessions by activity ID and suppresses idle
+launches for explicit CLI sessions. It keeps canonical saved settings separate
+from effective session settings. An automatic bot match clones the normal configuration,
+overrides only its two controllers and world seed, and passes that snapshot
+to the existing scenario host. Its repeats retain those effective overrides.
+Audio, renderer, Clock configuration, match length, bot breaks, and asteroid
+settings still come from the user's preferences. Normal audio/settings edits continue to
+save from the canonical settings object, never from the demo snapshot.
+
+Do not emulate button presses against the mutable launcher to start a demo.
+Factor a launch request/preparation boundary shared by manual and automatic
+starts, with an explicit persistence policy. Preserve the existing busy/error
+handling and only allow one start or replacement in flight.
+
+Explicit CLI launches (`--scenario`, `--rom`, `--kiosk`), benchmarks, render
+probes, and touch diagnostics suppress saved auto-start for that process.
+Their existing one-shot behavior takes precedence, including after returning
+to the launcher. Ordinary fullscreen launcher startup can honor auto-start.
+
+## Small activity catalog
+
+An activity is a named unattended use of the app. A scenario is one possible
+way to implement it. Keep a compile-time catalog with stable IDs and labels,
+an availability check, a start/stop adapter, and a completion policy:
+
+| Activity ID | Implementation | Completion behavior |
+| --- | --- | --- |
+| `clock` | Existing Clock scenario and saved configuration | Continuous |
+| `spacewars-bots` | Existing `spacewars`, fresh seed, two rule bots | Ordinary match completion, result delay, then fresh world |
+| Future `device-info` | Existing information screen | Continuous; stop its sampler on exit |
+| Future gardening activity | Its own scenario/session adapter | Decide resume versus fresh world when added |
+| Future training activity | Managed training job plus a progress view | Explicit job/checkpoint/stop semantics |
+
+Only implemented and available activities appear in the selector. This does
+not require a plugin system, arbitrary shell commands, or registering every
+lab/benchmark as a supported unattended activity. Do not refactor the entire
+scenario registry. The small activity catalog delegates to it where useful.
+
+The Device Info branch already gives App Settings a child screen and controls
+its worker through visibility. Reuse that screen later, adding an automatic
+entry/exit context so Back has a meaningful destination. It need not become
+a fake physics scenario. The committed Device Info navigation was integrated before the overlapping
+menu edits; the other checkout remains untouched.
+
+Future training needs a different stop contract: returning to the launcher
+may detach a view or request a checkpoint rather than destroy a job. Define
+that contract when a training activity exists. A small extensible catalog now
+is sufficient; a general task scheduler is not part of this slice.
+
+Saved shape:
+
+```toml
+[autostart]
+enabled = false
+activity = "clock"
+delay_seconds = 30
+```
+
+Off toggles `enabled` while preserving the last activity and delay. Store a
+stable activity ID, not a menu index or command line. Unknown/unavailable IDs
+remain readable, display an explanation, and suppress automatic launch rather
+than invalidating the whole settings file. Invalid timer fields normalize individually without discarding unrelated preferences.
+
+## Timing, errors, and observability
+
+Use one client-side controller with injected monotonic time for unit tests.
+Keep it outside the physics timestep; low rendering rates must not turn a
+30-second launcher delay into minutes. This controller owns only the launcher
+countdown and post-result delay. The scenario owns the match clock, measured
+in gameplay time as described above. Continuous Clock needs no periodic reset.
+
+The controller distinguishes disabled/ineligible, countdown, launching,
+running, result delay, and failed states. A start or replacement is requested
+once; its completion is acknowledged before another transition can occur.
+Tie delayed actions to the automatic session identity and scenario revision.
+If the user exits or starts something else, stale timer callbacks do nothing.
+
+Launch/restart failures stop automatic transitions and leave a visible error
+with a usable route to the launcher. A failed activity does not retry forever;
+an explicit retry/Start now, an auto-start configuration change, or a new
+client process can clear failure suppression. Merely waiting or revisiting
+the launcher does not retry the failed activity. This transient failure state
+does not turn off the saved preference. Manual launches remain available.
+
+The existing status API reports automatic activity ID, phase, session origin,
+repeat count, and configured delay. The visible caption shows the countdown.
+World seed and match finish reason are available through the host/result
+inventory and match diagnostics. A structured countdown and stop-reason history
+can be added when additional activity types need them.
+Add stable App Settings/Auto-start control IDs. Read-only countdown ticks
+should not invalidate action revision guards every second; use a telemetry
+field or otherwise distinguish changing display values from actionable state.
+This policy supplements existing strict screen/revision guards.
+
+## Implementation and verification order
+
+1. Add the shared match time-limit setting and scenario rule first. Test exact
+   expiry boundaries, zero-duration steps, pause/resume, reset, Unlimited,
+   final-step elimination precedence, ownership-based expiry results, and frozen
+   post-match state. Verify remaining time and finish reason in the HUD,
+   observations, and result screen. Exercise human/bot seat combinations and
+   keep untimed lab fixtures unchanged. Cover each player leading, tied
+   ownership (including zero each), neutral planets, and ownership changes
+   from capture or flag destruction on the final step.
+2. Add saved auto-start preferences, validation, the initial activity catalog,
+   and a deterministic controller. Test deadline boundaries, idle reset/suspension,
+   input-versus-timeout precedence, stale sessions, failure suppression, and
+   direct-launch precedence using virtual time. Cover full-delay rearming
+   after submenus, manual games, interrupted demos, settings changes, and kiosk
+   process restarts. Verify that disabling persists and prevents later starts.
+3. Add the launch request/session-origin boundary. Verify that automatic
+   controllers, seeds, last scenario, and manual launcher selections never
+   leak into saved preferences, including on repeat, exit, and save failure.
+4. Add the Auto-start screen and countdown through the existing keyboard,
+   gamepad, touch, and structured UI paths. Integrate Device Info navigation
+   first if available; preserve existing stable App Settings IDs.
+5. Wire Clock, then bot matches, to the existing host. Verify that both pilot
+   elimination and time-limit results lead to one fresh-world replacement. Use
+   controlled host fixtures to force results/errors; do not require bots to
+   win a randomly generated match before a UI test can pass.
+6. Run focused real-process workflows with isolated settings: settings survive
+   a new client process; Clock starts; input returns to the launcher without
+   firing a second action; bot seats are effective only for demos; multiple
+   fresh worlds replace cleanly; pause and read-only inspection behave as
+   specified; returning to the launcher and leaving it idle starts the saved
+   activity after a full delay. Check each new scenario revision and clean input/resource teardown,
+   not only screenshots.
+7. Run the relevant workspace and UI regression checks, then deploy to
+   `sw-picade`. Verify boot countdown, both physical controllers, entering
+   settings during countdown, manual play, Clock, and repeated bot rounds.
+   Observe at least three real unattended bot rounds, including a controlled
+   match-expiry path in tests. Capture settings and resulting runtime status.
+
+This delivers unattended Clock and bot matches with clear human control. Add
+Device Info as the next activity to verify the catalog works for a screen;
+consider rotation/playlists and time-of-day schedules only when requested.
+
+## Validation record — 2026-09-11
+
+- `cargo test --locked --workspace --all-targets` passed. Display-dependent
+  workflows remain explicitly ignored in that command. Subsequent focused
+  checks passed 289 client unit tests (one unrelated ignored test), 19 match
+  rule tests, and the physical final-step flag-destruction expiry test.
+- Two real-client auto-start workflows passed under a private Xvfb display.
+  Clock stayed in settings beyond the idle delay, launched from the idle
+  launcher, resumed from a host pause, survived a client restart, and stayed
+  disabled after Off. Three short bot matches completed on the ordinary match
+  timer and were replaced with fresh seeds/revisions. The host reported both
+  effective bot controllers while saved human settings remained unchanged.
+- Five existing UI workflows passed: launcher navigation, Device Info, sound
+  persistence, all manual controller choices with both renderers, and fresh
+  worlds/rematches/process restart. Backend-neutral Slint input checks verify
+  that keyboard repeats and touch release do not activate the newly exposed
+  launcher; focus-loss cleanup prevents a lost release blocking idle forever.
+- Default-duration endurance and physical cabinet-button testing are separate
+  playtest follow-ups. The short functional fixtures exercise the actual match
+  rule and host lifecycle without waiting ten minutes for each result.
+
+The numbered verification plan above also lists useful future fault-injection
+cases. It is not a claim that every error, stale callback, or direct-launch
+combination has a dedicated end-to-end test.

--- a/docs/design/auto-start-activities.md
+++ b/docs/design/auto-start-activities.md
@@ -1,9 +1,10 @@
 # Automatic activities
 
-Status: first implementation validated and deployed to `sw-picade`, 2026-09-11, on
-`auto-start-activities`. Includes merged main `4f8894e` and the committed
-Device Info change `2e6791f`. See [the user guide](../auto-start.md) for current
-controls and saved settings.
+Status: updated against merged main `07b9dc0` (Device Info and responsive kiosk
+menus, PR #70) on `auto-start-activities`, now checked out directly in
+`/home/data/workspace/space-wars2`. The earlier cabinet validation described
+below used build `8041b952ac4c`; this layout integration has not been deployed
+as part of this update. See [the user guide](../auto-start.md) for controls and settings.
 
 ## Goal and first slice
 
@@ -335,3 +336,25 @@ and the default **10-minute** match limit. Captured real device screenshots of
 Clock, bot play, and the settings screen. The three completed repeat rounds
 were verified in desktop full-client tests; this cabinet smoke check did not
 wait for three full ten-minute rounds or simulate physical gamepad presses.
+
+### Integration with merged responsive menus
+
+After PR #70 merged as `07b9dc0`, rebased the auto-start commits onto that
+main revision and dropped the already-merged Device Info precursor from the
+branch. The branch is now checked out directly in `space-wars2`.
+
+Auto-start uses `MenuPage`, its opaque background, responsive rows, 48-pixel
+actions, and fixed footer. App Settings places it below Device Info and
+updates the scroll extent and focus-reveal range for all five rows. The idle
+countdown occupies the new launcher's subtitle. The merged scenario-picker
+confirmation behavior and directional navigation are retained.
+
+Validation passed 291 client unit tests (one unrelated ignored), including
+keyboard/touch scrolling in an 800×360 window, and seven real-client UI
+workflows covering automatic Clock, three repeated bot results, Device Info,
+launcher navigation, saved sound settings, manual controller choices, and
+rematches/new worlds. Rendering comparisons cover 800×480, 1024×768, and
+480×800, including Auto-start, save errors, and match settings.
+
+No PR was open for the auto-start branch at this point. The updated branch is
+local; this integration does not publish a PR or redeploy the cabinet.

--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -1,5 +1,15 @@
 # Functional UI tests
 
+The `autostart_` workflows exercise persistent launcher-idle Clock and bot
+activities, settings suspension, input reset, client restart, Off, pause/resume,
+and preservation of manual preferences. Three short real bot matches expire
+through the shared scenario rule and repeat with distinct world seeds and
+scenario revisions. They inspect actual effective controller diagnostics and
+save screenshots. Virtual-time unit tests cover exact idle boundaries; scenario
+tests cover ownership-based expiry, elimination precedence, and frozen results.
+Backend-neutral Slint input tests check that returning from an automatic
+activity consumes the original keyboard/touch input.
+
 The functional suite launches the real `engine-client` binary and controls it
 only through the public Unix-socket API in `spacewars-control`. It protects the
 process, protocol, Slint callback, menu-navigation, rendering, and screenshot

--- a/docs/menu-layout.md
+++ b/docs/menu-layout.md
@@ -1,7 +1,7 @@
 # Launcher and app menu layout
 
-The launcher, App Settings, and Device Info use the same `MenuPage` frame in
-`crates/engine-client/ui/main.slint`. The compact target is the HyperPixel's
+The launcher, App Settings, Device Info, and Auto-start use the same
+`MenuPage` frame in `crates/engine-client/ui/main.slint`. The compact target is the HyperPixel's
 800×480 landscape display; 1024×768 Picade and 480×800 portrait layouts are
 also covered by render tests. The page is centered and capped at 760×520,
 with 48 px or larger action buttons. Larger windows add margins and roomier
@@ -33,6 +33,8 @@ settings rows rather than scaling down text on smaller displays.
 App Settings uses label/value rows: volume adjustment with a level indicator,
 On/Off toggles, and chevrons for subpages. Its body scrolls by touch or mouse
 wheel; controller/keyboard selection reveals the focused row when needed.
+Auto-start is the fifth row, below Device Info; navigating to it reveals the
+row. Its child page shares the same frame and fixed actions.
 Back, save status, and Retry Save stay outside the scroll area. A save failure
 does not prevent adjustment, navigation, or retrying the same settings.
 
@@ -48,7 +50,8 @@ work; see [Device Info and app navigation](device-info.md).
 all three display sizes, including long names, Space-Wars, and save errors.
 Set `SPACEWARS_MENU_TEST_ARTIFACTS` to export PNGs for visual inspection.
 Keyboard/touch tests also force App Settings into a shorter window to verify
-focus reveal and the fixed Back action. The real-process functional suite
-checks launcher navigation, settings persistence/retry, and Info return paths.
+focus reveal, the Auto-start child page, and the fixed Back action. The
+real-process functional suite checks launcher navigation, settings
+persistence/retry, and Info return paths.
 Device screenshots complement these checks; a rendered screenshot alone does
 not verify the physical touchscreen or controller wiring.

--- a/docs/spacewars-match.md
+++ b/docs/spacewars-match.md
@@ -31,6 +31,14 @@ persists through transfers and rebuilding; pilot death ends that player's
 round, even with owned planets. Simultaneous deaths draw. **Rematch** starts
 the same seed with fresh health, terrain, ownership and bot state.
 
+**Match length** defaults to ten minutes of gameplay time. Settings offers
+5, 10, or 15 minutes and Unlimited. The HUD shows the remaining time; pausing
+freezes it. At expiry, the player owning more planets wins, and equal ownership
+(including zero each) draws. Count current ownership, not past captures.
+Pilot death on the final step takes precedence over the time-limit result.
+Rematch and New Match reset the clock. This rule applies to human and bot seats
+alike, including [automatically repeated matches](auto-start.md).
+
 | Action | Assigned gamepad | P1 keyboard | P2 keyboard |
 | --- | --- | --- | --- |
 | Turn aboard / walk or steer on foot | Left/right | A/D | Numpad 4/6 |
@@ -58,7 +66,7 @@ hatches, fight and recover using the same action interface as humans.
 
 ## Settings and historical comparisons
 
-Normal Spacewars exposes both player choices, renderer/raster scale, bot combat
+Normal Spacewars exposes match length, both player choices, renderer/raster scale, bot combat
 break interval/duration, and asteroid arrival interval/strength. Breaks leave
 the bot moving and vulnerable with its weapons off. The first promoted match
 keeps three planets and the established health/world profile.

--- a/scenarios/spacewars/src/surface_sortie.rs
+++ b/scenarios/spacewars/src/surface_sortie.rs
@@ -715,6 +715,7 @@ impl Scenario for SurfaceSortieScenario {
             ship.set_cannon(armed && weapons.cannon);
         }
         // Schedule terrain, solve gravity, and step Rapier exactly once for all seats.
+        let match_dt = dt;
         let dt = dt.as_secs_f32();
         state.update_surface_wings(dt);
         let damage_before = state.damage_sample();
@@ -731,7 +732,8 @@ impl Scenario for SurfaceSortieScenario {
         );
         state.reconcile_recovery_vehicles();
         state.record_surface_damage(damage_before);
-        if state.finish_round() {
+        state.advance_match_time(match_dt);
+        if state.finish_round(false) {
             return result;
         }
         for (player, (before, effective)) in samples.into_iter().zip(effective_inputs).enumerate() {
@@ -757,6 +759,7 @@ impl Scenario for SurfaceSortieScenario {
         state.update_planet_claims(Duration::from_secs_f32(dt));
         state.update_recovery(Duration::from_secs_f32(dt));
         state.update_mining();
+        state.finish_round(true);
         result
     }
 

--- a/scenarios/spacewars/src/surface_sortie/match_rules.rs
+++ b/scenarios/spacewars/src/surface_sortie/match_rules.rs
@@ -95,14 +95,42 @@ pub enum MatchOutcome {
     Draw,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MatchEndReason {
+    PilotDeath,
+    SimultaneousDeaths,
+    TimeLimit,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub(super) struct MatchRound {
+    time_limit: Option<Duration>,
+    elapsed: Duration,
+    reason: Option<MatchEndReason>,
     outcome: Option<MatchOutcome>,
     finished_tick: Option<u64>,
 }
 
+impl Default for MatchRound {
+    fn default() -> Self {
+        Self {
+            time_limit: Some(Duration::from_secs(600)),
+            elapsed: Duration::ZERO,
+            reason: None,
+            outcome: None,
+            finished_tick: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MatchObservation {
+    pub time_limit_seconds: Option<f64>,
+    pub elapsed_seconds: f64,
+    pub remaining_seconds: Option<f64>,
+    pub reason: Option<MatchEndReason>,
+    pub owned_planets: [usize; 2],
     pub version: u32,
     pub pilots: Vec<PilotVitals>,
     pub outcome: Option<MatchOutcome>,
@@ -133,6 +161,61 @@ impl SurfaceSortieState {
         }
     }
 
+    pub fn set_match_time_limit(&mut self, limit: Option<Duration>) {
+        assert_eq!(self.world.tick, 0, "configure the match before stepping");
+        if let Some(round) = &mut self.round {
+            round.time_limit = limit;
+        }
+    }
+
+    pub(super) fn advance_match_time(&mut self, dt: Duration) {
+        if let Some(round) = &mut self.round {
+            round.elapsed = round.elapsed.saturating_add(dt);
+            if let Some(limit) = round.time_limit {
+                round.elapsed = round.elapsed.min(limit);
+            }
+        }
+    }
+
+    pub fn match_result_message(&self) -> Option<String> {
+        let round = self.round.as_ref()?;
+        let outcome = round.outcome?;
+        Some(match (outcome, round.reason?) {
+            (MatchOutcome::Winner(owner), MatchEndReason::PilotDeath) => {
+                format!("Player {} wins / opposing pilot lost", owner.index() + 1)
+            }
+            (MatchOutcome::Winner(owner), MatchEndReason::TimeLimit) => format!(
+                "Player {} wins / time limit / more planets owned",
+                owner.index() + 1
+            ),
+            (MatchOutcome::Draw, MatchEndReason::TimeLimit) => {
+                "Draw / time limit / equal planets".into()
+            }
+            _ => "Draw / both pilots lost".into(),
+        })
+    }
+
+    pub fn match_clock_label(&self) -> Option<String> {
+        let round = self.round.as_ref()?;
+        Some(match round.time_limit {
+            Some(limit) => {
+                let seconds = limit.saturating_sub(round.elapsed).as_secs_f64().ceil() as u64;
+                format!("Time {:02}:{:02}", seconds / 60, seconds % 60)
+            }
+            None => "Time unlimited".into(),
+        })
+    }
+
+    fn owned_planet_counts(&self) -> [usize; 2] {
+        std::array::from_fn(|seat| {
+            self.world
+                .planets
+                .iter()
+                .filter(|planet| planet.owner_id == Some(seat))
+                .count()
+        })
+    }
+
     pub fn match_outcome(&self) -> Option<MatchOutcome> {
         self.round.as_ref().and_then(|round| round.outcome)
     }
@@ -140,7 +223,14 @@ impl SurfaceSortieState {
     pub fn match_observation(&self) -> Option<MatchObservation> {
         let round = self.round.as_ref()?;
         Some(MatchObservation {
-            version: 1,
+            version: 2,
+            time_limit_seconds: round.time_limit.map(|limit| limit.as_secs_f64()),
+            elapsed_seconds: round.elapsed.as_secs_f64(),
+            remaining_seconds: round
+                .time_limit
+                .map(|limit| limit.saturating_sub(round.elapsed).as_secs_f64()),
+            reason: round.reason,
+            owned_planets: self.owned_planet_counts(),
             pilots: self
                 .pilots
                 .iter()
@@ -152,7 +242,8 @@ impl SurfaceSortieState {
     }
 
     /// Evaluate both pilots only after all damage in the shared physics step.
-    pub(super) fn finish_round(&mut self) -> bool {
+    pub(super) fn finish_round(&mut self, evaluate_timeout: bool) -> bool {
+        let owned = self.owned_planet_counts();
         let Some(round) = &mut self.round else {
             return false;
         };
@@ -161,11 +252,28 @@ impl SurfaceSortieState {
             .iter()
             .filter(|p| p.vitals.unwrap().alive())
             .collect();
-        round.outcome = match alive.as_slice() {
-            [] => Some(MatchOutcome::Draw),
-            [pilot] => Some(MatchOutcome::Winner(pilot.owner)),
+        let result = match alive.as_slice() {
+            [] => Some((MatchOutcome::Draw, MatchEndReason::SimultaneousDeaths)),
+            [pilot] => Some((
+                MatchOutcome::Winner(pilot.owner),
+                MatchEndReason::PilotDeath,
+            )),
+            _ if evaluate_timeout
+                && round.time_limit.is_some_and(|limit| round.elapsed >= limit) =>
+            {
+                let outcome = match owned[0].cmp(&owned[1]) {
+                    std::cmp::Ordering::Greater => MatchOutcome::Winner(PlayerId::PLAYER_1),
+                    std::cmp::Ordering::Less => MatchOutcome::Winner(PlayerId::PLAYER_2),
+                    std::cmp::Ordering::Equal => MatchOutcome::Draw,
+                };
+                Some((outcome, MatchEndReason::TimeLimit))
+            }
             _ => None,
         };
+        if let Some((outcome, reason)) = result {
+            round.outcome = Some(outcome);
+            round.reason = Some(reason);
+        }
         if round.outcome.is_none() {
             return false;
         }

--- a/scenarios/spacewars/src/surface_sortie/material/tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/material/tests.rs
@@ -190,6 +190,47 @@ fn flag_survives_remeshing_but_destroyed_footing_neutralizes_without_awarding_at
 }
 
 #[test]
+fn match_expiry_scores_a_flag_destroyed_on_the_final_step_as_neutral() {
+    use crate::surface_sortie::match_rules::{MatchEndReason, MatchOutcome};
+    let mut state = SurfaceSortieScenario::init_material_combat_flight(42, &[]);
+    state.enable_match_rules();
+    state.world.planets[0].wrapper_omega = 0.0;
+    idle(&mut state, 240);
+    transfer(&mut state, 0);
+    idle(&mut state, 240);
+    assert_eq!(state.world.planets[0].owner_id, Some(0));
+    let cell = flag_cell(&state);
+    let remaining = Duration::from_secs(600) - DT * state.world.tick as u32;
+    state.advance_match_time(remaining - DT);
+    let mut retained = state.clone();
+    state
+        .world
+        .queue_planet_edit(
+            0,
+            TerrainEdit {
+                brush: Brush::Circle {
+                    center: cell,
+                    radius: 2,
+                },
+                mode: EditMode::Remove,
+            },
+        )
+        .unwrap();
+    step(&mut retained, &[]);
+    step(&mut state, &[]);
+    assert_eq!(
+        retained.match_outcome(),
+        Some(MatchOutcome::Winner(PlayerId::PLAYER_1))
+    );
+    assert_eq!(state.world.planets[0].owner_id, None);
+    let observation = state.match_observation().unwrap();
+    assert_eq!(observation.reason, Some(MatchEndReason::TimeLimit));
+    assert_eq!(observation.outcome, Some(MatchOutcome::Draw));
+    assert_eq!(observation.owned_planets, [0, 0]);
+    assert!(observation.pilots.iter().all(|pilot| pilot.alive()));
+}
+
+#[test]
 fn removal_of_ship_support_rejects_same_tick_transfer() {
     let mut state = parked(1);
     let body = state

--- a/scenarios/spacewars/src/surface_sortie/render.rs
+++ b/scenarios/spacewars/src/surface_sortie/render.rs
@@ -1107,6 +1107,7 @@ fn draw_player_hud(
         vehicle_status
     };
     let lines = [
+        (0.49, state.match_clock_label().unwrap_or_default(), LIGHT),
         (0.445, pilot_status, color),
         (0.385, vehicle_status, LIGHT),
         (
@@ -1121,13 +1122,8 @@ fn draw_player_hud(
         ),
         (
             -0.29,
-            if let Some(outcome) = state.match_outcome() {
-                match outcome {
-                    match_rules::MatchOutcome::Winner(owner) => {
-                        format!("Round over / P{} wins", owner.index() + 1)
-                    }
-                    match_rules::MatchOutcome::Draw => "Draw / both pilots lost".to_owned(),
-                }
+            if let Some(message) = state.match_result_message() {
+                message
             } else if !observation.controls_armed {
                 "Release controls to continue".to_owned()
             } else if let Some(message) = recovery_message {

--- a/scenarios/spacewars/src/surface_sortie/tests/match_tests.rs
+++ b/scenarios/spacewars/src/surface_sortie/tests/match_tests.rs
@@ -1,6 +1,98 @@
 use super::*;
 use match_rules::{MatchOutcome, PILOT_HEALTH, PilotDamageCause};
 
+#[test]
+fn time_limit_uses_current_ownership_and_freezes_living_pilots() {
+    use match_rules::MatchEndReason;
+    let dt = Duration::from_millis(1);
+    for leading in [None, Some(0), Some(1)] {
+        let mut state = round();
+        state.set_match_time_limit(Some(dt * 2));
+        SurfaceSortieScenario::step(&mut state, &[], dt);
+        assert_eq!(state.match_outcome(), None);
+        let before = state.match_observation().unwrap();
+        SurfaceSortieScenario::step(&mut state, &[], Duration::ZERO);
+        assert_eq!(state.match_observation().unwrap(), before);
+        for planet in &mut state.world.planets {
+            planet.owner_id = None;
+        }
+        state.world.planets[0].owner_id = leading;
+        SurfaceSortieScenario::step(&mut state, &[], dt);
+        let expected = leading.map_or(MatchOutcome::Draw, |seat| {
+            MatchOutcome::Winner(PlayerId::from_index(seat).unwrap())
+        });
+        assert_eq!(state.match_outcome(), Some(expected));
+        let observation = state.match_observation().unwrap();
+        assert_eq!(observation.remaining_seconds, Some(0.0));
+        assert_eq!(observation.reason, Some(MatchEndReason::TimeLimit));
+        assert!(observation.pilots.iter().all(|v| v.alive()));
+        assert!(state.world.players.iter().all(|p| !p.eliminated));
+        assert!(state.match_result_message().unwrap().contains("time limit"));
+        let frozen = SurfaceSortieScenario::observe(&state);
+        SurfaceSortieScenario::step(&mut state, &[], Duration::from_secs(1));
+        assert_eq!(
+            frozen.payload,
+            SurfaceSortieScenario::observe(&state).payload
+        );
+    }
+}
+
+#[test]
+fn time_limit_draws_with_equal_nonzero_ownership_and_a_neutral_planet() {
+    let mut state = SurfaceSortieScenario::init_material_match(42);
+    let dt = Duration::from_millis(1);
+    state.set_match_time_limit(Some(dt));
+    state.world.planets[0].owner_id = Some(0);
+    state.world.planets[1].owner_id = Some(1);
+    state.world.planets[2].owner_id = None;
+    SurfaceSortieScenario::step(&mut state, &[], dt);
+    assert_eq!(state.match_outcome(), Some(MatchOutcome::Draw));
+    assert_eq!(state.match_observation().unwrap().owned_planets, [1, 1]);
+}
+
+#[test]
+fn unlimited_rounds_and_new_rounds_have_independent_clocks() {
+    let mut state = round();
+    state.set_match_time_limit(None);
+    state.advance_match_time(Duration::from_secs(86_400));
+    assert!(!state.finish_round(true));
+    assert_eq!(state.match_clock_label().as_deref(), Some("Time unlimited"));
+    let fresh = round();
+    assert_eq!(fresh.match_observation().unwrap().elapsed_seconds, 0.0);
+    assert_eq!(fresh.match_clock_label().as_deref(), Some("Time 10:00"));
+}
+
+#[test]
+fn final_step_pilot_death_takes_precedence_over_time_limit_and_ownership() {
+    use match_rules::MatchEndReason;
+    for dead in [vec![0], vec![1], vec![0, 1]] {
+        let mut state = solar_round(&dead, false);
+        state.set_match_time_limit(Some(Duration::from_millis(1)));
+        state.world.planets[0].owner_id = Some(dead[0]);
+        for &seat in &dead {
+            state.pilots[seat].vitals.as_mut().unwrap().health = 0.1;
+        }
+        idle(&mut state, 1);
+        let observation = state.match_observation().unwrap();
+        assert_eq!(
+            observation.reason,
+            Some(if dead.len() == 2 {
+                MatchEndReason::SimultaneousDeaths
+            } else {
+                MatchEndReason::PilotDeath
+            })
+        );
+        assert_eq!(
+            observation.outcome,
+            Some(if dead.len() == 2 {
+                MatchOutcome::Draw
+            } else {
+                MatchOutcome::Winner(PlayerId::from_index(1 - dead[0]).unwrap())
+            })
+        );
+    }
+}
+
 fn round() -> SurfaceSortieState {
     let mut state = SurfaceSortieScenario::init_material_combat_flight(42, &[]);
     state.enable_match_rules();
@@ -483,7 +575,7 @@ fn sustained_real_laser_fire_finishes_a_round_against_either_survivor() {
             text.iter()
                 .any(|t| t.contains("DEAD") && t.contains("pilot 0%"))
         );
-        assert!(text.contains(&"Round over / P1 wins"));
+        assert!(text.contains(&"Player 1 wins / opposing pilot lost"));
         assert!(!text.contains(&"Release controls to continue"));
     }
 }


### PR DESCRIPTION
An idle cabinet currently stays at the launcher, and a Spacewars match with two surviving pilots has no time limit. This adds saved automatic activities and a match-owned deadline so cabinets can run Clock or repeat ordinary two-bot Spacewars matches unattended.

## Changes

- Add **App Settings → Auto-start** with Off, Clock, Spacewars bots, a configurable 5–600-second idle delay, and Start now. Defaults are Off and 30 seconds. The preference persists across launcher visits and device restarts.
- Count inactivity only on the root launcher. Input resets the countdown; settings and manual play suspend it. Input during an automatic activity returns to the launcher and is consumed before it can activate a menu item.
- Run bot matches with temporary controller choices and fresh worlds, preserving saved manual preferences. Display each result for eight seconds before starting the next match. Keep activity selection in a small catalog with stable IDs and document how future activities fit.
- Add ordinary Spacewars match lengths of 5, 10, 15 minutes or Unlimited, defaulting to 10 minutes of gameplay time. At expiry, most planets owned wins; equal ownership draws. Pausing freezes the timer, and pilot death on the final step takes precedence. HUD and observations expose the timer and finish reason.
- Integrate with the responsive menus and Device Info merged in #70, including scrolling to the fifth App Settings row, guarded UI controls, settings migration, and user/design documentation.

## Validation

- 291 client unit tests passed; one unrelated test remains ignored.
- Seven real-client workflows passed under Xvfb: sticky Clock and process restart, three completed/repeated timed bot matches, Device Info, launcher navigation, audio persistence, both-player controller choices, and rematches/new worlds.
- Rendering checks passed at 800×480, 1024×768 and 480×800; keyboard/touch checks cover the short 800×360 scrolling layout. Match-rule tests cover timeout outcomes and final-step flag destruction.
- Release `d12853e12f73` deployed to `sw-picade` and `sw-picade-2`. Runtime compatibility, installed binary hashes, responsive settings screens and preserved preferences were verified on both. Both initially had zero kiosk restarts during verification. Full-duration unattended cabinet runs remain a playtest follow-up.
- `git diff --check` passed. The branch includes current main `07b9dc0`.

Cabinet observation: `sw-picade-2` subsequently stopped responding and showed disk errors, then recovered after a user reboot. Read-only checks found USB over-current events, a USB boot-drive reset and a disk read error in the new boot's kernel log. The deployed hashes still match and the kiosk is running; the original failure's cause is unconfirmed. This remains a monitored USB/power/storage investigation.
