### PR TITLE
Add calibrated Duck movement and varied obstacle courses

### DIFF
--- a/crates/engine-client/src/client_scenarios/clock.rs
+++ b/crates/engine-client/src/client_scenarios/clock.rs
@@ -73,6 +73,9 @@ fn create(
                     .as_deref(),
             ),
             time_format: settings.clock.time_format,
+            duck_course_pattern: duck_course_pattern(
+                std::env::var("SPACEWARS_CLOCK_DUCK_COURSE").ok().as_deref(),
+            ),
             event_profile: settings.clock.event_profile,
             events: settings.clock.events,
             marquee_preset: settings.clock.marquee_preset,
@@ -97,6 +100,17 @@ fn duck_jump_profile(value: Option<&str>) -> Option<engine_common::ClockDuckJump
     match value {
         Some("careful") => Some(engine_common::ClockDuckJumpProfile::Careful),
         Some("flowing") => Some(engine_common::ClockDuckJumpProfile::Flowing),
+        _ => None,
+    }
+}
+
+fn duck_course_pattern(value: Option<&str>) -> Option<engine_common::ClockDuckCoursePattern> {
+    use engine_common::ClockDuckCoursePattern;
+    match value {
+        Some("platforms") => Some(ClockDuckCoursePattern::Platforms),
+        Some("terraces") => Some(ClockDuckCoursePattern::Terraces),
+        Some("two-jump") => Some(ClockDuckCoursePattern::TwoJump),
+        Some("shortcut") => Some(ClockDuckCoursePattern::Shortcut),
         _ => None,
     }
 }
@@ -516,10 +530,20 @@ mod tests {
 
     #[test]
     fn duck_course_reaches_both_render_paths_and_resets_to_the_normal_arena() {
-        for profile in [
+        for (profile, pattern) in [
             engine_common::ClockDuckJumpProfile::Careful,
             engine_common::ClockDuckJumpProfile::Flowing,
-        ] {
+        ]
+        .into_iter()
+        .flat_map(|profile| {
+            [
+                engine_common::ClockDuckCoursePattern::Platforms,
+                engine_common::ClockDuckCoursePattern::Terraces,
+                engine_common::ClockDuckCoursePattern::TwoJump,
+                engine_common::ClockDuckCoursePattern::Shortcut,
+            ]
+            .map(|pattern| (profile, pattern))
+        }) {
             for viewport in [
                 Viewport::new(800.0, 480.0),
                 Viewport::new(1024.0, 768.0),
@@ -530,6 +554,7 @@ mod tests {
                     ClockConfig {
                         aspect_ratio: viewport.aspect_ratio(),
                         duck_jump_profile: Some(profile),
+                        duck_course_pattern: Some(pattern),
                         event_profile: engine_common::ClockEventProfile::Off,
                         ..ClockConfig::default()
                     },
@@ -604,7 +629,13 @@ mod tests {
                         crate::raster::RasterOptions::default(),
                     );
                     let pixels = image.to_rgb8().unwrap();
-                    if [1235, 1260].contains(&tick) {
+                    // Shorter patterns may already be fading after a successful
+                    // exit at this timestamp. Only inspect an active course.
+                    let active_duck = scenario
+                        .state
+                        .duck_state()
+                        .is_some_and(|duck| duck.outcome.is_none());
+                    if [1235, 1260].contains(&tick) && active_duck {
                         // Inspect the exit frame itself, not just telemetry or its
                         // closed panel: it must be absent before the spawn timer.
                         let duck = scenario.state.duck_state().unwrap();
@@ -622,7 +653,7 @@ mod tests {
                         assert_eq!(
                             visible,
                             tick == 1260,
-                            "exit frame at {tick} in {viewport:?}"
+                            "exit frame at {tick} in {viewport:?} {pattern:?} {profile:?}"
                         );
                     }
                     let yellow = pixels
@@ -630,7 +661,7 @@ mod tests {
                         .iter()
                         .filter(|p| p.r > 240 && p.g > 200 && p.b < 50)
                         .count();
-                    if [60, 170, 395, 600, 900, 1260].contains(&tick) {
+                    if [60, 170, 395, 600, 900, 1260].contains(&tick) && active_duck {
                         assert!(yellow > 25, "duck missing at {tick} in {viewport:?}");
                     }
                     if tick == 0 || tick == scenario_clock::DUCK_TICKS {
@@ -641,7 +672,7 @@ mod tests {
                         let directory = std::path::PathBuf::from(directory);
                         std::fs::create_dir_all(&directory).unwrap();
                         let file = std::fs::File::create(directory.join(format!(
-                            "duck-{profile:?}-{tick}-{}x{}.png",
+                            "duck-{pattern:?}-{profile:?}-{tick}-{}x{}.png",
                             viewport.width, viewport.height
                         )))
                         .unwrap();
@@ -788,6 +819,22 @@ mod tests {
         );
         for value in [None, Some("mixed"), Some(""), Some("unknown")] {
             assert_eq!(duck_jump_profile(value), None);
+        }
+    }
+
+    #[test]
+    fn duck_course_override_preserves_authored_choices_and_defaults_to_a_seeded_mix() {
+        use engine_common::ClockDuckCoursePattern;
+        for (value, pattern) in [
+            ("platforms", ClockDuckCoursePattern::Platforms),
+            ("terraces", ClockDuckCoursePattern::Terraces),
+            ("two-jump", ClockDuckCoursePattern::TwoJump),
+            ("shortcut", ClockDuckCoursePattern::Shortcut),
+        ] {
+            assert_eq!(duck_course_pattern(Some(value)), Some(pattern));
+        }
+        for value in [None, Some("mixed"), Some("unknown")] {
+            assert_eq!(duck_course_pattern(value), None);
         }
     }
 

--- a/crates/engine-client/src/client_scenarios/clock.rs
+++ b/crates/engine-client/src/client_scenarios/clock.rs
@@ -65,6 +65,13 @@ fn create(
     let mut state = ClockScenario::init(
         ClockConfig {
             aspect_ratio: viewport.aspect_ratio(),
+            duck_debug_overlay: std::env::var("SPACEWARS_CLOCK_DUCK_DEBUG")
+                .is_ok_and(|value| value == "1"),
+            duck_jump_profile: duck_jump_profile(
+                std::env::var("SPACEWARS_CLOCK_DUCK_PROFILE")
+                    .ok()
+                    .as_deref(),
+            ),
             time_format: settings.clock.time_format,
             event_profile: settings.clock.event_profile,
             events: settings.clock.events,
@@ -84,6 +91,14 @@ fn create(
         last_emitted_reading: Cell::new(Some(reading)),
         benchmark: None,
     }))
+}
+
+fn duck_jump_profile(value: Option<&str>) -> Option<engine_common::ClockDuckJumpProfile> {
+    match value {
+        Some("careful") => Some(engine_common::ClockDuckJumpProfile::Careful),
+        Some("flowing") => Some(engine_common::ClockDuckJumpProfile::Flowing),
+        _ => None,
+    }
 }
 
 impl ClientScenario for ClockClientScenario {
@@ -501,14 +516,161 @@ mod tests {
 
     #[test]
     fn duck_course_reaches_both_render_paths_and_resets_to_the_normal_arena() {
-        for viewport in [
-            Viewport::new(800.0, 480.0),
-            Viewport::new(480.0, 800.0),
-            Viewport::new(1280.0, 720.0),
+        for profile in [
+            engine_common::ClockDuckJumpProfile::Careful,
+            engine_common::ClockDuckJumpProfile::Flowing,
         ] {
+            for viewport in [
+                Viewport::new(800.0, 480.0),
+                Viewport::new(1024.0, 768.0),
+                Viewport::new(480.0, 800.0),
+                Viewport::new(1280.0, 720.0),
+            ] {
+                let mut state = ClockScenario::init(
+                    ClockConfig {
+                        aspect_ratio: viewport.aspect_ratio(),
+                        duck_jump_profile: Some(profile),
+                        event_profile: engine_common::ClockEventProfile::Off,
+                        ..ClockConfig::default()
+                    },
+                    42,
+                );
+                ClockScenario::step(
+                    &mut state,
+                    &[ClockAction::set_reading(
+                        ClockReading::new(8, 8, 0).unwrap(),
+                    )],
+                    Duration::ZERO,
+                );
+                let normal = ClockScenario::render_frame(&state);
+                ClockScenario::step(
+                    &mut state,
+                    &[ClockAction::trigger_event(
+                        engine_common::ClockEventKind::Duck,
+                    )],
+                    Duration::ZERO,
+                );
+                let mut scenario = ClockClientScenario {
+                    state,
+                    last_emitted_reading: Cell::new(None),
+                    benchmark: None,
+                };
+                let mut renderer = crate::raster::RasterRenderer::new();
+                for tick in 0..=scenario_clock::DUCK_TICKS {
+                    if tick > 0 {
+                        scenario.step(&[], Duration::from_nanos(16_666_667));
+                    }
+                    if ![
+                        0,
+                        18,
+                        60,
+                        170,
+                        395,
+                        600,
+                        900,
+                        1235,
+                        1260,
+                        1650,
+                        1800,
+                        scenario_clock::DUCK_TICKS,
+                    ]
+                    .contains(&tick)
+                    {
+                        continue;
+                    }
+                    let frames = scenario.render_frames(RenderBackend::Raster, viewport);
+                    assert_eq!(
+                        frames,
+                        scenario.render_frames(RenderBackend::Vector, viewport)
+                    );
+                    assert!(
+                        frames[0]
+                            .layers
+                            .iter()
+                            .map(|l| l.primitives.len())
+                            .sum::<usize>()
+                            < 300
+                    );
+                    let presentation = crate::render::scene_presentation_from_frames_with_layout(
+                        &frames,
+                        viewport,
+                        scenario.frame_layout(),
+                    );
+                    assert!(!presentation.main_primitives.is_empty());
+                    let image = renderer.image_from_frames_with_layout(
+                        &frames,
+                        viewport,
+                        scenario.frame_layout(),
+                        crate::raster::RasterOptions::default(),
+                    );
+                    let pixels = image.to_rgb8().unwrap();
+                    if [1235, 1260].contains(&tick) {
+                        // Inspect the exit frame itself, not just telemetry or its
+                        // closed panel: it must be absent before the spawn timer.
+                        let duck = scenario.state.duck_state().unwrap();
+                        let world_width = 480.0 * viewport.aspect_ratio();
+                        let radius = duck.navigation.unwrap().body_radius_milli as f32 / 1000.0;
+                        let side = if duck.left_to_right { 1.0 } else { -1.0 };
+                        let scale = viewport.height / 480.0;
+                        let x = (viewport.width * 0.5
+                            + (world_width * 0.5 - 2.0 * radius) * side * scale)
+                            as usize;
+                        let y = (viewport.height * 0.5 - (-163.2 + 4.1 * radius) * scale) as usize;
+                        let frame_pixel = pixels.as_slice()[y * pixels.width() as usize + x];
+                        let visible =
+                            frame_pixel.r > 40 && frame_pixel.g > 80 && frame_pixel.b > 100;
+                        assert_eq!(
+                            visible,
+                            tick == 1260,
+                            "exit frame at {tick} in {viewport:?}"
+                        );
+                    }
+                    let yellow = pixels
+                        .as_slice()
+                        .iter()
+                        .filter(|p| p.r > 240 && p.g > 200 && p.b < 50)
+                        .count();
+                    if [60, 170, 395, 600, 900, 1260].contains(&tick) {
+                        assert!(yellow > 25, "duck missing at {tick} in {viewport:?}");
+                    }
+                    if tick == 0 || tick == scenario_clock::DUCK_TICKS {
+                        assert_eq!(yellow, 0);
+                        assert_eq!(frames[0], normal);
+                    }
+                    if let Some(directory) = std::env::var_os("SPACEWARS_CLOCK_ARTIFACTS") {
+                        let directory = std::path::PathBuf::from(directory);
+                        std::fs::create_dir_all(&directory).unwrap();
+                        let file = std::fs::File::create(directory.join(format!(
+                            "duck-{profile:?}-{tick}-{}x{}.png",
+                            viewport.width, viewport.height
+                        )))
+                        .unwrap();
+                        let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
+                        encoder.set_color(png::ColorType::Rgb);
+                        encoder.set_depth(png::BitDepth::Eight);
+                        encoder
+                            .write_header()
+                            .unwrap()
+                            .write_image_data(pixels.as_bytes())
+                            .unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn duck_planning_overlay_is_visible_without_changing_the_physics() {
+        for profile in [
+            engine_common::ClockDuckJumpProfile::Careful,
+            engine_common::ClockDuckJumpProfile::Flowing,
+        ] {
+            let viewport = Viewport::new(800.0, 480.0);
             let mut state = ClockScenario::init(
                 ClockConfig {
                     aspect_ratio: viewport.aspect_ratio(),
+                    duck_debug_overlay: true,
+                    duck_jump_profile: Some(profile),
                     event_profile: engine_common::ClockEventProfile::Off,
                     ..ClockConfig::default()
                 },
@@ -516,88 +678,116 @@ mod tests {
             );
             ClockScenario::step(
                 &mut state,
-                &[ClockAction::set_reading(
-                    ClockReading::new(8, 8, 0).unwrap(),
-                )],
+                &[
+                    ClockAction::set_reading(ClockReading::new(8, 8, 0).unwrap()),
+                    ClockAction::preview_event(engine_common::ClockEventKind::Duck),
+                ],
                 Duration::ZERO,
             );
-            let normal = ClockScenario::render_frame(&state);
-            ClockScenario::step(
-                &mut state,
-                &[ClockAction::trigger_event(
-                    engine_common::ClockEventKind::Duck,
-                )],
-                Duration::ZERO,
+            for _ in 0..240 {
+                ClockScenario::step(&mut state, &[], Duration::from_nanos(16_666_667));
+            }
+            if profile == engine_common::ClockDuckJumpProfile::Flowing {
+                // Capture the running arc, not an earlier careful fallback.
+                for _ in 0..1000 {
+                    let duck = state.duck_state().unwrap();
+                    if !duck.grounded
+                        && duck.navigation.unwrap().behavior
+                            == engine_common::ClockDuckBehavior::Jumping
+                        && duck
+                            .navigation
+                            .unwrap()
+                            .planning
+                            .unwrap()
+                            .plan
+                            .is_some_and(|plan| plan.running_takeoff)
+                    {
+                        break;
+                    }
+                    ClockScenario::step(&mut state, &[], Duration::from_nanos(16_666_667));
+                }
+                assert!(
+                    state
+                        .duck_state()
+                        .unwrap()
+                        .navigation
+                        .unwrap()
+                        .planning
+                        .unwrap()
+                        .plan
+                        .unwrap()
+                        .running_takeoff
+                );
+            }
+            assert!(
+                state
+                    .duck_state()
+                    .unwrap()
+                    .navigation
+                    .unwrap()
+                    .planning
+                    .unwrap()
+                    .plan
+                    .is_some()
             );
-            let mut scenario = ClockClientScenario {
+            let scenario = ClockClientScenario {
                 state,
                 last_emitted_reading: Cell::new(None),
                 benchmark: None,
             };
+            let frames = scenario.render_frames(RenderBackend::Raster, viewport);
+            assert_eq!(
+                frames,
+                scenario.render_frames(RenderBackend::Vector, viewport)
+            );
             let mut renderer = crate::raster::RasterRenderer::new();
-            for tick in 0..=scenario_clock::DUCK_TICKS {
-                if tick > 0 {
-                    scenario.step(&[], Duration::from_nanos(16_666_667));
-                }
-                if ![0, 18, 60, 170, 260, 395, 460, 590, 600].contains(&tick) {
-                    continue;
-                }
-                let frames = scenario.render_frames(RenderBackend::Raster, viewport);
-                assert_eq!(
-                    frames,
-                    scenario.render_frames(RenderBackend::Vector, viewport)
-                );
-                assert!(
-                    frames[0]
-                        .layers
-                        .iter()
-                        .map(|l| l.primitives.len())
-                        .sum::<usize>()
-                        < 300
-                );
-                let presentation = crate::render::scene_presentation_from_frames_with_layout(
-                    &frames,
-                    viewport,
-                    scenario.frame_layout(),
-                );
-                assert!(!presentation.main_primitives.is_empty());
-                let image = renderer.image_from_frames_with_layout(
-                    &frames,
-                    viewport,
-                    scenario.frame_layout(),
-                    crate::raster::RasterOptions::default(),
-                );
-                let pixels = image.to_rgb8().unwrap();
-                let yellow = pixels
-                    .as_slice()
-                    .iter()
-                    .filter(|p| p.r > 240 && p.g > 200 && p.b < 50)
-                    .count();
-                if [60, 170, 260, 395].contains(&tick) {
-                    assert!(yellow > 25, "duck missing at {tick} in {viewport:?}");
-                }
-                if tick == 0 || tick == 600 {
-                    assert_eq!(yellow, 0);
-                    assert_eq!(frames[0], normal);
-                }
-                if let Some(directory) = std::env::var_os("SPACEWARS_CLOCK_ARTIFACTS") {
-                    let directory = std::path::PathBuf::from(directory);
-                    std::fs::create_dir_all(&directory).unwrap();
-                    let file = std::fs::File::create(directory.join(format!(
-                        "duck-{tick}-{}x{}.png",
-                        viewport.width, viewport.height
-                    )))
+            let image = renderer.image_from_frames_with_layout(
+                &frames,
+                viewport,
+                scenario.frame_layout(),
+                crate::raster::RasterOptions::default(),
+            );
+            let pixels = image.to_rgb8().unwrap();
+            let purple = pixels
+                .as_slice()
+                .iter()
+                .filter(|pixel| {
+                    pixel.r > 180 && pixel.r < 240 && pixel.g > 70 && pixel.g < 140 && pixel.b > 230
+                })
+                .count();
+            assert!(purple > 20, "planned arc should be visible");
+            if let Some(directory) = std::env::var_os("SPACEWARS_CLOCK_ARTIFACTS") {
+                let directory = std::path::PathBuf::from(directory);
+                std::fs::create_dir_all(&directory).unwrap();
+                let file = std::fs::File::create(
+                    directory.join(format!("duck-planner-{profile:?}-overlay.png")),
+                )
+                .unwrap();
+                let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
+                encoder.set_color(png::ColorType::Rgb);
+                encoder.set_depth(png::BitDepth::Eight);
+                encoder
+                    .write_header()
+                    .unwrap()
+                    .write_image_data(pixels.as_bytes())
                     .unwrap();
-                    let mut encoder = png::Encoder::new(file, pixels.width(), pixels.height());
-                    encoder.set_color(png::ColorType::Rgb);
-                    encoder.set_depth(png::BitDepth::Eight);
-                    encoder
-                        .write_header()
-                        .unwrap()
-                        .write_image_data(pixels.as_bytes())
-                        .unwrap();
-                }
             }
+        }
+    }
+
+    #[test]
+    fn duck_profile_override_preserves_both_choices_and_defaults_to_a_seeded_mix() {
+        use engine_common::ClockDuckJumpProfile;
+        assert_eq!(
+            duck_jump_profile(Some("flowing")),
+            Some(ClockDuckJumpProfile::Flowing)
+        );
+        assert_eq!(
+            duck_jump_profile(Some("careful")),
+            Some(ClockDuckJumpProfile::Careful)
+        );
+        for value in [None, Some("mixed"), Some(""), Some("unknown")] {
+            assert_eq!(duck_jump_profile(value), None);
         }
     }
 

--- a/crates/engine-client/src/client_scenarios/clock/benchmark.rs
+++ b/crates/engine-client/src/client_scenarios/clock/benchmark.rs
@@ -68,6 +68,7 @@ impl Driver {
     pub fn new(config: ClockBenchmarkConfig, seed: u64, aspect: f32) -> (ClockState, Self) {
         let mut state = ClockScenario::init(
             ClockConfig {
+                duck_jump_profile: Some(engine_common::ClockDuckJumpProfile::Careful),
                 aspect_ratio: aspect,
                 event_profile: ClockEventProfile::Off,
                 marquee_preset: config.marquee_preset,

--- a/crates/engine-client/src/client_scenarios/clock/benchmark.rs
+++ b/crates/engine-client/src/client_scenarios/clock/benchmark.rs
@@ -69,6 +69,7 @@ impl Driver {
         let mut state = ClockScenario::init(
             ClockConfig {
                 duck_jump_profile: Some(engine_common::ClockDuckJumpProfile::Careful),
+                duck_course_pattern: Some(engine_common::ClockDuckCoursePattern::Platforms),
                 aspect_ratio: aspect,
                 event_profile: ClockEventProfile::Off,
                 marquee_preset: config.marquee_preset,

--- a/crates/engine-client/tests/ui_control_functional/clock.rs
+++ b/crates/engine-client/tests/ui_control_functional/clock.rs
@@ -804,9 +804,16 @@ impl FunctionalHarness {
             event_id: Some(event_id),
             min_phase_tick,
         };
-        let result = self
-            .client
-            .wait_for_clock_state(&predicate, Duration::from_secs(30));
+        // Follow the declared event envelope (Duck now lasts up to 35 s),
+        // with host scheduling margin rather than assuming all events < 30 s.
+        let max_ticks = state
+            .events
+            .iter()
+            .map(|event| event.duration_ticks)
+            .max()
+            .unwrap_or(0);
+        let timeout = Duration::from_secs_f64(max_ticks as f64 / 60.0) + Duration::from_secs(10);
+        let result = self.client.wait_for_clock_state(&predicate, timeout);
         self.require_clock(&format!("clock wait {predicate:?}"), result)
     }
 
@@ -988,7 +995,18 @@ fn duck_runs_jumps_exits_and_supports_live_controls_and_cleanup() {
         // Short door phases are checked at exact simulation ticks in the core
         // tests. A loaded UI runner need not catch a sub-second animation.
         let running = harness.clock_wait(&initial, "running", 1, 140);
-        assert_eq!((running.body_count, running.collider_count), (5, 5));
+        let surfaces = running
+            .duck
+            .unwrap()
+            .navigation
+            .unwrap()
+            .planning
+            .unwrap()
+            .surface_count;
+        assert_eq!(
+            (running.body_count, running.collider_count),
+            (surfaces + 1, surfaces + 1)
+        );
         assert!(running.duck.unwrap().jumps >= 1);
         harness.capture_screenshot("clock-duck-running.png");
         harness.activate_guarded("gameplay.clock-controls", &gameplay);
@@ -1018,7 +1036,40 @@ fn duck_runs_jumps_exits_and_supports_live_controls_and_cleanup() {
         assert!(!resetting.settings.events.duck);
         let duck = resetting.duck.unwrap();
         assert_eq!(duck.outcome, Some(engine_common::ClockDuckOutcome::Exited));
-        assert_eq!((duck.jumps, duck.cleared_obstacles), (3, 3));
+        assert_eq!(duck.cleared_obstacles, duck.obstacle_count);
+        let navigation = duck.navigation.unwrap();
+        match std::env::var("SPACEWARS_CLOCK_DUCK_PROFILE").as_deref() {
+            Ok("flowing") => assert_eq!(
+                navigation.jump_profile,
+                engine_common::ClockDuckJumpProfile::Flowing
+            ),
+            Ok("careful") => assert_eq!(
+                navigation.jump_profile,
+                engine_common::ClockDuckJumpProfile::Careful
+            ),
+            _ => {} // Mixed selects a concrete personality once per event.
+        }
+        assert_eq!(navigation.calibrated_jumps, 2);
+        assert_eq!(navigation.speed_samples, 9);
+        assert!(navigation.wall_tags.iter().all(|tags| *tags > 0));
+        let planning = navigation.planning.unwrap();
+        if navigation.jump_profile == engine_common::ClockDuckJumpProfile::Flowing {
+            assert!(planning.running_jumps > 0);
+            assert!(planning.moving_landings > 0);
+        } else {
+            assert_eq!(planning.running_jumps, 0);
+        }
+        assert_eq!(duck.jumps, 2 + planning.confirmed_landings);
+        assert!(planning.confirmed_landings >= (planning.surface_count - 1) as u32 * 3);
+        assert_eq!(
+            (
+                planning.undershoots,
+                planning.overshoots,
+                planning.wrong_surface_landings
+            ),
+            (0, 0, 0)
+        );
+        assert!(navigation.exit_visible);
         assert_eq!((resetting.body_count, resetting.collider_count), (0, 0));
         harness.capture_screenshot("clock-duck-resetting.png");
         let idle = harness.clock_wait(&initial, "idle", 2, 0);

--- a/crates/engine-client/tests/ui_control_functional/clock.rs
+++ b/crates/engine-client/tests/ui_control_functional/clock.rs
@@ -1060,7 +1060,10 @@ fn duck_runs_jumps_exits_and_supports_live_controls_and_cleanup() {
             assert_eq!(planning.running_jumps, 0);
         }
         assert_eq!(duck.jumps, 2 + planning.confirmed_landings);
-        assert!(planning.confirmed_landings >= (planning.surface_count - 1) as u32 * 3);
+        assert!(
+            planning.confirmed_landings + planning.skipped_platforms
+                >= (planning.surface_count - 1) as u32 * 3
+        );
         assert_eq!(
             (
                 planning.undershoots,

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -516,6 +516,16 @@ pub enum ClockDuckJumpProfile {
     Flowing,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClockDuckCoursePattern {
+    #[default]
+    Platforms,
+    Terraces,
+    TwoJump,
+    Shortcut,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ClockDuckBehavior {
@@ -546,6 +556,8 @@ pub struct ClockDuckPlanState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClockDuckPlanningState {
+    #[serde(default)]
+    pub pattern: ClockDuckCoursePattern,
     pub surface_count: usize,
     pub support: Option<usize>,
     pub plan: Option<ClockDuckPlanState>,
@@ -564,6 +576,8 @@ pub struct ClockDuckPlanningState {
     pub flowing_fallbacks: u32,
     #[serde(default)]
     pub moving_landings: u32,
+    #[serde(default)]
+    pub skipped_platforms: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/engine-common/src/lib.rs
+++ b/crates/engine-common/src/lib.rs
@@ -507,6 +507,98 @@ pub enum ClockDuckOutcome {
     TimedOut,
 }
 
+/// Movement personality, independent of event scheduling and course geometry.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClockDuckJumpProfile {
+    #[default]
+    Careful,
+    Flowing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClockDuckBehavior {
+    WarmingUp,
+    MeasuringRun,
+    Running,
+    Turning,
+    Exiting,
+    Approaching,
+    Jumping,
+    Landing,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClockDuckPlanState {
+    pub source: usize,
+    pub target: usize,
+    pub takeoff_milli: [i32; 2],
+    pub landing_milli: [i32; 2],
+    pub flight_ticks: u32,
+    pub cruise_speed_milli: u32,
+    #[serde(default)]
+    pub running_takeoff: bool,
+    #[serde(default)]
+    pub next_target: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClockDuckPlanningState {
+    pub surface_count: usize,
+    pub support: Option<usize>,
+    pub plan: Option<ClockDuckPlanState>,
+    pub confirmed_landings: u32,
+    pub undershoots: u32,
+    pub overshoots: u32,
+    pub wrong_surface_landings: u32,
+    pub rejected_plans: u32,
+    pub rejection: Option<ClockDuckRejection>,
+    pub acceleration_milli: Option<u32>,
+    pub generation_attempts: u32,
+    pub fallback_course: bool,
+    #[serde(default)]
+    pub running_jumps: u32,
+    #[serde(default)]
+    pub flowing_fallbacks: u32,
+    #[serde(default)]
+    pub moving_landings: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClockDuckRejection {
+    TooNarrow,
+    TooHigh,
+    OutOfRange,
+    Obstructed,
+}
+
+/// Bounded controller diagnostics; measurements come from actual body motion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClockDuckNavigationState {
+    #[serde(default)]
+    pub jump_profile: ClockDuckJumpProfile,
+    pub course_seed: u64,
+    pub behavior: ClockDuckBehavior,
+    pub facing_right: bool,
+    /// Render-space left/right wall tags, independent of the entrance side.
+    pub wall_tags: [u32; 2],
+    pub calibrated_jumps: usize,
+    pub speed_samples: usize,
+    pub jump_height_milli: Option<u32>,
+    pub flight_ticks: Option<u32>,
+    pub run_speed_milli: Option<u32>,
+    pub target_obstacle: Option<usize>,
+    pub spawned_ticks: u64,
+    pub exit_visible: bool,
+    #[serde(default)]
+    pub body_radius_milli: u32,
+    #[serde(default)]
+    pub planning: Option<ClockDuckPlanningState>,
+}
+
 /// Temporary course/controller telemetry. Position is in thousandths of render
 /// world units; the duck and its physics are absent during opening/resetting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -520,6 +612,9 @@ pub struct ClockDuckState {
     pub entrance_open_milli: u32,
     pub exit_open_milli: u32,
     pub outcome: Option<ClockDuckOutcome>,
+    /// Additive diagnostics: old schema-8 payloads may omit this object.
+    #[serde(default)]
+    pub navigation: Option<ClockDuckNavigationState>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/spacewars-cli/src/clock.rs
+++ b/crates/spacewars-cli/src/clock.rs
@@ -286,6 +286,63 @@ fn print_state(state: &ClockState, json: bool) -> Result<(), CliError> {
                 duck.grounded,
                 duck.outcome
             );
+            if let Some(navigation) = duck.navigation {
+                println!(
+                    "Duck controller: {:?} / {:?}, facing {}; wall tags L/R={:?}, target obstacle={:?}, exit visible={}; course seed={}",
+                    navigation.jump_profile,
+                    navigation.behavior,
+                    if navigation.facing_right {
+                        "right"
+                    } else {
+                        "left"
+                    },
+                    navigation.wall_tags,
+                    navigation.target_obstacle,
+                    navigation.exit_visible,
+                    navigation.course_seed
+                );
+                println!(
+                    "Duck measured: {} warm-up jumps, {} speed samples; run={:?} units/s, jump={:?} units, flight={:?} ticks",
+                    navigation.calibrated_jumps,
+                    navigation.speed_samples,
+                    navigation.run_speed_milli.map(|v| v as f32 / 1000.0),
+                    navigation.jump_height_milli.map(|v| v as f32 / 1000.0),
+                    navigation.flight_ticks
+                );
+                if let Some(planning) = navigation.planning {
+                    println!(
+                        "Duck movement: {} running jumps, {} moving landings, {} careful fallbacks",
+                        planning.running_jumps,
+                        planning.moving_landings,
+                        planning.flowing_fallbacks
+                    );
+                    println!(
+                        "Duck landings: {} confirmed, {} short, {} long, {} wrong-surface; support={:?}/{}, rejected={} ({:?}), fallback={}",
+                        planning.confirmed_landings,
+                        planning.undershoots,
+                        planning.overshoots,
+                        planning.wrong_surface_landings,
+                        planning.support,
+                        planning.surface_count,
+                        planning.rejected_plans,
+                        planning.rejection,
+                        planning.fallback_course
+                    );
+                    if let Some(plan) = planning.plan {
+                        println!(
+                            "Duck plan: {} -> {}, takeoff={:?}, landing={:?} (milliunits), flight={} ticks, cruise={:.3} units/s, running={}, next={:?}",
+                            plan.source,
+                            plan.target,
+                            plan.takeoff_milli,
+                            plan.landing_milli,
+                            plan.flight_ticks,
+                            plan.cruise_speed_milli as f32 / 1000.0,
+                            plan.running_takeoff,
+                            plan.next_target
+                        );
+                    }
+                }
+            }
         }
         if let Some(marquee) = &state.marquee {
             println!(

--- a/crates/spacewars-cli/src/clock.rs
+++ b/crates/spacewars-cli/src/clock.rs
@@ -311,10 +311,12 @@ fn print_state(state: &ClockState, json: bool) -> Result<(), CliError> {
                 );
                 if let Some(planning) = navigation.planning {
                     println!(
-                        "Duck movement: {} running jumps, {} moving landings, {} careful fallbacks",
+                        "Duck movement: {:?} course; {} running jumps, {} moving landings, {} careful fallbacks, {} platforms skipped",
+                        planning.pattern,
                         planning.running_jumps,
                         planning.moving_landings,
-                        planning.flowing_fallbacks
+                        planning.flowing_fallbacks,
+                        planning.skipped_platforms
                     );
                     println!(
                         "Duck landings: {} confirmed, {} short, {} long, {} wrong-surface; support={:?}/{}, rejected={} ({:?}), fallback={}",

--- a/crates/spacewars-control/src/clock.rs
+++ b/crates/spacewars-control/src/clock.rs
@@ -542,6 +542,7 @@ mod tests {
                 exit_visible: true,
                 body_radius_milli: 8000,
                 planning: Some(engine_common::ClockDuckPlanningState {
+                    pattern: engine_common::ClockDuckCoursePattern::Shortcut,
                     surface_count: 5,
                     support: Some(1),
                     plan: Some(engine_common::ClockDuckPlanState {
@@ -566,6 +567,7 @@ mod tests {
                     running_jumps: 10,
                     flowing_fallbacks: 1,
                     moving_landings: 10,
+                    skipped_platforms: 2,
                 }),
             }),
         });
@@ -585,7 +587,13 @@ mod tests {
             .unwrap();
         navigation.remove("jump_profile");
         let planning = navigation["planning"].as_object_mut().unwrap();
-        for field in ["running_jumps", "flowing_fallbacks", "moving_landings"] {
+        for field in [
+            "running_jumps",
+            "flowing_fallbacks",
+            "moving_landings",
+            "skipped_platforms",
+            "pattern",
+        ] {
             planning.remove(field);
         }
         let plan = planning["plan"].as_object_mut().unwrap();
@@ -598,6 +606,11 @@ mod tests {
             engine_common::ClockDuckJumpProfile::Careful
         );
         let planning = navigation.planning.unwrap();
+        assert_eq!(
+            planning.pattern,
+            engine_common::ClockDuckCoursePattern::Platforms
+        );
+        assert_eq!(planning.skipped_platforms, 0);
         assert_eq!(
             (
                 planning.running_jumps,

--- a/crates/spacewars-control/src/clock.rs
+++ b/crates/spacewars-control/src/clock.rs
@@ -526,6 +526,48 @@ mod tests {
             entrance_open_milli: 0,
             exit_open_milli: 700,
             outcome: Some(engine_common::ClockDuckOutcome::Exited),
+            navigation: Some(engine_common::ClockDuckNavigationState {
+                jump_profile: engine_common::ClockDuckJumpProfile::Flowing,
+                course_seed: 42,
+                behavior: engine_common::ClockDuckBehavior::Exiting,
+                facing_right: false,
+                wall_tags: [2, 2],
+                calibrated_jumps: 2,
+                speed_samples: 9,
+                jump_height_milli: Some(35_000),
+                flight_ticks: Some(51),
+                run_speed_milli: Some(160_000),
+                target_obstacle: None,
+                spawned_ticks: 1650,
+                exit_visible: true,
+                body_radius_milli: 8000,
+                planning: Some(engine_common::ClockDuckPlanningState {
+                    surface_count: 5,
+                    support: Some(1),
+                    plan: Some(engine_common::ClockDuckPlanState {
+                        source: 1,
+                        target: 2,
+                        takeoff_milli: [-100_000, -150_000],
+                        landing_milli: [0, -140_000],
+                        flight_ticks: 45,
+                        cruise_speed_milli: 120_000,
+                        running_takeoff: true,
+                        next_target: Some(3),
+                    }),
+                    confirmed_landings: 10,
+                    undershoots: 1,
+                    overshoots: 0,
+                    wrong_surface_landings: 0,
+                    rejected_plans: 1,
+                    rejection: Some(engine_common::ClockDuckRejection::OutOfRange),
+                    acceleration_milli: Some(960_000),
+                    generation_attempts: 2,
+                    fallback_course: false,
+                    running_jumps: 10,
+                    flowing_fallbacks: 1,
+                    moving_landings: 10,
+                }),
+            }),
         });
         assert_eq!(
             ClockState::from_json(&state.to_json().unwrap()).unwrap(),
@@ -535,6 +577,48 @@ mod tests {
         assert_eq!(
             ClockTriggerRequest::from_json(&request.to_json().unwrap()).unwrap(),
             request
+        );
+        // The two-profile diagnostics remain additive to the careful planner.
+        let mut careful_payload = serde_json::to_value(&state).unwrap();
+        let navigation = careful_payload["duck"]["navigation"]
+            .as_object_mut()
+            .unwrap();
+        navigation.remove("jump_profile");
+        let planning = navigation["planning"].as_object_mut().unwrap();
+        for field in ["running_jumps", "flowing_fallbacks", "moving_landings"] {
+            planning.remove(field);
+        }
+        let plan = planning["plan"].as_object_mut().unwrap();
+        plan.remove("running_takeoff");
+        plan.remove("next_target");
+        let older = ClockState::from_json(&careful_payload.to_string()).unwrap();
+        let navigation = older.duck.unwrap().navigation.unwrap();
+        assert_eq!(
+            navigation.jump_profile,
+            engine_common::ClockDuckJumpProfile::Careful
+        );
+        let planning = navigation.planning.unwrap();
+        assert_eq!(
+            (
+                planning.running_jumps,
+                planning.flowing_fallbacks,
+                planning.moving_landings
+            ),
+            (0, 0, 0)
+        );
+        assert!(!planning.plan.unwrap().running_takeoff);
+        assert_eq!(planning.plan.unwrap().next_target, None);
+        // Navigation is an additive schema-8 field; older clients/recordings
+        // can still exchange the original Duck diagnostics.
+        let mut old_payload = serde_json::to_value(&state).unwrap();
+        old_payload["duck"]
+            .as_object_mut()
+            .unwrap()
+            .remove("navigation");
+        state.duck.as_mut().unwrap().navigation = None;
+        assert_eq!(
+            ClockState::from_json(&old_payload.to_string()).unwrap(),
+            state
         );
     }
 

--- a/docs/clock.md
+++ b/docs/clock.md
@@ -94,16 +94,27 @@ whole event-local representation. This does not depend on destructible terrain.
 
 Duck opens a side door and spawns a yellow pixel duck. It makes two vertical
 warm-up jumps, measures its sustained running speed along the entrance runway,
-then plays wall-tag across raised platforms and gaps. Seeded variations choose
-two or three platforms, their heights, widths and positions, and the entrance
-side. Each landing becomes the starting point for the next planned jump. The opposite
+then plays wall-tag across raised platforms and gaps. Each visit independently
+selects a seeded course pattern and movement personality. The patterns are:
+
+- **Platforms:** the original two/three randomly spaced raised platforms.
+- **Terraces:** low–high–low steps, with seeded height variation.
+- **Two-jump:** a small landing platform between two runways. Arrival position
+  and speed determine whether there is room for another running takeoff.
+- **Shortcut:** a low intermediate platform that can be landed on or skipped
+  in one longer jump to the following surface.
+
+Authored patterns keep their runway/gap widths and vary raised heights by ±10%.
+All preserve a safe adjacent-platform route for Careful, in both directions.
+The entrance side is seeded too. Each landing becomes the starting point for the
+next planned jump. The opposite
 door is entirely hidden for 20 simulation seconds after spawn (warm-up included).
 When it appears, the duck finishes its current crossing, turning at the entrance
 if necessary, and leaves through the exit. The course fades away, restoring the
 ordinary floor and center drain; the clock follows live time throughout.
 
 The duck uses **one dynamic round body** and one fixed body/collider per landing
-surface, including the entrance and exit runways: normally **five or six bodies
+surface, including the entrance and exit runways: normally **four to six bodies
 and colliders**. The course ceiling is seven surfaces plus the duck, with no
 joints or growing particle/entity lists. An acceleration-limited movement controller provides
 standing, walking, running and grounded jumping. Run speed is 1.4 times walk
@@ -155,7 +166,7 @@ speed limits, calibration and generated course. It considers three takeoff
 positions and three landing positions, carrying constant horizontal speed through
 flight and touchdown. A two-link lookahead scores the approach/flight time of
 the next jump too, preferring landings that leave a running continuation. There
-are at most 9 + 9×9 candidate arcs per planning decision, with at most 120
+are at most 9 + 9×9 + 9 + 9 = **108 candidate arcs** per planning decision, with at most 120
 clearance samples per arc. There is no second physics world or per-frame route
 search; the small candidate arrays are stack allocated.
 
@@ -163,8 +174,18 @@ Both takeoff and landing retain room to brake safely. At launch, the planned
 arc is re-anchored to the actual position and checked again; after contact, the
 next decision uses actual support/velocity, not the prediction. If a running
 takeoff is unavailable or invalidated, Flowing falls back to the **unchanged
-Careful hop**. It does not skip platforms or change jump strength. Moving
-platforms, variable-height jumps and longer route searches remain future work.
+Careful hop**. Edge landing candidates include a tick of launch-position margin
+so a slightly early actual takeoff does not immediately invalidate the landing.
+
+Flowing also considers skipping **one** intermediate platform. It compares the
+direct jump's estimated approach/flight time with the two adjacent links,
+requiring at least a 5% saving when a running route exists. The existing fallback
+penalty is used for a non-running continuation; this is a bounded heuristic,
+not a globally optimal route search. The entire arc must clear the intervening
+platform and leave braking room on the destination. Unavailable/obstructed
+shortcuts are refused. Jump strength is unchanged. A linked pair of jumps always
+has real ground contact between them: this is **not an airborne double jump**.
+Moving platforms, variable-height jumps and longer searches remain future work.
 
 To compare profiles, use the same `--seed` and preview sequence:
 
@@ -179,13 +200,24 @@ SPACEWARS_CLOCK_DUCK_PROFILE=careful \
 # Running jumps where the course leaves enough room; careful hops elsewhere.
 SPACEWARS_CLOCK_DUCK_PROFILE=flowing \
   cargo run --release -p engine-client -- --scenario clock --seed 42
+
+# Revisit a specific test course with the trajectory overlay.
+SPACEWARS_CLOCK_DUCK_PROFILE=flowing SPACEWARS_CLOCK_DUCK_COURSE=two-jump \
+  SPACEWARS_CLOCK_DUCK_DEBUG=1 \
+  cargo run --release -p engine-client -- --scenario clock --seed 42
 ```
 
 The environment override is read when creating/restarting the Clock scenario;
 `careful` and `flowing` force a personality, while unset, `mixed`, or unknown
 values use the seeded mix. It is not a persistent menu setting. Changing the
 override requires relaunching the process. Standard benchmark mode remains
-pinned to the Careful configuration. The seeded physics comparison below
+pinned to Careful on the original Platforms pattern. The course override accepts
+`platforms`, `terraces`, `two-jump`, or `shortcut`; unset, `mixed`, and unknown
+values select a seeded pattern. Preview Duck through Clock Controls after
+launching. Use `shortcut` in the last command to watch platform skipping, or
+switch the personality to `careful` to watch the adjacent route on the same course.
+These overrides are independent and do not change event scheduling.
+The seeded physics comparison below
 exercises both profiles.
 The upright pixel sprite and sliding doors are presentation, not articulated
 physics. Doors are logical backstage entry/exit markers, not trapping colliders.
@@ -456,7 +488,8 @@ null until sampled. `left_to_right` remains the **entrance side**; use
 current crossing's surface transitions; total jumps include warm-up jumps. Navigation fields retain
 the final controller state during reset, not a claim of a still-live body.
 
-`navigation.planning` adds surface count, current physical support (null when
+`navigation.planning` adds `pattern` (`platforms`, `terraces`, `two-jump`,
+`shortcut`), surface count, current physical support (null when
 airborne or despawned), generation attempts/fallback status, measured acceleration,
 confirmed landings, undershoots, overshoots, wrong-surface landings and rejected
 plans. The rejection reason is `too-narrow`, `too-high`, `out-of-range`, or
@@ -473,6 +506,10 @@ counts running-plan refusals/aborts that use the careful planner (separate from
 and optional `next_target`: the latter is a feasible second link at planning
 time, not a commitment to execute it regardless of the actual landing. Older
 payloads without these fields default to Careful, false/null and zero counts.
+`skipped_platforms` counts intermediate platforms bypassed by **confirmed**
+landings, not proposed shortcuts or merely passing overhead. A fallback course
+reports its actual Platforms pattern. Older payloads default to Platforms and
+zero skips.
 
 Older schema-8 payloads without `navigation` still decode; this adds no commands
 or action payload changes. Both text and JSON `clock state` show these diagnostics.
@@ -633,7 +670,8 @@ The release Duck UI workflow passed under Xvfb with both profiles (including the
 Flowing overlay), covering diagnostics, pause, preview replacement, exit,
 cleanup, restart and relaunch.
 
-The two-profile comparison uses **448 identical course/seed/aspect combinations
+The pre-authored-course baseline comparison (commit `65db26f`, before shortcut
+selection and the landing-margin refinement) used **448 identical course/seed/aspect combinations
 per profile** (seeds 0–63 across the same seven aspect ratios). All 896 runs
 exited and cleaned up without falls, timeouts or missed landings. Careful's
 5,163 confirmed landings and Flowing's 7,587 total **12,750 physical landings**.
@@ -679,6 +717,37 @@ overlay-on/off simulation equivalence are covered too.
 Raster captures were reviewed at 800×480 and 1024×768, including a trajectory
 overlay capture. Automated render checks also cover portrait and verify the
 actual exit-frame pixels before/after the timer.
+
+The authored-course regression suite adds a one-jump-planner ablation: on the
+Two-jump fixture, aiming for the platform center leaves no running continuation,
+while lookahead chooses an earlier, slower landing that preserves one. Solver
+tests then require actual consecutive running takeoffs **and confirmed landings**,
+without stopping between them, in both directions. The Shortcut fixture must
+actually bypass a platform and land on the second in both directions; Careful
+must still finish via adjacent platforms. Separate checks reject an obstructing
+platform and a too-narrow shortcut destination. Skip counters only advance after
+confirmed target contact, and every jump must begin grounded.
+
+The normal pattern matrix covers four seeds × four patterns × seven aspects ×
+two profiles (224 runs). Its extended sweep covers seeds 4–31. Both enforce
+zero missed landings/falls/timeouts, both wall tags, at least three traversals
+(counting skipped links), bounded bodies and complete cleanup. Rendering tests
+cover all four patterns with both personalities at four resolutions.
+
+The combined **1,792-run** sweep passed: **21,418 confirmed landings**, including
+**7,066 completed running-jump pairs** and **958 confirmed platform skips** for
+Flowing; Careful skipped none. The fixed Two-jump fixture completes five running
+pairs per visit, and the Shortcut fixture skips five platforms per visit, at both
+800×480 and 1024×768 aspect ratios. These totals include return crossings while
+waiting for the exit; they are not counts of distinct platforms.
+
+```sh
+cargo test -p scenario-clock authored_routes -- --nocapture
+cargo test -p scenario-clock skips_an_intermediate -- --nocapture
+cargo test -p scenario-clock lookahead_preserves -- --nocapture
+cargo test -p scenario-clock seeded_patterns -- --nocapture
+cargo test -p scenario-clock authored_pattern_stress -- --ignored --nocapture
+```
 
 Formatting, diff checks, the host `pi-kiosk` feature check and strict Clippy with
 `--no-deps` for Clock/common/control/CLI passed. Dependency-inclusive Clippy

--- a/docs/clock.md
+++ b/docs/clock.md
@@ -7,8 +7,9 @@ reads the system clock. Configure the device's timezone/NTP as described in
 
 Implementation checkpoint for [#19](https://github.com/aortez/space-wars/issues/19):
 the useful clock, Falling and Color Cycle are merged, as are Meltdown (#52),
-Duck and composed Marquee/saved text (#53). The issue's September 6 resume notes
-predate those deliveries. This slice adds time-change-triggered Digit Slide;
+Duck and composed Marquee/saved text (#53), and time-change-triggered Digit Slide.
+The issue's September 6 resume notes predate those deliveries. The current Duck
+upgrade (#69) adds calibrated platform planning and generated wall-tag courses;
 rain/storm, flashlight/glow polish and concurrent events remain future work.
 
 ## Events
@@ -41,7 +42,7 @@ the Off profile still disables every automatic event.
 | `falling` | Digit geometry / rigid bodies | 3.5 s fall + 1.5 s reform | 30 s |
 | `color-cycle` | Appearance only | 6 s | 15 s |
 | `meltdown` | Individual cells, pooling water and drain | 3 s melt + 4 s drain + 1.5 s reform | 40 s |
-| `duck` | Temporary floor course and a physical runner | 10 s envelope, including doors/reset | 30 s |
+| `duck` | Temporary floor course and a physical wall-tag runner | 35 s envelope, exit appears 20 s after spawn | 30 s |
 | `marquee` | Composed content motion and lighting, no physics | 12 s, including 0.75 s fades | 20 s |
 | `digit-slide` | Changed digits roll down inside clipped slots, no physics | 0.8 s | 2 s |
 
@@ -91,28 +92,126 @@ boundary accounts for and clears any remaining material rather than reporting
 it as successfully drained. Preview replacement, resize and restart drop the
 whole event-local representation. This does not depend on destructible terrain.
 
-Duck opens a side door, spawns a yellow pixel duck, and runs it across two small
-hurdles and one pit. Seeded variations choose the hurdle heights/positions, pit
-width, and entrance side. The opposite door opens as the duck approaches; after
-it exits, both doors and the temporary course fade away, restoring the ordinary
-floor and center drain. The clock remains anchored and follows live time above.
+Duck opens a side door and spawns a yellow pixel duck. It makes two vertical
+warm-up jumps, measures its sustained running speed along the entrance runway,
+then plays wall-tag across raised platforms and gaps. Seeded variations choose
+two or three platforms, their heights, widths and positions, and the entrance
+side. Each landing becomes the starting point for the next planned jump. The opposite
+door is entirely hidden for 20 simulation seconds after spawn (warm-up included).
+When it appears, the duck finishes its current crossing, turning at the entrance
+if necessary, and leaves through the exit. The course fades away, restoring the
+ordinary floor and center drain; the clock follows live time throughout.
 
-The duck uses **one dynamic round body**, two fixed floor pieces, and two fixed
-hurdles: at most **five bodies and five colliders**, no joints, and no growing
-particle/entity lists. A small horizontal velocity servo runs it forward. Its
-rule controller looks ahead to the next obstacle and applies a jump velocity
-change only while supported by a real upward-facing contact. Gravity and Rapier
-contacts handle the resulting motion; it does not teleport across obstacles.
+The duck uses **one dynamic round body** and one fixed body/collider per landing
+surface, including the entrance and exit runways: normally **five or six bodies
+and colliders**. The course ceiling is seven surfaces plus the duck, with no
+joints or growing particle/entity lists. An acceleration-limited movement controller provides
+standing, walking, running and grounded jumping. Run speed is 1.4 times walk
+speed; the tuned jump height is 50% higher than the original duck's. It slows
+near a safe turnaround line inside each edge and reverses through acceleration,
+not by reflecting velocity or teleporting the body. The sprite faces its chosen
+travel direction independently of the entrance-side course mirroring.
+
+The rule controller measures actual body motion, not the actuator's tuning:
+peak height and flight time from two clean vertical jumps, acceleration during
+the runway run-up, and a rolling median of up to nine steady grounded speed
+samples. Side/ceiling-disturbed jumps are discarded
+and retried; airborne, blocked, accelerating and turnaround motion cannot train
+the run-speed estimate. The median prevents an isolated speed spike from
+becoming a permanent maximum. Warm-up height uses the conservative lower of the
+two observations. Calibration then freezes for this course; those observations
+remain local to this event instance. Braking and airborne steering use the same
+symmetric acceleration-limited actuator as the grounded run-up.
+
+Each Duck event now chooses a **Careful** or **Flowing** personality once at
+creation, with a seeded 50/50 choice. It keeps that personality throughout its
+warm-up, crossings, turnarounds and exit. Repeated visits can have different
+personalities; they do not have to alternate. A separate seeded stream leaves
+course geometry, entrance side and the event schedule unchanged, making both
+the choice and movement replayable. The personalities can evolve separately
+without removing either style.
+
+The **Careful** jumping profile preserves the deliberate stop-and-hop
+motion. Its planner reconstructs a ballistic arc from the measured height and flight
+time, using its descending intersection with the next platform's height. It
+tries at most three inset landing points, checks body clearance along the arc,
+and leaves headroom in jump height, speed and acceleration. The duck approaches
+and brakes at the takeoff point, jumps from real support, and steers/brakes
+toward its target. A landing only succeeds after an actual upward Rapier contact
+with the intended surface inside its safe landing interval. The next plan uses
+that actual support, not the predicted landing time. Short, long and wrong-surface
+landings are counted separately; unreachable plans are refused and retried at
+a bounded rate. Gravity and Rapier contacts handle the resulting motion.
+
+Generation checks every adjacent link in **both directions** against conservative
+capabilities, with at most 16 candidates before using a fixed fallback course.
+This is bounded, course-local planning, not general-purpose pathfinding or
+learning a policy. The ordered route and stationary platforms keep it cheap.
+The old two-hurdle/pit course
+is retained as a regression fixture, not a separate scenario or UI choice.
+
+The **Flowing** jumping profile uses the same body, gravity, jump impulse,
+speed limits, calibration and generated course. It considers three takeoff
+positions and three landing positions, carrying constant horizontal speed through
+flight and touchdown. A two-link lookahead scores the approach/flight time of
+the next jump too, preferring landings that leave a running continuation. There
+are at most 9 + 9×9 candidate arcs per planning decision, with at most 120
+clearance samples per arc. There is no second physics world or per-frame route
+search; the small candidate arrays are stack allocated.
+
+Both takeoff and landing retain room to brake safely. At launch, the planned
+arc is re-anchored to the actual position and checked again; after contact, the
+next decision uses actual support/velocity, not the prediction. If a running
+takeoff is unavailable or invalidated, Flowing falls back to the **unchanged
+Careful hop**. It does not skip platforms or change jump strength. Moving
+platforms, variable-height jumps and longer route searches remain future work.
+
+To compare profiles, use the same `--seed` and preview sequence:
+
+```sh
+# Normal operation: a seeded mix, chosen once per Duck visit.
+cargo run --release -p engine-client -- --scenario clock --seed 42
+
+# Force the original deliberate hop for comparison.
+SPACEWARS_CLOCK_DUCK_PROFILE=careful \
+  cargo run --release -p engine-client -- --scenario clock --seed 42
+
+# Running jumps where the course leaves enough room; careful hops elsewhere.
+SPACEWARS_CLOCK_DUCK_PROFILE=flowing \
+  cargo run --release -p engine-client -- --scenario clock --seed 42
+```
+
+The environment override is read when creating/restarting the Clock scenario;
+`careful` and `flowing` force a personality, while unset, `mixed`, or unknown
+values use the seeded mix. It is not a persistent menu setting. Changing the
+override requires relaunching the process. Standard benchmark mode remains
+pinned to the Careful configuration. The seeded physics comparison below
+exercises both profiles.
 The upright pixel sprite and sliding doors are presentation, not articulated
 physics. Doors are logical backstage entry/exit markers, not trapping colliders.
 
 Phases are `opening`, `running`, `exiting`, and `resetting`. A fall or a runner
-still blocked at 9.5 seconds enters reset; successful exits normally occur sooner.
+still blocked at 34.5 seconds enters reset; successful exits normally occur sooner.
+`exiting` starts when the door appears, even if the duck is still heading toward
+the entrance before its final return crossing.
 Reset immediately drops all physics, fades the course over half a second, and
-keeps the last outcome available until the fixed ten-second event envelope ends.
+keeps the last outcome available until the fixed 35-second event envelope ends.
 Resize, restart, or preview replacement also release the whole event. Narrow
 layouts scale the duck and jump height down; wider layouts increase running
 speed and horizontal course spacing while keeping the action below the face.
+
+This implements the calibrated movement, wall-tag, generated courses and
+platform-landing portions of [#69](https://github.com/aortez/space-wars/issues/69).
+For an optional planning overlay, start the client with:
+
+```sh
+SPACEWARS_CLOCK_DUCK_DEBUG=1 cargo run --release -p engine-client -- --scenario clock
+```
+
+Use **Clock Controls → Preview Event → Duck → Preview & Resume**. Cyan marks the planned takeoff,
+purple dots show the estimated body-center arc, and green marks the landing.
+This environment-only diagnostic is off by default, is not saved in settings,
+and does not alter the simulation. Normal benchmarks leave it off.
 
 All durations use fixed 60 Hz simulation ticks, so pause freezes the event and
 its schedule. The strict `clock trigger` command requires unpaused, synchronized,
@@ -166,7 +265,7 @@ or a host-time correction. Resizing during an event restores the current face
 and enters cooldown. Restart/relaunch starts a fresh seeded schedule. Rapier
 exists only during Falling's falling phase or Duck's running/exiting phases:
 at most 28 moving bars plus four arena bodies and 100 colliders for Falling,
-or five bodies/colliders for Duck, with no accumulating debris.
+or eight bodies/colliders at the Duck course ceiling, with no accumulating debris.
 
 ## Extending the event system
 
@@ -345,6 +444,38 @@ render world units, grounded state, jumps, cleared/total obstacles, door opennes
 in thousandths, and outcome (`exited`, `fell`, `timed-out`). It is present only
 during Duck; position is null before spawn and after despawn. Outcomes remain
 available during reset, not as a persistent event history.
+Its additive `navigation` object includes the reproducible course seed,
+`jump_profile` (`careful` or `flowing`), behavior
+(`warming-up`, `measuring-run`, `running`, `turning`, `exiting`, `approaching`,
+`jumping`, `landing`, `blocked`), sprite facing,
+left/right wall-tag counts, accepted calibration/sample counts, measured jump
+height/run speed (thousandths of world units or units/second), flight ticks,
+target surface index (`target_obstacle`), body radius, ticks since spawn, and exit visibility. Measurements are
+null until sampled. `left_to_right` remains the **entrance side**; use
+`navigation.facing_right` for the current direction. Cleared obstacles count the
+current crossing's surface transitions; total jumps include warm-up jumps. Navigation fields retain
+the final controller state during reset, not a claim of a still-live body.
+
+`navigation.planning` adds surface count, current physical support (null when
+airborne or despawned), generation attempts/fallback status, measured acceleration,
+confirmed landings, undershoots, overshoots, wrong-surface landings and rejected
+plans. The rejection reason is `too-narrow`, `too-high`, `out-of-range`, or
+`obstructed`. An active plan reports source/target indices, takeoff/landing **feet**
+positions in thousandths of render world units, predicted flight ticks and cruise
+speed. The overlay shifts these feet positions up by the radius to show the body
+center. Plan/counter diagnostics remain available during reset, alongside the
+outcome. This is a bounded snapshot, not an accumulating trace.
+
+`running_jumps` counts executed running takeoffs, `moving_landings` counts
+confirmed landings above 15% of measured run speed, and `flowing_fallbacks`
+counts running-plan refusals/aborts that use the careful planner (separate from
+`fallback_course`, which concerns generation). Plans expose `running_takeoff`
+and optional `next_target`: the latter is a feasible second link at planning
+time, not a commitment to execute it regardless of the actual landing. Older
+payloads without these fields default to Careful, false/null and zero counts.
+
+Older schema-8 payloads without `navigation` still decode; this adds no commands
+or action payload changes. Both text and JSON `clock state` show these diagnostics.
 The optional `marquee` object reports the active recipe, content, cell/group
 counts, progress in thousandths, scrolling/waving flags, rotation target and
 lighting mode. `settings.marquee_preset` and `settings.marquee_message` are the
@@ -483,31 +614,111 @@ The device captures below document the earlier events, not Meltdown.
 
 ### Duck local validation
 
-The workspace/all-target suite passed **875 tests** (16 display-dependent
-workflows ignored); all **six Clock UI workflows** were then run explicitly on
-the local X display and passed. Strict Clippy passed for Clock/common/control/CLI.
+The original Duck workspace/all-target suite passed **875 tests** (16
+display-dependent workflows ignored); all **six Clock UI workflows** were then
+run explicitly on the local X display and passed. Strict Clippy passed for
+Clock/common/control/CLI.
 
-The deterministic course test runs 32 seeds at each of four aspect ratios
-(0.25, 0.75, 800/480, and 4): every run must jump all three obstacles, reach the
-exit, and release every body. Each jump must start from physical support; door
-openness and spawn/despawn are checked at exact simulation ticks. Separate tests
-inject a fall and an unjumpable wall to verify bounded recovery. Pause, time
-changes, resize, repeatability, and replacement by every other event are covered
-too. Raster tests at 800×480,
-480×800, and 1280×720 check visible duck pixels and exact restoration of the
-normal frame, with fewer than 300 draw primitives; the same frames reach vector
+For the calibrated platform-planning upgrade (2026-09-11), the deterministic
+physics sweep covered **1,792 generated courses** across seven aspect ratios:
+**20,202 confirmed landings**, no short/long/wrong-surface landings, no falls or
+timeouts, and no fallback generation. Exits occurred at event ticks 1296–1492
+(21.60–24.87 seconds). The ordinary suite runs 224 of those courses; an explicitly
+ignored stress test covers the other 1,568. These are local tests, not device
+performance measurements or a guarantee for every possible seed.
+
+**124 Clock/common/control/CLI tests** and **289 client tests** passed (the
+two extended stress tests and one existing client test are ignored by default).
+The release Duck UI workflow passed under Xvfb with both profiles (including the
+Flowing overlay), covering diagnostics, pause, preview replacement, exit,
+cleanup, restart and relaunch.
+
+The two-profile comparison uses **448 identical course/seed/aspect combinations
+per profile** (seeds 0–63 across the same seven aspect ratios). All 896 runs
+exited and cleaned up without falls, timeouts or missed landings. Careful's
+5,163 confirmed landings and Flowing's 7,587 total **12,750 physical landings**.
+The course, physics tuning, calibration and exit gate are held constant.
+
+| Metric | Careful | Flowing |
+| --- | ---: | ---: |
+| Mean first-wall arrival, including warm-up | 9.278 s | 8.125 s |
+| Mean nearly-stopped ticks before first wall, after calibration | 13.42 | 2.50 |
+| Running takeoffs / confirmed landings | 0 / 5,163 | 5,886 / 7,587 |
+| Careful fallbacks | 0 | 1,701 |
+
+“Nearly stopped” means grounded below 5% of measured run speed. Flowing arrived
+at the first wall **12.4% sooner**, with **81.4% fewer nearly-stopped ticks**.
+Of its running jumps, 4,160 had a feasible second running link when planned;
+that link is still replanned after actual contact. These are behavior metrics,
+not CPU benchmarks or guarantees for unseen courses. The 20-second exit gate
+means whole-event completion time is not a useful speed score: a faster duck
+instead completes more crossings while it waits.
+
+Additional tests preserve the explicit Careful fixture replay, identical
+calibration across profiles, constant-speed arc endpoints in both directions,
+takeoff revalidation, and recovery from an injected lost-speed takeoff through
+the careful fallback. Rendering and debug-overlay checks exercise both profiles.
+
+A 32-visit mixed-personality replay (20 Careful / 12 Flowing for seed 42) checks
+that both styles appear, each remains
+fixed for its entire event, and an identical seed reproduces every diagnostic
+snapshot. A forced-Careful run alongside it verifies identical course geometry,
+entrance side, event IDs and scheduling deadlines. The client override parser
+also tests forced Careful, forced Flowing and default/mixed behavior.
+The mixed-default live UI workflow also passed under Xvfb using the debug client.
+
+Fixed single-platform, stepped and gap fixtures run at all seven aspect ratios.
+Every confirmed landing must match the planned collider's actual physical
+support. Every course must tag both walls, complete at least three traversals
+of its surface links, exit and release all bodies. Separate fault injection
+verifies short, long and wrong-surface classifications, refusal of impossible
+plans, bounded retries and timeout cleanup. Forced generator exhaustion checks
+the fallback course at every aspect ratio; pause, resize, replacement and
+overlay-on/off simulation equivalence are covered too.
+
+Raster captures were reviewed at 800×480 and 1024×768, including a trajectory
+overlay capture. Automated render checks also cover portrait and verify the
+actual exit-frame pixels before/after the timer.
+
+Formatting, diff checks, the host `pi-kiosk` feature check and strict Clippy with
+`--no-deps` for Clock/common/control/CLI passed. Dependency-inclusive Clippy
+encounters an existing `collapsible_else_if` warning in
+`engine-rapier/src/spaceling.rs`; no unrelated physics code was changed.
+
+The retained hurdle/pit regression test runs **32 seeds at seven aspect ratios**
+(0.25, 0.6, 0.75, 1024/768, 800/480, 1280/720, and 4). Every run must complete its
+calibration, tag both walls, jump all three obstacles on every crossing, exit,
+and release every body. Each jump must start from physical support; door
+visibility/openness and spawn/despawn are checked at exact simulation ticks.
+Separate tests alter the actual actuator speed, jump height and gravity to check
+the estimates, disturb a warm-up flight to verify rejection/retry, reject invalid
+and outlier samples, and inject a fall/unjumpable wall for bounded cleanup.
+Pause, time changes, resize, repeatability, and replacement by every other event
+are covered too. Raster tests at 800×480, 1024×768, 480×800, and 1280×720 check
+visible duck pixels and exact restoration of the normal frame, with fewer than
+300 draw primitives; the same frames reach vector
 presentation. The real-client Duck workflow checks both settings pages, disabled
 previews, controller navigation, phase telemetry, pause, exit, and restart/relaunch.
 It does not need to catch the brief door animations on a busy machine.
 
 ```sh
-cargo test --locked -p scenario-clock events::duck
+cargo test --locked -p scenario-clock events::duck -- --nocapture
+cargo test --locked -p scenario-clock platform_seed_stress -- --ignored --nocapture
+cargo test --locked -p scenario-clock jumping_profiles_compare -- --nocapture
+cargo test --locked -p scenario-clock jumping_profile_stress -- --ignored --nocapture
 SPACEWARS_CLOCK_ARTIFACTS=/tmp/clock-captures \
   cargo test --locked -p engine-client duck_course_reaches -- --nocapture
+SPACEWARS_CLOCK_ARTIFACTS=/tmp/clock-captures \
+  cargo test --locked -p engine-client duck_planning_overlay -- --nocapture
 ```
 
-**Duck has not been deployed or tested on the Pi.** Ask before deploying; another
-task may be testing there.
+These are scripted real-physics tests, not wall-clock sleeps. `--nocapture` prints
+the seeded matrix's success count and earliest/latest exit ticks. The original
+one-pass implementation fails the new wall-tag regression by opening its exit
+at tick 371 after spawn, before the required 1,200-tick delay.
+
+**This Duck upgrade has not been deployed or tested on the Pi.** Ask before
+deploying; another task may be testing there.
 
 ### Marquee local verification
 

--- a/scenarios/clock/src/events.rs
+++ b/scenarios/clock/src/events.rs
@@ -171,12 +171,17 @@ impl ActiveEvent {
         marquee_preset: engine_common::ClockMarqueePreset,
         marquee_message: engine_common::ClockMarqueeMessage,
         previous_display: Option<DisplaySnapshot>,
+        duck_jump_profile: Option<engine_common::ClockDuckJumpProfile>,
     ) -> Self {
         match kind {
             ClockEventKind::Falling => Self::Falling(FallingEvent::new(context, seed)),
             ClockEventKind::ColorCycle => Self::ColorCycle(ColorCycle::default()),
             ClockEventKind::Meltdown => Self::Meltdown(Box::new(MeltdownEvent::new(context, seed))),
-            ClockEventKind::Duck => Self::Duck(Box::new(DuckEvent::new(context.layout, seed))),
+            ClockEventKind::Duck => {
+                let mut event = DuckEvent::new_platforms(context.layout, seed);
+                event.select_jump_profile(duck_jump_profile);
+                Self::Duck(Box::new(event))
+            }
             ClockEventKind::Marquee => Self::Marquee(Box::new(MarqueeEvent::new(
                 marquee_preset,
                 marquee_message,

--- a/scenarios/clock/src/events.rs
+++ b/scenarios/clock/src/events.rs
@@ -168,23 +168,22 @@ impl ActiveEvent {
         kind: ClockEventKind,
         context: EventContext<'_>,
         seed: u64,
-        marquee_preset: engine_common::ClockMarqueePreset,
-        marquee_message: engine_common::ClockMarqueeMessage,
+        config: super::ClockConfig,
         previous_display: Option<DisplaySnapshot>,
-        duck_jump_profile: Option<engine_common::ClockDuckJumpProfile>,
     ) -> Self {
         match kind {
             ClockEventKind::Falling => Self::Falling(FallingEvent::new(context, seed)),
             ClockEventKind::ColorCycle => Self::ColorCycle(ColorCycle::default()),
             ClockEventKind::Meltdown => Self::Meltdown(Box::new(MeltdownEvent::new(context, seed))),
             ClockEventKind::Duck => {
-                let mut event = DuckEvent::new_platforms(context.layout, seed);
-                event.select_jump_profile(duck_jump_profile);
+                let mut event =
+                    DuckEvent::new_course(context.layout, seed, config.duck_course_pattern);
+                event.select_jump_profile(config.duck_jump_profile);
                 Self::Duck(Box::new(event))
             }
             ClockEventKind::Marquee => Self::Marquee(Box::new(MarqueeEvent::new(
-                marquee_preset,
-                marquee_message,
+                config.marquee_preset,
+                config.marquee_message,
                 context.display,
             ))),
             ClockEventKind::DigitSlide => {

--- a/scenarios/clock/src/events/duck.rs
+++ b/scenarios/clock/src/events/duck.rs
@@ -58,7 +58,20 @@ pub(crate) struct DuckEvent {
 }
 
 impl DuckEvent {
+    #[cfg(test)]
     pub fn new_platforms(layout: Layout, seed: u64) -> Self {
+        Self::new_course(
+            layout,
+            seed,
+            Some(engine_common::ClockDuckCoursePattern::Platforms),
+        )
+    }
+
+    pub fn new_course(
+        layout: Layout,
+        seed: u64,
+        pattern: Option<engine_common::ClockDuckCoursePattern>,
+    ) -> Self {
         let mut event = Self::new(layout, seed);
         // Preserve room for the full jump arc below the clock on very wide
         // displays. Standard device layouts keep the existing duck size.
@@ -66,7 +79,12 @@ impl DuckEvent {
             .radius
             .min((layout.face_origin.y - layout.floor_y - 4.0) / 10.5);
         event.movement = Movement::new(event.width, event.radius);
-        event.course = Some(planner::Course::generated(event.width, event.radius, seed));
+        event.course = Some(planner::Course::varied(
+            event.width,
+            event.radius,
+            seed,
+            pattern,
+        ));
         event
     }
 
@@ -442,6 +460,7 @@ impl DuckEvent {
                         ]
                     };
                     ClockDuckPlanningState {
+                        pattern: course.pattern,
                         surface_count: course.surfaces.len(),
                         support: self.supported_surface(),
                         plan: navigator.plan.map(|plan| ClockDuckPlanState {
@@ -475,6 +494,7 @@ impl DuckEvent {
                         running_jumps: navigator.running_jumps,
                         flowing_fallbacks: navigator.flowing_fallbacks,
                         moving_landings: navigator.moving_landings,
+                        skipped_platforms: navigator.skipped_platforms,
                     }
                 }),
             }),

--- a/scenarios/clock/src/events/duck.rs
+++ b/scenarios/clock/src/events/duck.rs
@@ -1,10 +1,16 @@
 //! A bounded, event-local obstacle course. The round body is physical; the
 //! upright pixel character and side doors are presentation, not articulated rigs.
 
+mod controller;
+mod flow;
+pub(crate) mod planner;
+#[cfg(test)]
+mod platform_tests;
 #[cfg(test)]
 mod tests;
 
-use engine_common::{ClockDuckOutcome, ClockDuckState};
+use controller::{Controller, CourseContext, Movement, Observation};
+use engine_common::{ClockDuckNavigationState, ClockDuckOutcome, ClockDuckState};
 use engine_core::Vec2;
 use engine_rapier::world::{
     BodyId, BodyKind, BodyRole, BodySpec, ColliderId, ColliderRole, ColliderSpec, PhysicsId,
@@ -15,7 +21,8 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 use super::EventPhase;
 use crate::layout::Layout;
 
-pub const DUCK_TICKS: u64 = 10 * 60;
+pub const DUCK_TICKS: u64 = 35 * 60;
+const EXIT_DELAY_TICKS: u64 = 20 * 60;
 const OPENING_TICKS: u64 = 36;
 const RESET_TICKS: u64 = 30;
 const DT: f32 = 1.0 / 60.0;
@@ -38,18 +45,31 @@ pub(crate) struct DuckEvent {
     pub layout: Layout,
     pub width: f32,
     pub radius: f32,
+    /// Fixed entrance-side course mirroring, not the runner's current facing.
     pub direction: f32,
     pub obstacles: [Obstacle; 3],
+    pub course: Option<planner::Course>,
     world: Option<PhysicsWorld>,
-    speed: f32,
-    gravity: f32,
-    jumped: u8,
+    seed: u64,
+    movement: Movement,
+    controller: Controller,
     jumps: u32,
-    cleared: usize,
     outcome: Option<ClockDuckOutcome>,
 }
 
 impl DuckEvent {
+    pub fn new_platforms(layout: Layout, seed: u64) -> Self {
+        let mut event = Self::new(layout, seed);
+        // Preserve room for the full jump arc below the clock on very wide
+        // displays. Standard device layouts keep the existing duck size.
+        event.radius = event
+            .radius
+            .min((layout.face_origin.y - layout.floor_y - 4.0) / 10.5);
+        event.movement = Movement::new(event.width, event.radius);
+        event.course = Some(planner::Course::generated(event.width, event.radius, seed));
+        event
+    }
+
     pub fn new(layout: Layout, seed: u64) -> Self {
         let mut rng = StdRng::seed_from_u64(seed);
         let width = layout.bounds_max.x - layout.bounds_min.x;
@@ -83,57 +103,75 @@ impl DuckEvent {
                 last,
             ],
             world: None,
-            speed: width / 7.0,
-            gravity: radius * 50.0,
-            jumped: 0,
+            course: None,
+            seed,
+            movement: Movement::new(width, radius),
+            controller: Controller::new(),
             jumps: 0,
-            cleared: 0,
             outcome: None,
         }
     }
 
     fn spawn(&mut self) {
         let mut world = PhysicsWorld::new(PhysicsWorldConfig {
-            gravity: Vec2::new(0.0, -self.gravity),
+            gravity: Vec2::new(0.0, -self.movement.gravity),
             length_unit: self.radius,
             max_ccd_substeps: 2,
             collect_events: false,
             ..PhysicsWorldConfig::default()
         });
-        // Two floor halves, two hurdles and exactly one dynamic body.
-        world.reserve(5, 5, 0);
+        // One dynamic body; all course surfaces are fixed, bounded geometry.
+        let count = self
+            .course
+            .as_ref()
+            .map_or(5, |course| course.surfaces.len() + 1);
+        world.reserve(count, count, 0);
         let pit = self.obstacles[1];
         let floor = self.layout.floor_y;
-        for (index, (start, end, bottom, top)) in [
-            (
-                -self.radius * 8.0,
-                pit.start,
-                self.layout.bounds_min.y,
-                floor,
-            ),
-            (
-                pit.end,
-                self.width + self.radius * 8.0,
-                self.layout.bounds_min.y,
-                floor,
-            ),
-            (
-                self.obstacles[0].start,
-                self.obstacles[0].end,
-                floor,
-                floor + self.obstacles[0].height,
-            ),
-            (
-                self.obstacles[2].start,
-                self.obstacles[2].end,
-                floor,
-                floor + self.obstacles[2].height,
-            ),
-        ]
-        .into_iter()
-        .enumerate()
-        {
-            let entity = PhysicsId::new(100 + index as u64);
+        let geometry = if let Some(course) = &self.course {
+            course
+                .surfaces
+                .iter()
+                .map(|surface| {
+                    (
+                        surface.start,
+                        surface.end,
+                        self.layout.bounds_min.y,
+                        floor + surface.height,
+                    )
+                })
+                .collect::<Vec<_>>()
+        } else {
+            vec![
+                (
+                    -self.radius * 8.0,
+                    pit.start,
+                    self.layout.bounds_min.y,
+                    floor,
+                ),
+                (
+                    pit.end,
+                    self.width + self.radius * 8.0,
+                    self.layout.bounds_min.y,
+                    floor,
+                ),
+                (
+                    self.obstacles[0].start,
+                    self.obstacles[0].end,
+                    floor,
+                    floor + self.obstacles[0].height,
+                ),
+                (
+                    self.obstacles[2].start,
+                    self.obstacles[2].end,
+                    floor,
+                    floor + self.obstacles[2].height,
+                ),
+            ]
+        };
+        for (index, (start, end, bottom, top)) in geometry.into_iter().enumerate() {
+            let entity =
+                PhysicsId::new(if self.course.is_some() { 1000 } else { 100 } + index as u64);
             let mut collider = ColliderSpec::cuboid(
                 ColliderId::new(entity, ColliderRole::PRIMARY, 0),
                 (end - start) * 0.5,
@@ -157,7 +195,7 @@ impl DuckEvent {
         assert!(world.insert_body(
             DUCK_BODY,
             BodySpec {
-                position: Vec2::new(0.0, floor + self.radius * 1.05),
+                position: Vec2::new(self.radius * 6.0, floor + self.radius * 1.05),
                 can_sleep: false,
                 ccd_enabled: true,
                 ..BodySpec::default()
@@ -182,33 +220,61 @@ impl DuckEvent {
         })
     }
 
+    fn supported_surface(&self) -> Option<usize> {
+        let world = self.world.as_ref()?;
+        let course = self.course.as_ref()?;
+        world.surface_contacts(DUCK_COLLIDER).find_map(|contact| {
+            if contact.normal.y > 0.7 && contact.separation <= self.radius * 0.05 {
+                let index = contact.collider.entity.value().checked_sub(1000)? as usize;
+                (index < course.surfaces.len()).then_some(index)
+            } else {
+                None
+            }
+        })
+    }
+
     fn run(&mut self) {
         let grounded = self.grounded();
+        let support = self.supported_surface();
+        let exit_visible = self.exit_visible();
         let Some(world) = &mut self.world else { return };
         let motion = world.motion(DUCK_BODY).expect("live duck body");
-        // A small velocity servo accelerates the runner horizontally. Gravity,
-        // obstacle contacts and the jump impulse govern its vertical motion.
-        let dx = (self.speed - motion.linear_velocity.x)
-            .clamp(-self.speed * DT * 6.0, self.speed * DT * 6.0);
-        world.apply_velocity_delta(DUCK_BODY, Vec2::new(dx, 0.0), true);
-        for (index, obstacle) in self.obstacles.iter().enumerate() {
-            if motion.position.x > obstacle.end + self.radius {
-                self.cleared = self.cleared.max(index + 1);
-            } else if grounded
-                && self.jumped & (1 << index) == 0
-                && motion.position.x >= obstacle.start - self.radius - self.speed * 0.12
-            {
-                let jump_speed = (2.0 * self.gravity * self.radius * 3.0).sqrt();
-                world.apply_velocity_delta(
-                    DUCK_BODY,
-                    Vec2::new(0.0, jump_speed - motion.linear_velocity.y),
-                    true,
-                );
-                self.jumped |= 1 << index;
-                self.jumps += 1;
-                break;
-            }
+        let observed = Observation {
+            position: motion.position,
+            velocity: motion.linear_velocity,
+            grounded,
+            blocked: world.surface_contacts(DUCK_COLLIDER).any(|contact| {
+                (contact.normal.x.abs() > 0.3 || contact.normal.y < -0.3)
+                    && contact.separation <= self.radius * 0.05
+            }),
+            support,
+        };
+        let command = if let Some(course) = &self.course {
+            self.controller.decide_course(
+                observed,
+                CourseContext {
+                    course,
+                    obstacles: &self.obstacles,
+                    width: self.width,
+                    radius: self.radius,
+                    floor: self.layout.floor_y,
+                },
+                exit_visible,
+            )
+        } else {
+            self.controller.decide(
+                observed,
+                &self.obstacles,
+                self.width,
+                self.radius,
+                exit_visible,
+            )
+        };
+        let delta = self.movement.velocity_delta(observed, &command);
+        if command.jump && grounded {
+            self.jumps += 1;
         }
+        world.apply_velocity_delta(DUCK_BODY, delta, true);
         world.step(DT);
     }
 
@@ -232,6 +298,9 @@ impl DuckEvent {
                 self.enter(EventPhase::Running);
             }
             EventPhase::Running | EventPhase::Exiting => {
+                if self.phase == EventPhase::Running && self.exit_visible() {
+                    self.enter(EventPhase::Exiting);
+                }
                 self.run();
                 let position = self.position().expect("running duck");
                 if !position.x.is_finite()
@@ -239,12 +308,10 @@ impl DuckEvent {
                     || position.y < self.layout.floor_y - self.radius * 5.0
                 {
                     self.reset(ClockDuckOutcome::Fell);
-                } else if position.x > self.width + self.radius * 2.0 {
+                } else if self.exit_visible() && position.x > self.width + self.radius * 2.0 {
                     self.reset(ClockDuckOutcome::Exited);
                 } else if self.tick >= DUCK_TICKS - RESET_TICKS {
                     self.reset(ClockDuckOutcome::TimedOut);
-                } else if self.phase == EventPhase::Running && position.x > self.width * 0.87 {
-                    self.enter(EventPhase::Exiting);
                 }
             }
             _ => {}
@@ -260,6 +327,24 @@ impl DuckEvent {
             EventPhase::Resetting => (1.0 - self.phase_tick as f32 / RESET_TICKS as f32).max(0.0),
             _ => 1.0,
         }
+    }
+
+    pub fn exit_visible(&self) -> bool {
+        self.tick >= OPENING_TICKS + EXIT_DELAY_TICKS
+    }
+
+    /// Character facing is independent of the entrance-side course transform.
+    pub fn facing(&self) -> f32 {
+        self.controller.direction
+    }
+
+    pub fn debug_arc(&self) -> Option<[Vec2; 25]> {
+        let plan = self.controller.navigator.plan?;
+        let capabilities = self.controller.capabilities()?;
+        Some(std::array::from_fn(|i| {
+            plan.sample(capabilities, i as f32 / 24.0)
+                + Vec2::new(0.0, self.layout.floor_y + self.radius)
+        }))
     }
 
     pub fn door_openness(&self) -> (f32, f32) {
@@ -304,11 +389,112 @@ impl DuckEvent {
             }),
             grounded: self.grounded(),
             jumps: self.jumps,
-            cleared_obstacles: self.cleared,
-            obstacle_count: self.obstacles.len(),
+            cleared_obstacles: self.controller.cleared,
+            obstacle_count: self
+                .course
+                .as_ref()
+                .map_or(self.obstacles.len(), |course| course.surfaces.len() - 1),
             entrance_open_milli: (entrance * 1000.0).round() as u32,
             exit_open_milli: (exit * 1000.0).round() as u32,
             outcome: self.outcome,
+            navigation: Some(ClockDuckNavigationState {
+                jump_profile: self.controller.profile,
+                course_seed: self.seed,
+                behavior: self.controller.behavior,
+                facing_right: self.controller.direction * self.direction > 0.0,
+                wall_tags: if self.direction > 0.0 {
+                    self.controller.wall_tags
+                } else {
+                    [self.controller.wall_tags[1], self.controller.wall_tags[0]]
+                },
+                calibrated_jumps: self.controller.heights.count,
+                speed_samples: self.controller.speeds.count,
+                jump_height_milli: self
+                    .controller
+                    .heights
+                    .median()
+                    .map(|h| (h * 1000.0).round() as u32),
+                flight_ticks: self
+                    .controller
+                    .flight_ticks
+                    .median()
+                    .map(|t| t.round() as u32),
+                run_speed_milli: self
+                    .controller
+                    .speeds
+                    .median()
+                    .map(|s| (s * 1000.0).round() as u32),
+                target_obstacle: self.controller.target_obstacle,
+                spawned_ticks: self.tick.saturating_sub(OPENING_TICKS),
+                exit_visible: self.exit_visible(),
+                body_radius_milli: (self.radius * 1000.0).round() as u32,
+                planning: self.course.as_ref().map(|course| {
+                    use engine_common::{
+                        ClockDuckPlanState, ClockDuckPlanningState, ClockDuckRejection,
+                    };
+                    let navigator = &self.controller.navigator;
+                    let point = |position: Vec2| {
+                        let position =
+                            self.render_position(position + Vec2::new(0.0, self.layout.floor_y));
+                        [
+                            (position.x * 1000.0).round() as i32,
+                            (position.y * 1000.0).round() as i32,
+                        ]
+                    };
+                    ClockDuckPlanningState {
+                        surface_count: course.surfaces.len(),
+                        support: self.supported_surface(),
+                        plan: navigator.plan.map(|plan| ClockDuckPlanState {
+                            source: plan.source,
+                            target: plan.target,
+                            takeoff_milli: point(plan.takeoff),
+                            landing_milli: point(plan.landing),
+                            flight_ticks: (plan.flight / DT).round() as u32,
+                            cruise_speed_milli: (plan.cruise * 1000.0).round() as u32,
+                            running_takeoff: plan.running,
+                            next_target: plan.next_target,
+                        }),
+                        confirmed_landings: navigator.confirmed,
+                        undershoots: navigator.undershoots,
+                        overshoots: navigator.overshoots,
+                        wrong_surface_landings: navigator.wrong_surface,
+                        rejected_plans: navigator.rejected,
+                        rejection: navigator.reason.map(|reason| match reason {
+                            planner::Rejection::Narrow => ClockDuckRejection::TooNarrow,
+                            planner::Rejection::High => ClockDuckRejection::TooHigh,
+                            planner::Rejection::Range => ClockDuckRejection::OutOfRange,
+                            planner::Rejection::Obstructed => ClockDuckRejection::Obstructed,
+                        }),
+                        acceleration_milli: self
+                            .controller
+                            .accelerations
+                            .median()
+                            .map(|a| (a * 1000.0).round() as u32),
+                        generation_attempts: course.attempts,
+                        fallback_course: course.fallback,
+                        running_jumps: navigator.running_jumps,
+                        flowing_fallbacks: navigator.flowing_fallbacks,
+                        moving_landings: navigator.moving_landings,
+                    }
+                }),
+            }),
         }
+    }
+
+    pub fn select_jump_profile(&mut self, profile: Option<engine_common::ClockDuckJumpProfile>) {
+        assert_eq!(
+            self.tick, 0,
+            "personality is selected only at event creation"
+        );
+        // A separate seeded stream keeps personality independent of course
+        // generation, entrance side, and the automatic event schedule.
+        self.controller.profile = profile.unwrap_or_else(|| {
+            let mut rng = StdRng::seed_from_u64(self.seed ^ 0x4455_434b_5354_594c);
+            if rng.random_bool(0.5) {
+                engine_common::ClockDuckJumpProfile::Careful
+            } else {
+                engine_common::ClockDuckJumpProfile::Flowing
+            }
+        });
     }
 }

--- a/scenarios/clock/src/events/duck/controller.rs
+++ b/scenarios/clock/src/events/duck/controller.rs
@@ -299,6 +299,7 @@ pub(super) struct Navigator {
     pub running_jumps: u32,
     pub flowing_fallbacks: u32,
     pub moving_landings: u32,
+    pub skipped_platforms: u32,
     pub plan: Option<Plan>,
     pub flight_tick: Option<u32>,
     pub confirmed: u32,
@@ -369,6 +370,8 @@ impl Controller {
                     && observed.position.x <= right + radius * 0.25
                 {
                     self.navigator.confirmed += 1;
+                    self.navigator.skipped_platforms +=
+                        plan.target.abs_diff(plan.source).saturating_sub(1) as u32;
                     if observed.velocity.x.abs() > capabilities.speed * 0.15 {
                         self.navigator.moving_landings += 1;
                     }
@@ -488,6 +491,7 @@ impl Controller {
                 .unwrap_or_else(|| planner::plan(course, source, target, radius, capabilities))
             {
                 Ok(plan) => {
+                    self.target_obstacle = Some(plan.target);
                     self.navigator.plan = Some(plan);
                     self.navigator.reason = None;
                 }

--- a/scenarios/clock/src/events/duck/controller.rs
+++ b/scenarios/clock/src/events/duck/controller.rs
@@ -1,0 +1,572 @@
+//! Small, deterministic controller. Decisions use observed motion, not the
+//! actuator's configured top speed or jump impulse. No path search per frame.
+
+use engine_common::{ClockDuckBehavior, ClockDuckJumpProfile};
+use engine_core::Vec2;
+
+use super::flow;
+use super::planner::{self, Capabilities, Course, Plan};
+use super::{DT, Obstacle};
+
+#[derive(Clone, Copy)]
+pub(super) struct Observation {
+    pub position: Vec2,
+    pub velocity: Vec2,
+    pub grounded: bool,
+    pub blocked: bool,
+    pub support: Option<usize>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum Gait {
+    Still,
+    Walk,
+    Run,
+    Pace(f32),
+}
+
+pub(super) struct Command {
+    pub gait: Gait,
+    pub direction: f32,
+    pub jump: bool,
+}
+
+pub(super) struct CourseContext<'a> {
+    pub course: &'a Course,
+    pub obstacles: &'a [Obstacle; 3],
+    pub width: f32,
+    pub radius: f32,
+    pub floor: f32,
+}
+
+/// Actuator tuning lives separately from the controller's learned capabilities.
+pub(super) struct Movement {
+    pub walk_speed: f32,
+    pub run_speed: f32,
+    pub gravity: f32,
+    pub jump_height: f32,
+}
+
+impl Movement {
+    pub fn new(width: f32, radius: f32) -> Self {
+        Self {
+            walk_speed: width / 7.0,
+            run_speed: width / 5.0,
+            gravity: radius * 50.0,
+            jump_height: radius * 4.5,
+        }
+    }
+
+    pub fn velocity_delta(&self, observed: Observation, command: &Command) -> Vec2 {
+        let target = command.direction
+            * match command.gait {
+                Gait::Still => 0.0,
+                Gait::Walk => self.walk_speed,
+                Gait::Run => self.run_speed,
+                Gait::Pace(fraction) => self.run_speed * fraction.clamp(0.0, 1.0),
+            };
+        Vec2::new(
+            (target - observed.velocity.x)
+                .clamp(-self.run_speed * DT * 6.0, self.run_speed * DT * 6.0),
+            if command.jump && observed.grounded {
+                (2.0 * self.gravity * self.jump_height).sqrt() - observed.velocity.y
+            } else {
+                0.0
+            },
+        )
+    }
+}
+
+/// Fixed-size rolling median: a transient spike cannot become a permanent max.
+#[derive(Default)]
+pub(super) struct Samples {
+    values: [f32; 9],
+    pub count: usize,
+    next: usize,
+}
+
+impl Samples {
+    pub fn push(&mut self, value: f32) {
+        if !value.is_finite() || value <= 0.0 {
+            return;
+        }
+        self.values[self.next] = value;
+        self.next = (self.next + 1) % self.values.len();
+        self.count = (self.count + 1).min(self.values.len());
+    }
+
+    pub fn median(&self) -> Option<f32> {
+        if self.count == 0 {
+            return None;
+        }
+        let mut values = self.values;
+        values[..self.count].sort_by(f32::total_cmp);
+        // With two warm-up jumps, use the conservative lower observation.
+        Some(values[(self.count - 1) / 2])
+    }
+}
+
+struct JumpTrial {
+    start: Vec2,
+    peak: f32,
+    ticks: u32,
+    airborne: bool,
+    clean: bool,
+}
+
+pub(super) struct Controller {
+    pub profile: ClockDuckJumpProfile,
+    pub behavior: ClockDuckBehavior,
+    pub direction: f32,
+    /// Entrance-relative left/right, transformed for public diagnostics.
+    pub wall_tags: [u32; 2],
+    pub target_obstacle: Option<usize>,
+    pub cleared: usize,
+    pub heights: Samples,
+    pub flight_ticks: Samples,
+    pub speeds: Samples,
+    pub accelerations: Samples,
+    pub navigator: Navigator,
+    trial: Option<JumpTrial>,
+    previous_speed: f32,
+    jumped: u8,
+}
+
+impl Controller {
+    pub fn new() -> Self {
+        Self {
+            profile: ClockDuckJumpProfile::Careful,
+            behavior: ClockDuckBehavior::WarmingUp,
+            direction: 1.0,
+            wall_tags: [0; 2],
+            target_obstacle: None,
+            cleared: 0,
+            heights: Samples::default(),
+            flight_ticks: Samples::default(),
+            speeds: Samples::default(),
+            accelerations: Samples::default(),
+            navigator: Navigator::default(),
+            trial: None,
+            previous_speed: 0.0,
+            jumped: 0,
+        }
+    }
+
+    fn observe_jump(&mut self, observed: Observation, radius: f32) {
+        let Some(trial) = &mut self.trial else { return };
+        trial.ticks += 1;
+        trial.peak = trial.peak.max(observed.position.y);
+        trial.airborne |= !observed.grounded;
+        trial.clean &=
+            !observed.blocked && (observed.position.x - trial.start.x).abs() < radius * 0.25;
+        if trial.airborne && observed.grounded && observed.velocity.y <= radius * 0.1 {
+            if trial.clean && (observed.position.y - trial.start.y).abs() < radius * 0.25 {
+                self.heights.push(trial.peak - trial.start.y);
+                self.flight_ticks.push(trial.ticks as f32);
+            }
+            self.trial = None;
+        }
+    }
+
+    pub fn decide(
+        &mut self,
+        observed: Observation,
+        obstacles: &[Obstacle; 3],
+        width: f32,
+        radius: f32,
+        exit_visible: bool,
+    ) -> Command {
+        self.observe_jump(observed, radius);
+        let mut command = Command {
+            gait: Gait::Still,
+            direction: self.direction,
+            jump: false,
+        };
+        if self.heights.count < 2 {
+            self.behavior = ClockDuckBehavior::WarmingUp;
+            if self.trial.is_none() && observed.grounded {
+                self.trial = Some(JumpTrial {
+                    start: observed.position,
+                    peak: observed.position.y,
+                    ticks: 0,
+                    airborne: false,
+                    clean: true,
+                });
+                command.jump = true;
+            }
+            return command;
+        }
+
+        // Sample sustained, unobstructed grounded travel, not acceleration,
+        // braking, flight or wall impacts. Keep adapting once up to speed.
+        let speed = observed.velocity.x.abs();
+        if self.behavior == ClockDuckBehavior::MeasuringRun
+            && observed.grounded
+            && !observed.blocked
+            && speed - self.previous_speed > radius * 0.05
+        {
+            self.accelerations.push((speed - self.previous_speed) / DT);
+        }
+        if matches!(
+            self.behavior,
+            ClockDuckBehavior::MeasuringRun | ClockDuckBehavior::Running
+        ) && observed.grounded
+            && !observed.blocked
+            && speed > radius
+            && (speed - self.previous_speed).abs() < speed * 0.01
+            && observed.velocity.x * self.direction > 0.0
+            && observed.position.x > width * 0.12
+            && observed.position.x < width * 0.88
+        {
+            self.speeds.push(speed);
+        }
+        self.previous_speed = speed;
+        self.behavior = if self.speeds.count < 9 {
+            ClockDuckBehavior::MeasuringRun
+        } else {
+            ClockDuckBehavior::Running
+        };
+        command.gait = Gait::Run;
+
+        // Tag a safe line just inside either edge. Reverse the requested motion
+        // through the acceleration limiter, never reflect/teleport the body.
+        let wall = if self.direction > 0.0 {
+            width - radius * 3.0
+        } else {
+            radius * 3.0
+        };
+        let distance = (wall - observed.position.x) * self.direction;
+        if !(exit_visible && self.direction > 0.0) {
+            if distance <= 0.0 && observed.grounded {
+                self.wall_tags[usize::from(self.direction > 0.0)] += 1;
+                self.direction = -self.direction;
+                self.jumped = 0;
+                self.cleared = 0;
+            } else if distance < width * 0.06 {
+                command.gait = Gait::Walk;
+            }
+        }
+        command.direction = self.direction;
+        if observed.velocity.x * self.direction < 0.0 {
+            self.behavior = ClockDuckBehavior::Turning;
+        } else if exit_visible && self.direction > 0.0 {
+            self.behavior = ClockDuckBehavior::Exiting;
+        }
+
+        self.target_obstacle = None;
+        self.cleared = 0;
+        for offset in 0..obstacles.len() {
+            let index = if self.direction > 0.0 {
+                offset
+            } else {
+                obstacles.len() - 1 - offset
+            };
+            let obstacle = obstacles[index];
+            let (near, far) = if self.direction > 0.0 {
+                (obstacle.start, obstacle.end)
+            } else {
+                (obstacle.end, obstacle.start)
+            };
+            if (observed.position.x - far) * self.direction > radius {
+                self.cleared += 1;
+                continue;
+            }
+            self.target_obstacle = Some(index);
+            // Retained hurdle/pit baseline: use observed flight time to choose
+            // a lead. Platform courses use this controller only for calibration
+            // on the clear runway, then switch to their landing planner.
+            if let (Some(run_speed), Some(flight)) =
+                (self.speeds.median(), self.flight_ticks.median())
+            {
+                let lead = run_speed * flight * DT * 0.22 + radius;
+                if observed.grounded
+                    && observed.velocity.x * self.direction > 0.0
+                    && self.jumped & (1 << index) == 0
+                    && (near - observed.position.x) * self.direction <= lead
+                {
+                    command.jump = true;
+                    self.jumped |= 1 << index;
+                }
+            }
+            break;
+        }
+        command
+    }
+}
+
+#[derive(Default)]
+pub(super) struct Navigator {
+    pub running_jumps: u32,
+    pub flowing_fallbacks: u32,
+    pub moving_landings: u32,
+    pub plan: Option<Plan>,
+    pub flight_tick: Option<u32>,
+    pub confirmed: u32,
+    pub undershoots: u32,
+    pub overshoots: u32,
+    pub wrong_surface: u32,
+    pub rejected: u32,
+    pub reason: Option<planner::Rejection>,
+    airborne: bool,
+    retry: u32,
+}
+
+impl Controller {
+    pub fn capabilities(&self) -> Option<Capabilities> {
+        Some(Capabilities {
+            height: self.heights.median()?,
+            flight: self.flight_ticks.median()? * DT,
+            speed: self.speeds.median()?,
+            acceleration: self.accelerations.median()?,
+        })
+    }
+
+    pub fn decide_course(
+        &mut self,
+        observed: Observation,
+        context: CourseContext<'_>,
+        exit_visible: bool,
+    ) -> Command {
+        let CourseContext {
+            course,
+            obstacles,
+            width,
+            radius,
+            floor,
+        } = context;
+        if self.heights.count < 2 || self.speeds.count < 9 {
+            return self.decide(observed, obstacles, width, radius, exit_visible);
+        }
+        let Some(capabilities) = self.capabilities() else {
+            self.behavior = ClockDuckBehavior::Blocked;
+            return Command {
+                gait: Gait::Still,
+                direction: self.direction,
+                jump: false,
+            };
+        };
+        let pace = |target: f32, maximum: f32| {
+            let distance = target - observed.position.x;
+            let speed =
+                (2.0 * capabilities.acceleration * 0.65 * (distance.abs() - radius * 0.1).max(0.0))
+                    .sqrt()
+                    .min(maximum);
+            Command {
+                gait: Gait::Pace(speed / capabilities.speed),
+                direction: distance.signum(),
+                jump: false,
+            }
+        };
+        if let (Some(plan), Some(tick)) = (self.navigator.plan, self.navigator.flight_tick) {
+            self.behavior = ClockDuckBehavior::Jumping;
+            self.navigator.flight_tick = Some(tick + 1);
+            self.navigator.airborne |= !observed.grounded;
+            if self.navigator.airborne && observed.grounded && observed.velocity.y <= radius * 0.1 {
+                let target = course.surfaces[plan.target];
+                let (left, right) = target.inside(radius).expect("planned landing interval");
+                if observed.support == Some(plan.target)
+                    && observed.position.x >= left - radius * 0.25
+                    && observed.position.x <= right + radius * 0.25
+                {
+                    self.navigator.confirmed += 1;
+                    if observed.velocity.x.abs() > capabilities.speed * 0.15 {
+                        self.navigator.moving_landings += 1;
+                    }
+                    self.behavior = ClockDuckBehavior::Landing;
+                } else {
+                    let distance = (observed.position.x - plan.landing.x) * self.direction;
+                    if distance < -radius {
+                        self.navigator.undershoots += 1;
+                    } else if distance > radius {
+                        self.navigator.overshoots += 1;
+                    } else {
+                        self.navigator.wrong_surface += 1;
+                    }
+                }
+                self.navigator.plan = None;
+                self.navigator.flight_tick = None;
+                self.navigator.airborne = false;
+                // One grounded frame separates landing confirmation from the
+                // next takeoff. The next decision uses the actual support.
+                return if plan.running {
+                    Command {
+                        gait: Gait::Pace(plan.cruise / capabilities.speed),
+                        direction: self.direction,
+                        jump: false,
+                    }
+                } else {
+                    pace(plan.landing.x, capabilities.speed * 0.4)
+                };
+            }
+            return if plan.running {
+                Command {
+                    gait: Gait::Pace(plan.cruise / capabilities.speed),
+                    direction: self.direction,
+                    jump: false,
+                }
+            } else {
+                pace(plan.landing.x, plan.cruise)
+            };
+        }
+        let Some(source) = observed.support else {
+            self.behavior = ClockDuckBehavior::Blocked;
+            return Command {
+                gait: Gait::Still,
+                direction: self.direction,
+                jump: false,
+            };
+        };
+        let last = course.surfaces.len() - 1;
+        self.cleared = if self.direction > 0.0 {
+            source
+        } else {
+            last - source
+        };
+        if (self.direction > 0.0 && source == last) || (self.direction < 0.0 && source == 0) {
+            let wall = if self.direction > 0.0 {
+                width - radius * 3.0
+            } else {
+                radius * 3.0
+            };
+            if exit_visible && self.direction > 0.0 {
+                self.behavior = ClockDuckBehavior::Exiting;
+                return Command {
+                    gait: Gait::Run,
+                    direction: self.direction,
+                    jump: false,
+                };
+            }
+            if (observed.position.x - wall).abs() < radius * 0.3
+                && observed.velocity.x.abs() < radius
+            {
+                self.wall_tags[usize::from(self.direction > 0.0)] += 1;
+                self.direction = -self.direction;
+                self.navigator.plan = None;
+                self.cleared = 0;
+            } else {
+                self.behavior = ClockDuckBehavior::Turning;
+                return pace(wall, capabilities.speed);
+            }
+        }
+        if self.navigator.retry > 0 {
+            self.navigator.retry -= 1;
+            self.behavior = ClockDuckBehavior::Blocked;
+            return Command {
+                gait: Gait::Still,
+                direction: self.direction,
+                jump: false,
+            };
+        }
+        if self.navigator.plan.is_none() {
+            let target = if self.direction > 0.0 {
+                source + 1
+            } else {
+                source - 1
+            };
+            self.target_obstacle = Some(target);
+            let running = if self.profile == ClockDuckJumpProfile::Flowing {
+                let plan = flow::plan(
+                    course,
+                    flow::Start {
+                        surface: source,
+                        x: observed.position.x,
+                        velocity: observed.velocity.x,
+                        direction: self.direction,
+                    },
+                    radius,
+                    capabilities,
+                );
+                if plan.is_none() {
+                    self.navigator.flowing_fallbacks += 1;
+                }
+                plan
+            } else {
+                None
+            };
+            match running
+                .map(Ok)
+                .unwrap_or_else(|| planner::plan(course, source, target, radius, capabilities))
+            {
+                Ok(plan) => {
+                    self.navigator.plan = Some(plan);
+                    self.navigator.reason = None;
+                }
+                Err(reason) => {
+                    self.navigator.reason = Some(reason);
+                    self.navigator.rejected += 1;
+                    self.navigator.retry = 30;
+                    self.behavior = ClockDuckBehavior::Blocked;
+                    return Command {
+                        gait: Gait::Still,
+                        direction: self.direction,
+                        jump: false,
+                    };
+                }
+            }
+        }
+        let plan = self.navigator.plan.expect("accepted route");
+        // A slip while approaching invalidates the source contract.
+        if source != plan.source {
+            self.navigator.plan = None;
+            self.navigator.wrong_surface += 1;
+            return Command {
+                gait: Gait::Still,
+                direction: self.direction,
+                jump: false,
+            };
+        }
+        self.behavior = ClockDuckBehavior::Approaching;
+        if plan.running {
+            let remaining = (plan.takeoff.x - observed.position.x) * self.direction;
+            let ready = (observed.velocity.x * self.direction - plan.cruise).abs()
+                <= capabilities.acceleration * DT * 0.85;
+            if remaining <= plan.cruise * DT {
+                if ready
+                    && let Some(actual) =
+                        flow::at_takeoff(course, plan, observed.position.x, radius, capabilities)
+                {
+                    self.navigator.plan = Some(actual);
+                    self.navigator.flight_tick = Some(0);
+                    self.navigator.airborne = false;
+                    self.navigator.running_jumps += 1;
+                    self.behavior = ClockDuckBehavior::Jumping;
+                    return Command {
+                        gait: Gait::Pace(plan.cruise / capabilities.speed),
+                        direction: self.direction,
+                        jump: true,
+                    };
+                }
+                // The candidate reserved space to brake on the source too.
+                // Abort before stepping off it; a careful plan starts next tick.
+                self.navigator.flowing_fallbacks += 1;
+                self.navigator.plan =
+                    planner::plan(course, source, plan.target, radius, capabilities).ok();
+                return Command {
+                    gait: Gait::Still,
+                    direction: self.direction,
+                    jump: false,
+                };
+            }
+            return Command {
+                gait: Gait::Pace(plan.cruise / capabilities.speed),
+                direction: self.direction,
+                jump: false,
+            };
+        }
+        let mut command = pace(plan.takeoff.x, capabilities.speed);
+        if (observed.position.x - plan.takeoff.x).abs() < radius * 0.3
+            && observed.velocity.x.abs() < radius * 0.5
+            && (observed.position.y - radius - floor - plan.takeoff.y).abs() < radius * 0.2
+        {
+            self.navigator.flight_tick = Some(0);
+            self.navigator.airborne = false;
+            self.behavior = ClockDuckBehavior::Jumping;
+            command = Command {
+                gait: Gait::Pace(plan.cruise / capabilities.speed),
+                direction: self.direction,
+                jump: true,
+            };
+        }
+        command
+    }
+}

--- a/scenarios/clock/src/events/duck/flow.rs
+++ b/scenarios/clock/src/events/duck/flow.rs
@@ -52,12 +52,62 @@ pub(super) fn plan(course: &Course, start: Start, radius: f32, caps: Capabilitie
             best_cost = cost;
         }
     }
+    // Compare equal progress: one direct jump versus the two adjacent links
+    // above. Require a useful time saving, not merely another reachable arc.
+    let skip_target = if start.direction > 0.0 {
+        start.surface.checked_add(2)
+    } else {
+        start.surface.checked_sub(2)
+    }
+    .filter(|target| *target < course.surfaces.len());
+    if let Some(target) = skip_target {
+        let mut shortcut = None;
+        let mut shortcut_cost = best_cost * 0.95;
+        for candidate in candidates_to(course, start, target, radius, caps)
+            .into_iter()
+            .flatten()
+        {
+            let cost = cost(candidate, start, radius);
+            if cost < shortcut_cost {
+                shortcut = Some(candidate);
+                shortcut_cost = cost;
+            }
+        }
+        if let Some(mut candidate) = shortcut {
+            let arrival = Start {
+                surface: candidate.target,
+                x: candidate.landing.x + start.direction * candidate.cruise * DT * 2.0,
+                velocity: start.direction * candidate.cruise,
+                direction: start.direction,
+            };
+            if candidates(course, arrival, radius, caps)
+                .iter()
+                .any(Option::is_some)
+            {
+                candidate.next_target = adjacent(course, arrival.surface, start.direction);
+            }
+            best = Some(candidate);
+        }
+    }
     best
 }
 
 fn cost(plan: Plan, start: Start, radius: f32) -> f32 {
     let run_up = (plan.takeoff.x - start.x).abs();
     run_up / ((start.velocity.abs() + plan.cruise) * 0.5).max(radius) + plan.flight
+}
+
+#[cfg(test)]
+pub(super) fn single_jump_plan(
+    course: &Course,
+    start: Start,
+    radius: f32,
+    caps: Capabilities,
+) -> Option<Plan> {
+    candidates(course, start, radius, caps)
+        .into_iter()
+        .flatten()
+        .min_by(|a, b| cost(*a, start, radius).total_cmp(&cost(*b, start, radius)))
 }
 
 fn adjacent(course: &Course, source: usize, direction: f32) -> Option<usize> {
@@ -69,12 +119,22 @@ fn adjacent(course: &Course, source: usize, direction: f32) -> Option<usize> {
 }
 
 // Three takeoff positions by three landing positions. Stack-only storage and
-// one further link bound the work to at most 9 + 9*9 candidate arcs per decision.
+// one further link plus one shortcut bound work to 9 + 9*9 + 9 + 9 arcs.
 fn candidates(course: &Course, start: Start, radius: f32, caps: Capabilities) -> [Option<Plan>; 9] {
-    let mut result = [None; 9];
     let Some(target) = adjacent(course, start.surface, start.direction) else {
-        return result;
+        return [None; 9];
     };
+    candidates_to(course, start, target, radius, caps)
+}
+
+fn candidates_to(
+    course: &Course,
+    start: Start,
+    target: usize,
+    radius: f32,
+    caps: Capabilities,
+) -> [Option<Plan>; 9] {
+    let mut result = [None; 9];
     let from = course.surfaces[start.surface];
     let to = course.surfaces[target];
     let Some((left, right)) = from.inside(radius) else {
@@ -83,10 +143,13 @@ fn candidates(course: &Course, start: Start, radius: f32, caps: Capabilities) ->
     let Some((land_left, land_right)) = to.inside(radius) else {
         return result;
     };
+    // The controller can launch up to one cruise tick early. Keep edge
+    // candidates that far inside the interval so re-anchoring remains safe.
+    let landing_margin = caps.speed * DT;
     let near = if start.direction > 0.0 {
-        land_left
+        land_left + landing_margin
     } else {
-        land_right
+        land_right - landing_margin
     };
     let far = if start.direction > 0.0 { right } else { left };
     let middle = (land_left + land_right) * 0.5;
@@ -233,6 +296,71 @@ fn safe(course: &Course, plan: Plan, radius: f32, caps: Capabilities) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn skips_an_intermediate_platform_only_with_a_clear_useful_landing() {
+        let radius = 8.0;
+        let caps = Capabilities {
+            height: 35.6,
+            flight: 52.0 / 60.0,
+            speed: 160.0,
+            acceleration: 960.0,
+        };
+        let mut course = Course::authored(
+            800.0,
+            radius,
+            engine_common::ClockDuckCoursePattern::Shortcut,
+        );
+        let start = Start {
+            surface: 0,
+            x: 120.0,
+            velocity: 160.0,
+            direction: 1.0,
+        };
+        assert!(
+            course.valid_routes(radius, caps),
+            "Careful retains the adjacent route"
+        );
+        let jump = plan(&course, start, radius, caps).unwrap();
+        assert_eq!((jump.source, jump.target), (0, 2));
+        let adjacent_cost = candidates(&course, start, radius, caps)
+            .into_iter()
+            .flatten()
+            .map(|first| {
+                let arrival = Start {
+                    surface: 1,
+                    x: first.landing.x + first.cruise * DT * 2.0,
+                    velocity: first.cruise,
+                    direction: 1.0,
+                };
+                cost(first, start, radius)
+                    + candidates(&course, arrival, radius, caps)
+                        .into_iter()
+                        .flatten()
+                        .map(|second| cost(second, arrival, radius))
+                        .reduce(f32::min)
+                        .unwrap_or(2.5)
+            })
+            .reduce(f32::min)
+            .unwrap();
+        assert!(cost(jump, start, radius) < adjacent_cost * 0.95);
+        course.surfaces[1].height = caps.height * 2.0;
+        assert!(
+            candidates_to(&course, start, 2, radius, caps)
+                .iter()
+                .all(Option::is_none)
+        );
+        assert!(
+            plan(&course, start, radius, caps).is_none(),
+            "do not jump through a blocked shortcut"
+        );
+        course.surfaces[1].height = radius * 0.45;
+        course.surfaces[2].end = course.surfaces[2].start + radius * 2.0;
+        assert!(
+            plan(&course, start, radius, caps).is_none_or(|jump| jump.target != 2),
+            "reject an unsafe landing even if the gap is reachable"
+        );
+    }
 
     #[test]
     fn running_arcs_keep_speed_and_revalidate_actual_takeoff_in_both_directions() {

--- a/scenarios/clock/src/events/duck/flow.rs
+++ b/scenarios/clock/src/events/duck/flow.rs
@@ -1,0 +1,278 @@
+//! Running jumps with bounded two-link lookahead. Unlike the careful planner,
+//! these candidates preserve horizontal speed through flight and touchdown.
+//! Plans are proposals: the controller revalidates the actual takeoff, then
+//! replans from actual support after landing. No physics rollout or global search.
+
+use engine_core::Vec2;
+
+use super::DT;
+use super::planner::{Capabilities, Course, Plan};
+
+#[derive(Clone, Copy)]
+pub(super) struct Start {
+    pub surface: usize,
+    pub x: f32,
+    pub velocity: f32,
+    pub direction: f32,
+}
+
+pub(super) fn plan(course: &Course, start: Start, radius: f32, caps: Capabilities) -> Option<Plan> {
+    let mut best = None;
+    let mut best_cost = f32::INFINITY;
+    for mut candidate in candidates(course, start, radius, caps)
+        .into_iter()
+        .flatten()
+    {
+        let arrival = Start {
+            surface: candidate.target,
+            // Allow a contact-confirmation tick before the next decision.
+            x: candidate.landing.x + start.direction * candidate.cruise * DT * 2.0,
+            velocity: start.direction * candidate.cruise,
+            direction: start.direction,
+        };
+        let next = adjacent(course, arrival.surface, start.direction);
+        let next_cost = if let Some(next) = next {
+            let onward = candidates(course, arrival, radius, caps)
+                .into_iter()
+                .flatten()
+                .map(|plan| cost(plan, arrival, radius))
+                .reduce(f32::min);
+            // No running continuation: the safe braking reserve still permits
+            // the careful fallback. Prefer a genuine chain when available.
+            if onward.is_some() {
+                candidate.next_target = Some(next);
+            }
+            onward.unwrap_or(2.5)
+        } else {
+            0.0
+        };
+        let cost = cost(candidate, start, radius) + next_cost;
+        if cost < best_cost {
+            best = Some(candidate);
+            best_cost = cost;
+        }
+    }
+    best
+}
+
+fn cost(plan: Plan, start: Start, radius: f32) -> f32 {
+    let run_up = (plan.takeoff.x - start.x).abs();
+    run_up / ((start.velocity.abs() + plan.cruise) * 0.5).max(radius) + plan.flight
+}
+
+fn adjacent(course: &Course, source: usize, direction: f32) -> Option<usize> {
+    if direction > 0.0 {
+        (source + 1 < course.surfaces.len()).then_some(source + 1)
+    } else {
+        source.checked_sub(1)
+    }
+}
+
+// Three takeoff positions by three landing positions. Stack-only storage and
+// one further link bound the work to at most 9 + 9*9 candidate arcs per decision.
+fn candidates(course: &Course, start: Start, radius: f32, caps: Capabilities) -> [Option<Plan>; 9] {
+    let mut result = [None; 9];
+    let Some(target) = adjacent(course, start.surface, start.direction) else {
+        return result;
+    };
+    let from = course.surfaces[start.surface];
+    let to = course.surfaces[target];
+    let Some((left, right)) = from.inside(radius) else {
+        return result;
+    };
+    let Some((land_left, land_right)) = to.inside(radius) else {
+        return result;
+    };
+    let near = if start.direction > 0.0 {
+        land_left
+    } else {
+        land_right
+    };
+    let far = if start.direction > 0.0 { right } else { left };
+    let middle = (land_left + land_right) * 0.5;
+    for (i, fraction) in [0.1, 0.25, 0.4].into_iter().enumerate() {
+        let takeoff = far - start.direction * (right - left) * fraction;
+        for (j, landing) in [middle, (near + middle) * 0.5, near]
+            .into_iter()
+            .enumerate()
+        {
+            let Some(plan) = trajectory(
+                course,
+                start.surface,
+                target,
+                takeoff,
+                landing,
+                radius,
+                caps,
+            ) else {
+                continue;
+            };
+            let run_up = (takeoff - start.x) * start.direction;
+            let current_speed = start.velocity * start.direction;
+            if current_speed < -radius * 0.1 {
+                continue;
+            }
+            let speed_change_distance = (plan.cruise.powi(2) - current_speed.powi(2)).abs()
+                / (2.0 * caps.acceleration * 0.65);
+            if run_up >= speed_change_distance + radius * 0.35
+                && (far - takeoff) * start.direction >= takeoff_reserve(plan, radius, caps)
+            {
+                result[i * 3 + j] = Some(plan);
+            }
+        }
+    }
+    result
+}
+
+fn trajectory(
+    course: &Course,
+    source: usize,
+    target: usize,
+    takeoff: f32,
+    landing: f32,
+    radius: f32,
+    caps: Capabilities,
+) -> Option<Plan> {
+    let from = course.surfaces.get(source)?;
+    let to = course.surfaces.get(target)?;
+    let rise = to.height - from.height;
+    if rise >= caps.height * 0.85 {
+        return None;
+    }
+    let gravity = 8.0 * caps.height / caps.flight.powi(2);
+    let launch = 4.0 * caps.height / caps.flight;
+    let flight = (launch + (launch * launch - 2.0 * gravity * rise).sqrt()) / gravity;
+    if !flight.is_finite() || flight <= 0.0 || flight > 2.0 {
+        return None;
+    }
+    let cruise = (landing - takeoff).abs() / flight;
+    if cruise < caps.speed * 0.15 || cruise > caps.speed * 0.9 {
+        return None;
+    }
+    let result = Plan {
+        source,
+        target,
+        takeoff: Vec2::new(takeoff, from.height),
+        landing: Vec2::new(landing, to.height),
+        flight,
+        cruise,
+        running: true,
+        next_target: None,
+    };
+    safe(course, result, radius, caps).then_some(result)
+}
+
+/// A takeoff is triggered by actual position, not by teleporting to the planned
+/// point. Re-anchor the constant-speed arc and recheck its entire landing reserve.
+pub(super) fn at_takeoff(
+    course: &Course,
+    mut plan: Plan,
+    x: f32,
+    radius: f32,
+    caps: Capabilities,
+) -> Option<Plan> {
+    let shift = x - plan.takeoff.x;
+    plan.takeoff.x = x;
+    plan.landing.x += shift;
+    let (left, right) = course.surfaces[plan.source].inside(radius)?;
+    let reserve = if plan.landing.x > x {
+        right - x
+    } else {
+        x - left
+    };
+    if reserve < takeoff_reserve(plan, radius, caps) {
+        return None;
+    }
+    safe(course, plan, radius, caps).then_some(plan)
+}
+
+fn takeoff_reserve(plan: Plan, radius: f32, caps: Capabilities) -> f32 {
+    // A rejected takeoff can brake immediately; a landing first has to be
+    // detected and confirmed. Keep the larger three-tick reserve for landing.
+    plan.cruise.powi(2) / (2.0 * caps.acceleration * 0.85) + plan.cruise * DT + radius * 0.25
+}
+
+fn braking_reserve(plan: Plan, radius: f32, caps: Capabilities) -> f32 {
+    plan.cruise.powi(2) / (2.0 * caps.acceleration * 0.65) + plan.cruise * DT * 3.0 + radius * 0.5
+}
+
+fn safe(course: &Course, plan: Plan, radius: f32, caps: Capabilities) -> bool {
+    let Some((left, right)) = course.surfaces[plan.target].inside(radius) else {
+        return false;
+    };
+    let direction = (plan.landing.x - plan.takeoff.x).signum();
+    let reserve = if direction > 0.0 {
+        right - plan.landing.x
+    } else {
+        plan.landing.x - left
+    };
+    // Enough room to confirm contact and brake even if the next running jump
+    // is invalidated. This constraint must also hold for the actual takeoff.
+    if plan.landing.x < left
+        || plan.landing.x > right
+        || reserve < braking_reserve(plan, radius, caps)
+    {
+        return false;
+    }
+    let steps = (plan.flight / DT).ceil() as u32;
+    (1..=steps).all(|step| {
+        let point = plan.sample(caps, (step as f32 * DT / plan.flight).min(1.0));
+        course.surfaces.iter().enumerate().all(|(index, surface)| {
+            let overlaps =
+                point.x + radius * 1.2 > surface.start && point.x - radius * 1.2 < surface.end;
+            !overlaps
+                || point.y >= surface.height + radius * 0.15
+                || (index == plan.target
+                    && point.x >= left - radius * 0.02
+                    && point.x <= right + radius * 0.02
+                    && point.y >= surface.height - radius * 0.02)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn running_arcs_keep_speed_and_revalidate_actual_takeoff_in_both_directions() {
+        let radius = 8.0;
+        let caps = Capabilities {
+            height: 35.6,
+            flight: 52.0 / 60.0,
+            speed: 160.0,
+            acceleration: 960.0,
+        };
+        let course = Course::fixed(800.0, radius, 0);
+        for start in [
+            Start {
+                surface: 0,
+                x: 80.0,
+                velocity: 160.0,
+                direction: 1.0,
+            },
+            Start {
+                surface: 2,
+                x: 720.0,
+                velocity: -160.0,
+                direction: -1.0,
+            },
+        ] {
+            let jump =
+                plan(&course, start, radius, caps).expect("wide fixture has a running route");
+            let end = jump.sample(caps, 1.0);
+            assert!((end - jump.landing).length() < 0.001);
+            let first = jump.sample(caps, 0.25);
+            let second = jump.sample(caps, 0.75);
+            assert!(
+                ((second.x - first.x) / (jump.flight * 0.5) - start.direction * jump.cruise).abs()
+                    < 0.001
+            );
+            assert!(at_takeoff(&course, jump, jump.takeoff.x, radius, caps).is_some());
+            // Starting early/late is not permission to land outside the surface.
+            for offset in [-800.0, 800.0] {
+                assert!(at_takeoff(&course, jump, jump.takeoff.x + offset, radius, caps).is_none());
+            }
+        }
+    }
+}

--- a/scenarios/clock/src/events/duck/planner.rs
+++ b/scenarios/clock/src/events/duck/planner.rs
@@ -1,6 +1,7 @@
 //! Bounded, course-local planning. Geometry is shared with rendering/physics;
 //! reachability uses measured movement capabilities, never a second simulator.
 
+use engine_common::ClockDuckCoursePattern;
 use engine_core::Vec2;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
@@ -26,6 +27,7 @@ impl Surface {
 #[derive(Debug, Clone)]
 pub struct Course {
     pub surfaces: Vec<Surface>,
+    pub pattern: ClockDuckCoursePattern,
     pub attempts: u32,
     pub fallback: bool,
 }
@@ -193,11 +195,47 @@ pub fn plan(
 }
 
 impl Course {
+    #[cfg(test)]
     pub fn generated(width: f32, radius: f32, seed: u64) -> Self {
         Self::generate_with_budget(width, radius, seed, 16)
     }
 
+    #[cfg(test)]
     pub fn generate_with_budget(width: f32, radius: f32, seed: u64, budget: u32) -> Self {
+        Self::pattern_with_budget(
+            width,
+            radius,
+            seed,
+            ClockDuckCoursePattern::Platforms,
+            budget,
+        )
+    }
+
+    pub fn varied(
+        width: f32,
+        radius: f32,
+        seed: u64,
+        pattern: Option<ClockDuckCoursePattern>,
+    ) -> Self {
+        let mut selector = StdRng::seed_from_u64(seed ^ 0x434f_5552_5345_5459);
+        let pattern = pattern.unwrap_or_else(|| {
+            [
+                ClockDuckCoursePattern::Platforms,
+                ClockDuckCoursePattern::Terraces,
+                ClockDuckCoursePattern::TwoJump,
+                ClockDuckCoursePattern::Shortcut,
+            ][selector.random_range(0..4)]
+        });
+        Self::pattern_with_budget(width, radius, seed, pattern, 16)
+    }
+
+    fn pattern_with_budget(
+        width: f32,
+        radius: f32,
+        seed: u64,
+        pattern: ClockDuckCoursePattern,
+        budget: u32,
+    ) -> Self {
         let mut rng = StdRng::seed_from_u64(seed ^ 0x504c_4154_464f_524d);
         // Generate against a smaller capability envelope than the tuned duck.
         // The runtime planner still has to measure its own actual capabilities.
@@ -208,31 +246,44 @@ impl Course {
             acceleration: width / 5.0 * 6.0,
         };
         for attempt in 1..=budget.min(16) {
-            let count = rng.random_range(2..=3);
-            let mut surfaces = Vec::with_capacity(MAX_SURFACES);
-            surfaces.push(Surface {
-                start: -radius * 8.0,
-                end: width * 0.25,
-                height: 0.0,
-            });
-            let slot = width * 0.5 / count as f32;
-            for i in 0..count {
-                let center =
-                    width * 0.25 + slot * (i as f32 + 0.5) + rng.random_range(-0.04..0.04) * slot;
-                let half_width = slot * rng.random_range(0.29..0.37);
+            let surfaces = if pattern == ClockDuckCoursePattern::Platforms {
+                let count = rng.random_range(2..=3);
+                let mut surfaces = Vec::with_capacity(MAX_SURFACES);
                 surfaces.push(Surface {
-                    start: center - half_width,
-                    end: center + half_width,
-                    height: radius * rng.random_range(0.7..2.6),
+                    start: -radius * 8.0,
+                    end: width * 0.25,
+                    height: 0.0,
                 });
-            }
-            surfaces.push(Surface {
-                start: width * 0.75,
-                end: width + radius * 8.0,
-                height: 0.0,
-            });
+                let slot = width * 0.5 / count as f32;
+                for i in 0..count {
+                    let center = width * 0.25
+                        + slot * (i as f32 + 0.5)
+                        + rng.random_range(-0.04..0.04) * slot;
+                    let half_width = slot * rng.random_range(0.29..0.37);
+                    surfaces.push(Surface {
+                        start: center - half_width,
+                        end: center + half_width,
+                        height: radius * rng.random_range(0.7..2.6),
+                    });
+                }
+                surfaces.push(Surface {
+                    start: width * 0.75,
+                    end: width + radius * 8.0,
+                    height: 0.0,
+                });
+                surfaces
+            } else {
+                let mut surfaces = Self::authored(width, radius, pattern).surfaces;
+                // Keep recognizable routes; vary raised surfaces without changing
+                // the authored runway/landing widths. Every result is revalidated.
+                for surface in &mut surfaces {
+                    surface.height *= rng.random_range(0.9..1.1);
+                }
+                surfaces
+            };
             let course = Self {
                 surfaces,
+                pattern,
                 attempts: attempt,
                 fallback: false,
             };
@@ -244,6 +295,44 @@ impl Course {
         course.attempts = budget.min(16);
         course.fallback = true;
         course
+    }
+
+    pub fn authored(width: f32, radius: f32, pattern: ClockDuckCoursePattern) -> Self {
+        let spans: &[(f32, f32, f32)] = match pattern {
+            ClockDuckCoursePattern::TwoJump => {
+                &[(0.0, 0.30, 0.0), (0.33, 0.42, 1.0), (0.45, 1.0, 0.0)]
+            }
+            ClockDuckCoursePattern::Shortcut => &[
+                (0.0, 0.24, 0.0),
+                (0.255, 0.315, 0.45),
+                (0.33, 0.64, 0.0),
+                (0.70, 1.0, 0.0),
+            ],
+            ClockDuckCoursePattern::Terraces => &[
+                (0.0, 0.25, 0.0),
+                (0.28, 0.42, 0.9),
+                (0.45, 0.59, 2.0),
+                (0.62, 0.76, 1.0),
+                (0.79, 1.0, 0.0),
+            ],
+            ClockDuckCoursePattern::Platforms => return Self::fixed(width, radius, 0),
+        };
+        let mut surfaces: Vec<_> = spans
+            .iter()
+            .map(|&(start, end, height)| Surface {
+                start: start * width,
+                end: end * width,
+                height: height * radius,
+            })
+            .collect();
+        surfaces.first_mut().unwrap().start = -radius * 8.0;
+        surfaces.last_mut().unwrap().end = width + radius * 8.0;
+        Self {
+            surfaces,
+            pattern,
+            attempts: 0,
+            fallback: false,
+        }
     }
 
     pub fn valid_routes(&self, radius: f32, capabilities: Capabilities) -> bool {
@@ -330,6 +419,7 @@ impl Course {
         };
         Self {
             surfaces,
+            pattern: ClockDuckCoursePattern::Platforms,
             attempts: 0,
             fallback: false,
         }

--- a/scenarios/clock/src/events/duck/planner.rs
+++ b/scenarios/clock/src/events/duck/planner.rs
@@ -1,0 +1,337 @@
+//! Bounded, course-local planning. Geometry is shared with rendering/physics;
+//! reachability uses measured movement capabilities, never a second simulator.
+
+use engine_core::Vec2;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+use super::DT;
+
+pub const MAX_SURFACES: usize = 7;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Surface {
+    pub start: f32,
+    pub end: f32,
+    /// Height above the event floor.
+    pub height: f32,
+}
+
+impl Surface {
+    pub fn inside(self, radius: f32) -> Option<(f32, f32)> {
+        let margin = radius * 1.5;
+        (self.end - self.start > margin * 2.0).then_some((self.start + margin, self.end - margin))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Course {
+    pub surfaces: Vec<Surface>,
+    pub attempts: u32,
+    pub fallback: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Capabilities {
+    pub height: f32,
+    pub flight: f32,
+    pub speed: f32,
+    pub acceleration: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rejection {
+    Narrow,
+    High,
+    Range,
+    Obstructed,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Plan {
+    pub source: usize,
+    pub target: usize,
+    pub takeoff: Vec2,
+    pub landing: Vec2,
+    pub flight: f32,
+    pub cruise: f32,
+    pub running: bool,
+    pub next_target: Option<usize>,
+}
+
+impl Plan {
+    pub fn sample(self, capabilities: Capabilities, fraction: f32) -> Vec2 {
+        let time = self.flight * fraction.clamp(0.0, 1.0);
+        let gravity = 8.0 * capabilities.height / capabilities.flight.powi(2);
+        let launch = 4.0 * capabilities.height / capabilities.flight;
+        let direction = (self.landing.x - self.takeoff.x).signum();
+        Vec2::new(
+            self.takeoff.x
+                + direction
+                    * if self.running {
+                        self.cruise * time
+                    } else {
+                        travel(
+                            time,
+                            self.flight,
+                            self.cruise,
+                            capabilities.acceleration * 0.85,
+                        )
+                    },
+            self.takeoff.y + launch * time - 0.5 * gravity * time * time,
+        )
+    }
+}
+
+/// Distance travelled while accelerating from rest and braking back to rest.
+fn travel(time: f32, duration: f32, cruise: f32, acceleration: f32) -> f32 {
+    let ramp = cruise / acceleration;
+    let t = time.clamp(0.0, duration);
+    if t < ramp {
+        0.5 * acceleration * t * t
+    } else if t <= duration - ramp {
+        cruise * (t - ramp * 0.5)
+    } else {
+        let remaining = duration - t;
+        cruise * (duration - ramp) - 0.5 * acceleration * remaining * remaining
+    }
+}
+
+pub fn plan(
+    course: &Course,
+    source: usize,
+    target: usize,
+    radius: f32,
+    capabilities: Capabilities,
+) -> Result<Plan, Rejection> {
+    if source >= course.surfaces.len()
+        || target >= course.surfaces.len()
+        || source == target
+        || ![
+            radius,
+            capabilities.height,
+            capabilities.flight,
+            capabilities.speed,
+            capabilities.acceleration,
+        ]
+        .into_iter()
+        .all(|value| value.is_finite() && value > 0.0)
+    {
+        return Err(Rejection::Range);
+    }
+    let from = course.surfaces[source];
+    let to = course.surfaces[target];
+    let direction = if target > source { 1.0 } else { -1.0 };
+    let (from_left, from_right) = from.inside(radius).ok_or(Rejection::Narrow)?;
+    let (left, right) = to.inside(radius).ok_or(Rejection::Narrow)?;
+    let takeoff = Vec2::new(
+        if direction > 0.0 {
+            from_right
+        } else {
+            from_left
+        },
+        from.height,
+    );
+    let rise = to.height - from.height;
+    if rise >= capabilities.height * 0.85 {
+        return Err(Rejection::High);
+    }
+    // A parabola reconstructed from measured peak height and same-height
+    // airtime. Higher/lower targets use the descending root of that parabola.
+    let gravity = 8.0 * capabilities.height / capabilities.flight.powi(2);
+    let launch = 4.0 * capabilities.height / capabilities.flight;
+    let flight = (launch + (launch * launch - 2.0 * gravity * rise).sqrt()) / gravity;
+    if !flight.is_finite() || flight > 2.0 {
+        return Err(Rejection::Range);
+    }
+    let acceleration = capabilities.acceleration * 0.85;
+    let near = if direction > 0.0 { left } else { right };
+    let middle = (left + right) * 0.5;
+    let mut rejection = Rejection::Range;
+    for landing_x in [middle, (middle + near) * 0.5, near] {
+        let distance = (landing_x - takeoff.x) * direction;
+        let discriminant = flight * flight - 4.0 * distance / acceleration;
+        if distance <= 0.0 || discriminant < 0.0 {
+            continue;
+        }
+        let cruise = acceleration * 0.5 * (flight - discriminant.sqrt());
+        if cruise > capabilities.speed * 0.9 {
+            continue;
+        }
+        let result = Plan {
+            source,
+            target,
+            takeoff,
+            landing: Vec2::new(landing_x, to.height),
+            flight,
+            cruise,
+            running: false,
+            next_target: None,
+        };
+        // Conservative expanded body clearance along the arc, including any
+        // intervening obstacles. Work is capped by the small course and flight.
+        let steps = (flight / DT).ceil() as u32;
+        let clear = (1..=steps).all(|step| {
+            let time = (step as f32 * DT).min(flight);
+            let x = takeoff.x + direction * travel(time, flight, cruise, acceleration);
+            let feet = takeoff.y + launch * time - 0.5 * gravity * time * time;
+            course.surfaces.iter().enumerate().all(|(index, surface)| {
+                let overlaps = x + radius * 1.2 > surface.start && x - radius * 1.2 < surface.end;
+                !overlaps
+                    || feet >= surface.height + radius * 0.15
+                    || (index == target
+                        && x >= left - radius * 0.02
+                        && x <= right + radius * 0.02
+                        && feet >= surface.height - radius * 0.02)
+            })
+        });
+        if clear {
+            return Ok(result);
+        }
+        rejection = Rejection::Obstructed;
+    }
+    Err(rejection)
+}
+
+impl Course {
+    pub fn generated(width: f32, radius: f32, seed: u64) -> Self {
+        Self::generate_with_budget(width, radius, seed, 16)
+    }
+
+    pub fn generate_with_budget(width: f32, radius: f32, seed: u64, budget: u32) -> Self {
+        let mut rng = StdRng::seed_from_u64(seed ^ 0x504c_4154_464f_524d);
+        // Generate against a smaller capability envelope than the tuned duck.
+        // The runtime planner still has to measure its own actual capabilities.
+        let conservative = Capabilities {
+            height: radius * 4.0,
+            flight: 0.80,
+            speed: width / 5.0,
+            acceleration: width / 5.0 * 6.0,
+        };
+        for attempt in 1..=budget.min(16) {
+            let count = rng.random_range(2..=3);
+            let mut surfaces = Vec::with_capacity(MAX_SURFACES);
+            surfaces.push(Surface {
+                start: -radius * 8.0,
+                end: width * 0.25,
+                height: 0.0,
+            });
+            let slot = width * 0.5 / count as f32;
+            for i in 0..count {
+                let center =
+                    width * 0.25 + slot * (i as f32 + 0.5) + rng.random_range(-0.04..0.04) * slot;
+                let half_width = slot * rng.random_range(0.29..0.37);
+                surfaces.push(Surface {
+                    start: center - half_width,
+                    end: center + half_width,
+                    height: radius * rng.random_range(0.7..2.6),
+                });
+            }
+            surfaces.push(Surface {
+                start: width * 0.75,
+                end: width + radius * 8.0,
+                height: 0.0,
+            });
+            let course = Self {
+                surfaces,
+                attempts: attempt,
+                fallback: false,
+            };
+            if course.valid_routes(radius, conservative) {
+                return course;
+            }
+        }
+        let mut course = Self::fixed(width, radius, 0);
+        course.attempts = budget.min(16);
+        course.fallback = true;
+        course
+    }
+
+    pub fn valid_routes(&self, radius: f32, capabilities: Capabilities) -> bool {
+        if !(2..=MAX_SURFACES).contains(&self.surfaces.len())
+            || self.surfaces.iter().any(|s| {
+                !s.start.is_finite()
+                    || !s.end.is_finite()
+                    || !s.height.is_finite()
+                    || s.height < 0.0
+                    || s.start >= s.end
+            })
+            || self
+                .surfaces
+                .windows(2)
+                .any(|pair| pair[0].end > pair[1].start)
+        {
+            return false;
+        }
+        (0..self.surfaces.len() - 1).all(|i| {
+            plan(self, i, i + 1, radius, capabilities).is_ok()
+                && plan(self, i + 1, i, radius, capabilities).is_ok()
+        })
+    }
+
+    /// Fixed regression fixtures: single platform, ascending steps, and gap.
+    pub fn fixed(width: f32, radius: f32, fixture: usize) -> Self {
+        let surfaces = match fixture {
+            0 => vec![
+                Surface {
+                    start: -radius * 8.0,
+                    end: width * 0.35,
+                    height: 0.0,
+                },
+                Surface {
+                    start: width * 0.39,
+                    end: width * 0.61,
+                    height: radius * 1.3,
+                },
+                Surface {
+                    start: width * 0.65,
+                    end: width + radius * 8.0,
+                    height: 0.0,
+                },
+            ],
+            1 => vec![
+                Surface {
+                    start: -radius * 8.0,
+                    end: width * 0.25,
+                    height: 0.0,
+                },
+                Surface {
+                    start: width * 0.28,
+                    end: width * 0.42,
+                    height: radius * 0.9,
+                },
+                Surface {
+                    start: width * 0.45,
+                    end: width * 0.59,
+                    height: radius * 2.0,
+                },
+                Surface {
+                    start: width * 0.62,
+                    end: width * 0.76,
+                    height: radius * 1.0,
+                },
+                Surface {
+                    start: width * 0.79,
+                    end: width + radius * 8.0,
+                    height: 0.0,
+                },
+            ],
+            _ => vec![
+                Surface {
+                    start: -radius * 8.0,
+                    end: width * 0.46,
+                    height: 0.0,
+                },
+                Surface {
+                    start: width * 0.54,
+                    end: width + radius * 8.0,
+                    height: 0.0,
+                },
+            ],
+        };
+        Self {
+            surfaces,
+            attempts: 0,
+            fallback: false,
+        }
+    }
+}

--- a/scenarios/clock/src/events/duck/platform_tests.rs
+++ b/scenarios/clock/src/events/duck/platform_tests.rs
@@ -1,5 +1,6 @@
 use super::planner::{Capabilities, Course, Rejection, Surface};
 use super::*;
+use engine_common::{ClockDuckCoursePattern, ClockDuckJumpProfile};
 
 const ASPECTS: [f32; 7] = [
     0.25,
@@ -11,6 +12,57 @@ const ASPECTS: [f32; 7] = [
     4.0,
 ];
 
+#[test]
+fn lookahead_preserves_a_second_running_jump_that_greedy_landing_loses() {
+    let radius = 8.0;
+    let caps = Capabilities {
+        height: 35.6,
+        flight: 52.0 / 60.0,
+        speed: 160.0,
+        acceleration: 960.0,
+    };
+    let course = Course::authored(800.0, radius, ClockDuckCoursePattern::TwoJump);
+    assert!(course.valid_routes(radius, caps));
+    let start = flow::Start {
+        surface: 0,
+        x: 150.0,
+        velocity: 160.0,
+        direction: 1.0,
+    };
+    let linked = flow::plan(&course, start, radius, caps).unwrap();
+    let greedy = flow::single_jump_plan(&course, start, radius, caps).unwrap();
+    assert_eq!(
+        (linked.source, linked.target, linked.next_target),
+        (0, 1, Some(2))
+    );
+    assert!(
+        linked.landing.x < greedy.landing.x,
+        "linked={linked:?} greedy={greedy:?}"
+    );
+    assert!(linked.cruise < greedy.cruise);
+    let onward = |p: planner::Plan| {
+        flow::single_jump_plan(
+            &course,
+            flow::Start {
+                surface: 1,
+                x: p.landing.x + p.cruise * DT * 2.0,
+                velocity: p.cruise,
+                direction: 1.0,
+            },
+            radius,
+            caps,
+        )
+    };
+    assert!(
+        onward(greedy).is_none(),
+        "center landing consumes the next runway"
+    );
+    assert!(
+        onward(linked).is_some(),
+        "earlier touchdown leaves a running continuation"
+    );
+}
+
 #[derive(Debug, Default)]
 struct RunStats {
     landings: u32,
@@ -21,6 +73,10 @@ struct RunStats {
     moving: u32,
     fallbacks: u32,
     lookahead: u32,
+    skipped: u32,
+    chains: u32,
+    chained_directions: [u32; 2],
+    skipped_directions: [u32; 2],
 }
 
 fn run(event: DuckEvent, label: &str) -> (u32, u64) {
@@ -32,12 +88,21 @@ fn run_stats(mut event: DuckEvent, label: &str) -> RunStats {
     let mut stats = RunStats::default();
     let mut landings = 0;
     let mut exit_tick = None;
+    let mut last_landing: Option<engine_common::ClockDuckPlanState> = None;
+    let mut moving_since_landing = false;
+    let mut chained_flight = false;
     for tick in 1..=DUCK_TICKS {
         let before = event.diagnostics();
         event.step();
         let after = event.diagnostics();
         let navigation = after.navigation.unwrap();
         let planning = navigation.planning.unwrap();
+        if last_landing.is_some()
+            && let Some(world) = &event.world
+        {
+            moving_since_landing &= world.motion(DUCK_BODY).unwrap().linear_velocity.x.abs()
+                > event.movement.run_speed * 0.05;
+        }
         if stats.first_crossing == 0 {
             if navigation.wall_tags.iter().sum::<u32>() > 0 {
                 stats.first_crossing = tick;
@@ -60,9 +125,15 @@ fn run_stats(mut event: DuckEvent, label: &str) -> RunStats {
         assert!(event.physics_counts().0 <= planner::MAX_SURFACES + 1);
         if after.jumps > before.jumps {
             assert!(before.grounded, "{label}: airborne jump");
+            chained_flight = false;
             if let Some(plan) = planning.plan
                 && plan.running_takeoff
             {
+                chained_flight = last_landing.is_some_and(|previous| {
+                    previous.running_takeoff
+                        && previous.target == plan.source
+                        && previous.next_target == Some(plan.target)
+                }) && moving_since_landing;
                 let speed = event
                     .world
                     .as_ref()
@@ -81,6 +152,48 @@ fn run_stats(mut event: DuckEvent, label: &str) -> RunStats {
             assert_eq!(planning.support, Some(previous_plan.target));
             assert!(before.grounded, "landing must be solver-supported");
             landings = planning.confirmed_landings;
+            stats.chains += u32::from(chained_flight);
+            let direction = usize::from(previous_plan.target > previous_plan.source);
+            stats.chained_directions[direction] += u32::from(chained_flight);
+            let skipped = previous_plan
+                .target
+                .abs_diff(previous_plan.source)
+                .saturating_sub(1) as u32;
+            stats.skipped_directions[direction] += skipped;
+            assert_eq!(
+                planning.skipped_platforms
+                    - before
+                        .navigation
+                        .unwrap()
+                        .planning
+                        .unwrap()
+                        .skipped_platforms,
+                skipped
+            );
+            chained_flight = false;
+            last_landing = Some(previous_plan);
+            moving_since_landing = true;
+        } else {
+            assert_eq!(
+                planning.skipped_platforms,
+                before
+                    .navigation
+                    .unwrap()
+                    .planning
+                    .unwrap()
+                    .skipped_platforms,
+                "only confirmed landings earn shortcuts"
+            );
+        }
+        if event.controller.navigator.flight_tick.is_some()
+            && let Some(plan) = planning.plan
+            && plan.target.abs_diff(plan.source) > 1
+            && let Some(support) = planning.support
+        {
+            assert!(
+                support == plan.source || support == plan.target,
+                "shortcut must fly over the intervening platform"
+            );
         }
         if let Some(outcome) = after.outcome {
             assert_eq!(
@@ -107,14 +220,18 @@ fn run_stats(mut event: DuckEvent, label: &str) -> RunStats {
         navigation.wall_tags.iter().all(|count| *count > 0),
         "{label}: {final_state:?}"
     );
-    assert!(landings >= (event.course.as_ref().unwrap().surfaces.len() - 1) as u32 * 3);
     assert_eq!(event.physics_counts(), (0, 0));
     let planning = navigation.planning.unwrap();
+    assert!(
+        landings + planning.skipped_platforms
+            >= (event.course.as_ref().unwrap().surfaces.len() - 1) as u32 * 3
+    );
     stats.landings = landings;
     stats.exit_tick = exit_tick.expect("must exit");
     stats.running = planning.running_jumps;
     stats.moving = planning.moving_landings;
     stats.fallbacks = planning.flowing_fallbacks;
+    stats.skipped = planning.skipped_platforms;
     stats
 }
 
@@ -154,6 +271,14 @@ fn compare_profiles(seeds: std::ops::Range<u64>) {
                 totals[index].moving += result.moving;
                 totals[index].fallbacks += result.fallbacks;
                 totals[index].lookahead += result.lookahead;
+                totals[index].skipped += result.skipped;
+                totals[index].chains += result.chains;
+                for direction in 0..2 {
+                    totals[index].chained_directions[direction] +=
+                        result.chained_directions[direction];
+                    totals[index].skipped_directions[direction] +=
+                        result.skipped_directions[direction];
+                }
             }
         }
     }
@@ -168,6 +293,111 @@ fn compare_profiles(seeds: std::ops::Range<u64>) {
     assert!(totals[1].moving >= totals[1].running * 9 / 10);
     assert!(totals[1].first_crossing < totals[0].first_crossing);
     assert!(totals[1].stopped_before_first_wall < totals[0].stopped_before_first_wall);
+}
+
+#[test]
+fn authored_routes_prove_linked_jumps_and_shortcuts_in_the_real_solver() {
+    for (pattern, profile, aspect) in [
+        (
+            ClockDuckCoursePattern::TwoJump,
+            ClockDuckJumpProfile::Flowing,
+        ),
+        (
+            ClockDuckCoursePattern::Shortcut,
+            ClockDuckJumpProfile::Flowing,
+        ),
+        (
+            ClockDuckCoursePattern::TwoJump,
+            ClockDuckJumpProfile::Careful,
+        ),
+        (
+            ClockDuckCoursePattern::Shortcut,
+            ClockDuckJumpProfile::Careful,
+        ),
+    ]
+    .into_iter()
+    .flat_map(|(pattern, profile)| {
+        [800.0 / 480.0, 1024.0 / 768.0].map(|aspect| (pattern, profile, aspect))
+    }) {
+        let mut event = DuckEvent::new_platforms(Layout::new(aspect), 42);
+        event.course = Some(Course::authored(event.width, event.radius, pattern));
+        event.select_jump_profile(Some(profile));
+        let stats = run_stats(event, &format!("{pattern:?} {profile:?}"));
+        eprintln!("authored {pattern:?} {profile:?} aspect={aspect}: {stats:?}");
+        if profile == ClockDuckJumpProfile::Careful {
+            assert_eq!(stats.skipped, 0);
+        } else if pattern == ClockDuckCoursePattern::TwoJump {
+            assert!(
+                stats.chained_directions.iter().all(|count| *count > 0),
+                "two real landings, with no stop between the jumps, in either direction"
+            );
+        } else {
+            assert!(
+                stats.skipped_directions.iter().all(|count| *count > 0),
+                "must confirm landing beyond the intermediate platform in either direction"
+            );
+        }
+    }
+}
+
+#[test]
+fn seeded_patterns_are_playable_by_both_profiles_at_every_aspect() {
+    pattern_matrix(0..4);
+}
+
+#[test]
+#[ignore = "extended deterministic authored-course sweep"]
+fn authored_pattern_stress() {
+    pattern_matrix(4..32);
+}
+
+fn pattern_matrix(seeds: std::ops::Range<u64>) {
+    #[derive(Debug, Default)]
+    struct Totals {
+        landings: u32,
+        chains: u32,
+        skipped: u32,
+    }
+    let mut totals = [Totals::default(), Totals::default()];
+    for pattern in [
+        ClockDuckCoursePattern::Platforms,
+        ClockDuckCoursePattern::Terraces,
+        ClockDuckCoursePattern::TwoJump,
+        ClockDuckCoursePattern::Shortcut,
+    ] {
+        for aspect in ASPECTS {
+            for seed in seeds.clone() {
+                for (index, profile) in
+                    [ClockDuckJumpProfile::Careful, ClockDuckJumpProfile::Flowing]
+                        .into_iter()
+                        .enumerate()
+                {
+                    let mut event = DuckEvent::new_course(Layout::new(aspect), seed, Some(pattern));
+                    let course = event.course.as_ref().unwrap();
+                    assert_eq!(course.pattern, pattern);
+                    assert!(!course.fallback);
+                    assert_eq!(
+                        course.surfaces,
+                        Course::varied(event.width, event.radius, seed, Some(pattern)).surfaces
+                    );
+                    event.select_jump_profile(Some(profile));
+                    let stats = run_stats(
+                        event,
+                        &format!("{pattern:?} {profile:?} aspect={aspect} seed={seed}"),
+                    );
+                    totals[index].landings += stats.landings;
+                    totals[index].chains += stats.chains;
+                    totals[index].skipped += stats.skipped;
+                }
+            }
+        }
+    }
+    eprintln!(
+        "pattern sweep seeds={seeds:?} careful={:?} flowing={:?}",
+        totals[0], totals[1]
+    );
+    assert_eq!(totals[0].skipped, 0);
+    assert!(totals[1].chains > 0 && totals[1].skipped > 0);
 }
 
 #[test]
@@ -577,6 +807,7 @@ fn planner_rejects_unreachable_narrow_and_obstructed_landings() {
     ] {
         let course = Course {
             surfaces: vec![base, target],
+            pattern: ClockDuckCoursePattern::Platforms,
             attempts: 0,
             fallback: false,
         };
@@ -586,6 +817,7 @@ fn planner_rejects_unreachable_narrow_and_obstructed_landings() {
         );
     }
     let course = Course {
+        pattern: ClockDuckCoursePattern::Platforms,
         surfaces: vec![
             base,
             Surface {

--- a/scenarios/clock/src/events/duck/platform_tests.rs
+++ b/scenarios/clock/src/events/duck/platform_tests.rs
@@ -1,0 +1,609 @@
+use super::planner::{Capabilities, Course, Rejection, Surface};
+use super::*;
+
+const ASPECTS: [f32; 7] = [
+    0.25,
+    0.6,
+    0.75,
+    1024.0 / 768.0,
+    800.0 / 480.0,
+    1280.0 / 720.0,
+    4.0,
+];
+
+#[derive(Debug, Default)]
+struct RunStats {
+    landings: u32,
+    exit_tick: u64,
+    first_crossing: u64,
+    stopped_before_first_wall: u64,
+    running: u32,
+    moving: u32,
+    fallbacks: u32,
+    lookahead: u32,
+}
+
+fn run(event: DuckEvent, label: &str) -> (u32, u64) {
+    let stats = run_stats(event, label);
+    (stats.landings, stats.exit_tick)
+}
+
+fn run_stats(mut event: DuckEvent, label: &str) -> RunStats {
+    let mut stats = RunStats::default();
+    let mut landings = 0;
+    let mut exit_tick = None;
+    for tick in 1..=DUCK_TICKS {
+        let before = event.diagnostics();
+        event.step();
+        let after = event.diagnostics();
+        let navigation = after.navigation.unwrap();
+        let planning = navigation.planning.unwrap();
+        if stats.first_crossing == 0 {
+            if navigation.wall_tags.iter().sum::<u32>() > 0 {
+                stats.first_crossing = tick;
+            } else if after.grounded
+                && navigation.speed_samples == 9
+                && event
+                    .world
+                    .as_ref()
+                    .unwrap()
+                    .motion(DUCK_BODY)
+                    .unwrap()
+                    .linear_velocity
+                    .x
+                    .abs()
+                    < navigation.run_speed_milli.unwrap() as f32 / 1000.0 * 0.05
+            {
+                stats.stopped_before_first_wall += 1;
+            }
+        }
+        assert!(event.physics_counts().0 <= planner::MAX_SURFACES + 1);
+        if after.jumps > before.jumps {
+            assert!(before.grounded, "{label}: airborne jump");
+            if let Some(plan) = planning.plan
+                && plan.running_takeoff
+            {
+                let speed = event
+                    .world
+                    .as_ref()
+                    .unwrap()
+                    .motion(DUCK_BODY)
+                    .unwrap()
+                    .linear_velocity
+                    .x
+                    .abs();
+                assert!(speed >= navigation.run_speed_milli.unwrap() as f32 / 1000.0 * 0.14);
+                stats.lookahead += u32::from(plan.next_target.is_some());
+            }
+        }
+        if planning.confirmed_landings > landings {
+            let previous_plan = before.navigation.unwrap().planning.unwrap().plan.unwrap();
+            assert_eq!(planning.support, Some(previous_plan.target));
+            assert!(before.grounded, "landing must be solver-supported");
+            landings = planning.confirmed_landings;
+        }
+        if let Some(outcome) = after.outcome {
+            assert_eq!(
+                outcome,
+                ClockDuckOutcome::Exited,
+                "{label} tick={tick} {after:?} course={:?}",
+                event.course
+            );
+            exit_tick.get_or_insert(tick);
+        }
+        assert_eq!(
+            (
+                planning.undershoots,
+                planning.overshoots,
+                planning.wrong_surface_landings
+            ),
+            (0, 0, 0),
+            "{label} tick={tick} {after:?}"
+        );
+    }
+    let final_state = event.diagnostics();
+    let navigation = final_state.navigation.unwrap();
+    assert!(
+        navigation.wall_tags.iter().all(|count| *count > 0),
+        "{label}: {final_state:?}"
+    );
+    assert!(landings >= (event.course.as_ref().unwrap().surfaces.len() - 1) as u32 * 3);
+    assert_eq!(event.physics_counts(), (0, 0));
+    let planning = navigation.planning.unwrap();
+    stats.landings = landings;
+    stats.exit_tick = exit_tick.expect("must exit");
+    stats.running = planning.running_jumps;
+    stats.moving = planning.moving_landings;
+    stats.fallbacks = planning.flowing_fallbacks;
+    stats
+}
+
+#[test]
+fn jumping_profiles_compare_on_identical_generated_courses() {
+    compare_profiles(0..8);
+}
+
+#[test]
+#[ignore = "extended deterministic two-profile comparison"]
+fn jumping_profile_stress() {
+    compare_profiles(8..64);
+}
+
+fn compare_profiles(seeds: std::ops::Range<u64>) {
+    use engine_common::ClockDuckJumpProfile;
+    let mut totals = [RunStats::default(), RunStats::default()];
+    let cases = (seeds.end - seeds.start) as usize * ASPECTS.len();
+    for aspect in ASPECTS {
+        for seed in seeds.clone() {
+            let careful = DuckEvent::new_platforms(Layout::new(aspect), seed);
+            let mut flowing = DuckEvent::new_platforms(Layout::new(aspect), seed);
+            flowing.select_jump_profile(Some(ClockDuckJumpProfile::Flowing));
+            assert_eq!(
+                careful.course.as_ref().unwrap().surfaces,
+                flowing.course.as_ref().unwrap().surfaces
+            );
+            for (index, event) in [careful, flowing].into_iter().enumerate() {
+                let result = run_stats(
+                    event,
+                    &format!("profile={index} aspect={aspect} seed={seed}"),
+                );
+                totals[index].first_crossing += result.first_crossing;
+                totals[index].stopped_before_first_wall += result.stopped_before_first_wall;
+                totals[index].landings += result.landings;
+                totals[index].running += result.running;
+                totals[index].moving += result.moving;
+                totals[index].fallbacks += result.fallbacks;
+                totals[index].lookahead += result.lookahead;
+            }
+        }
+    }
+    eprintln!(
+        "jump profiles ({cases} paired courses): careful={:?}; flowing={:?}",
+        totals[0], totals[1]
+    );
+    assert_eq!(totals[0].running, 0);
+    assert_eq!(totals[0].fallbacks, 0);
+    assert!(totals[1].running > cases as u32);
+    assert!(totals[1].lookahead > 0);
+    assert!(totals[1].moving >= totals[1].running * 9 / 10);
+    assert!(totals[1].first_crossing < totals[0].first_crossing);
+    assert!(totals[1].stopped_before_first_wall < totals[0].stopped_before_first_wall);
+}
+
+#[test]
+fn fixed_platform_step_and_gap_courses_land_in_both_directions() {
+    for aspect in ASPECTS {
+        for fixture in 0..3 {
+            let mut event = DuckEvent::new_platforms(Layout::new(aspect), 42);
+            event.course = Some(Course::fixed(event.width, event.radius, fixture));
+            run(event, &format!("aspect={aspect} fixture={fixture}"));
+        }
+    }
+}
+
+#[test]
+fn generated_platform_courses_have_confirmed_landings_and_bounded_exits() {
+    generated_matrix(0..32);
+}
+
+#[test]
+#[ignore = "extended deterministic platform-course seed sweep"]
+fn platform_seed_stress() {
+    generated_matrix(32..256);
+}
+
+fn generated_matrix(seeds: std::ops::Range<u64>) {
+    let cases = ASPECTS.len() as u64 * (seeds.end - seeds.start);
+    let mut landings = 0;
+    let mut exits = [u64::MAX, 0];
+    let mut fallbacks = 0;
+    for aspect in ASPECTS {
+        for seed in seeds.clone() {
+            let event = DuckEvent::new_platforms(Layout::new(aspect), seed);
+            fallbacks += usize::from(event.course.as_ref().unwrap().fallback);
+            let (count, exit) = run(event, &format!("aspect={aspect} seed={seed}"));
+            landings += count;
+            exits[0] = exits[0].min(exit);
+            exits[1] = exits[1].max(exit);
+        }
+    }
+    eprintln!(
+        "platform matrix: {cases} courses, {landings} confirmed landings, exit ticks {exits:?}, {fallbacks} fallbacks"
+    );
+}
+
+#[test]
+fn exhausted_generation_budget_uses_a_playable_fallback_and_seeds_vary_geometry() {
+    for aspect in ASPECTS {
+        let mut event = DuckEvent::new_platforms(Layout::new(aspect), 42);
+        let course = Course::generate_with_budget(event.width, event.radius, 42, 0);
+        assert!(course.fallback);
+        event.course = Some(course);
+        run(event, "forced fallback");
+    }
+    let a = Course::generated(800.0, 8.0, 42);
+    assert_eq!(a.surfaces, Course::generated(800.0, 8.0, 42).surfaces);
+    let variants = (0..32)
+        .filter(|seed| Course::generated(800.0, 8.0, *seed).surfaces != a.surfaces)
+        .count();
+    assert!(variants >= 30, "course generation should visibly vary");
+}
+
+#[test]
+fn forced_bad_landings_are_classified_using_real_supports_not_proximity() {
+    for kind in 0..3 {
+        let mut event = DuckEvent::new_platforms(Layout::new(800.0 / 480.0), 42);
+        while event.jumps < 3 || event.grounded() {
+            assert!(event.tick < 500);
+            event.step();
+        }
+        let plan = event.controller.navigator.plan.unwrap();
+        let floor = event.layout.floor_y;
+        let radius = event.radius;
+        let x = match kind {
+            0 => event.width * 0.1,
+            1 => event.width * 0.9,
+            _ => plan.landing.x,
+        };
+        let mut y = floor + radius * 1.2;
+        let world = event.world.as_mut().unwrap();
+        if kind == 2 {
+            // A foreign collider at the intended X coordinate: landing nearby
+            // must not count as landing on the intended platform.
+            let entity = PhysicsId::new(999);
+            let top = floor + plan.landing.y + radius * 3.0;
+            world.insert_body(
+                BodyId::new(entity, BodyRole::PRIMARY),
+                BodySpec {
+                    kind: BodyKind::Fixed,
+                    position: Vec2::new(x, top - radius),
+                    ..BodySpec::default()
+                },
+                &[ColliderSpec::cuboid(
+                    ColliderId::new(entity, ColliderRole::PRIMARY, 0),
+                    radius * 3.0,
+                    radius,
+                )],
+            );
+            y = top + radius * 1.2;
+        }
+        let motion = world.motion(DUCK_BODY).unwrap();
+        world.set_pose(DUCK_BODY, Vec2::new(x, y), 0.0, true);
+        world.apply_velocity_delta(DUCK_BODY, -motion.linear_velocity, true);
+        for _ in 0..30 {
+            event.step();
+            let navigator = &event.controller.navigator;
+            if navigator.undershoots + navigator.overshoots + navigator.wrong_surface > 0 {
+                break;
+            }
+        }
+        let navigator = &event.controller.navigator;
+        assert_eq!(navigator.confirmed, 0);
+        assert_eq!(
+            [
+                navigator.undershoots,
+                navigator.overshoots,
+                navigator.wrong_surface
+            ],
+            match kind {
+                0 => [1, 0, 0],
+                1 => [0, 1, 0],
+                _ => [0, 0, 1],
+            }
+        );
+    }
+}
+
+#[test]
+fn unreachable_platform_is_refused_and_event_still_cleans_up() {
+    let mut event = DuckEvent::new_platforms(Layout::new(800.0 / 480.0), 42);
+    event.course.as_mut().unwrap().surfaces[1].height = event.radius * 20.0;
+    for _ in 0..DUCK_TICKS {
+        event.step();
+    }
+    let stats = event.diagnostics();
+    let planning = stats.navigation.unwrap().planning.unwrap();
+    assert_eq!(stats.outcome, Some(ClockDuckOutcome::TimedOut));
+    assert_eq!(
+        stats.jumps, 2,
+        "do not blindly jump at an unreachable target"
+    );
+    assert_eq!(
+        planning.rejection,
+        Some(engine_common::ClockDuckRejection::TooHigh)
+    );
+    assert!(planning.rejected_plans > 0 && planning.rejected_plans < 100);
+    assert_eq!(event.physics_counts(), (0, 0));
+}
+
+#[test]
+fn platform_preview_pause_resize_and_debug_overlay_do_not_change_physics() {
+    use crate::{ClockAction, ClockConfig, ClockReading, ClockScenario};
+    use engine_common::{ClockEventKind, ClockEventProfile, Scenario};
+    use std::time::Duration;
+    for profile in [
+        engine_common::ClockDuckJumpProfile::Careful,
+        engine_common::ClockDuckJumpProfile::Flowing,
+    ] {
+        let init = |debug| {
+            let mut state = ClockScenario::init(
+                ClockConfig {
+                    event_profile: ClockEventProfile::Off,
+                    duck_debug_overlay: debug,
+                    duck_jump_profile: Some(profile),
+                    ..ClockConfig::default()
+                },
+                42,
+            );
+            ClockScenario::step(
+                &mut state,
+                &[
+                    ClockAction::set_reading(ClockReading::new(8, 8, 0).unwrap()),
+                    ClockAction::preview_event(ClockEventKind::Duck),
+                ],
+                Duration::ZERO,
+            );
+            state
+        };
+        let mut plain = init(false);
+        let mut debug = init(true);
+        assert_eq!(
+            debug.duck_state().unwrap().navigation.unwrap().jump_profile,
+            profile
+        );
+        let mut saw_overlay = false;
+        for _ in 0..600 {
+            assert_eq!(plain.duck_state(), debug.duck_state());
+            let stats = plain.duck_state().unwrap();
+            if stats.navigation.unwrap().planning.unwrap().plan.is_some() {
+                assert_ne!(
+                    ClockScenario::render_frame(&plain),
+                    ClockScenario::render_frame(&debug)
+                );
+                saw_overlay = true;
+            }
+            ClockScenario::step(&mut plain, &[], Duration::from_nanos(16_666_667));
+            ClockScenario::step(&mut debug, &[], Duration::from_nanos(16_666_667));
+        }
+        assert!(saw_overlay);
+        let before = debug.duck_state();
+        ClockScenario::step(
+            &mut debug,
+            &[ClockAction::set_reading(
+                ClockReading::new(12, 1, 0).unwrap(),
+            )],
+            Duration::ZERO,
+        );
+        assert_eq!(debug.duck_state(), before);
+        ClockScenario::step(
+            &mut debug,
+            &[ClockAction::preview_event(ClockEventKind::Duck)],
+            Duration::ZERO,
+        );
+        assert_eq!(debug.body_count(), 0);
+        assert_eq!(
+            debug
+                .duck_state()
+                .unwrap()
+                .navigation
+                .unwrap()
+                .planning
+                .unwrap()
+                .confirmed_landings,
+            0
+        );
+        debug.set_aspect_ratio(0.6);
+        assert_eq!(debug.duck_state(), None);
+        assert_eq!(debug.body_count(), 0);
+    }
+}
+
+#[test]
+fn careful_fixture_is_preserved_and_profiles_share_physics_and_calibration() {
+    let layout = Layout::new(800.0 / 480.0);
+    let mut default = DuckEvent::new_platforms(layout, 42);
+    let mut explicit = DuckEvent::new_platforms(layout, 42);
+    explicit.select_jump_profile(Some(engine_common::ClockDuckJumpProfile::Careful));
+    let mut flowing = DuckEvent::new_platforms(layout, 42);
+    flowing.select_jump_profile(Some(engine_common::ClockDuckJumpProfile::Flowing));
+    for _ in 0..DUCK_TICKS {
+        assert_eq!(default.diagnostics(), explicit.diagnostics());
+        if default.controller.speeds.count < 9 {
+            assert_eq!(default.position(), flowing.position());
+            assert_eq!(default.jumps, flowing.jumps);
+        }
+        default.step();
+        explicit.step();
+        flowing.step();
+    }
+}
+
+#[test]
+fn mixed_spawns_replay_both_personalities_without_changing_courses_or_schedules() {
+    use crate::{ClockAction, ClockConfig, ClockReading, ClockScenario, ClockState};
+    use engine_common::{ClockDuckJumpProfile, ClockEventKind, ClockEventProfile, Scenario};
+    use std::time::Duration;
+
+    let init = |profile| {
+        let mut state = ClockScenario::init(
+            ClockConfig {
+                duck_jump_profile: profile,
+                event_profile: ClockEventProfile::Demo,
+                ..ClockConfig::default()
+            },
+            42,
+        );
+        ClockScenario::step(
+            &mut state,
+            &[ClockAction::set_reading(
+                ClockReading::new(8, 8, 0).unwrap(),
+            )],
+            Duration::ZERO,
+        );
+        state
+    };
+    let geometry = |state: &ClockState| {
+        let Some(crate::events::ActiveEvent::Duck(event)) = &state.active_event else {
+            panic!("expected duck")
+        };
+        event.course.as_ref().unwrap().surfaces.clone()
+    };
+    assert_eq!(ClockConfig::default().duck_jump_profile, None);
+    let mut mixed = init(None);
+    let mut replay = init(None);
+    let mut forced = init(Some(ClockDuckJumpProfile::Careful));
+    let mut counts = [0; 2];
+    for _ in 0..32 {
+        for state in [&mut mixed, &mut replay, &mut forced] {
+            ClockScenario::step(
+                state,
+                &[ClockAction::preview_event(ClockEventKind::Duck)],
+                Duration::ZERO,
+            );
+        }
+        let profile = mixed.duck_state().unwrap().navigation.unwrap().jump_profile;
+        counts[usize::from(profile == ClockDuckJumpProfile::Flowing)] += 1;
+        assert_eq!(geometry(&mixed), geometry(&replay));
+        assert_eq!(geometry(&mixed), geometry(&forced));
+        assert_eq!(
+            mixed.duck_state().unwrap().left_to_right,
+            forced.duck_state().unwrap().left_to_right
+        );
+        for _ in 0..DUCK_TICKS + 130 {
+            assert_eq!(mixed.duck_state(), replay.duck_state());
+            if let Some(duck) = mixed.duck_state() {
+                assert_eq!(duck.navigation.unwrap().jump_profile, profile);
+            }
+            if let Some(duck) = forced.duck_state() {
+                assert_eq!(
+                    duck.navigation.unwrap().jump_profile,
+                    ClockDuckJumpProfile::Careful
+                );
+            }
+            assert_eq!(mixed.next_event_tick(), forced.next_event_tick());
+            assert_eq!(mixed.event_id(), forced.event_id());
+            for state in [&mut mixed, &mut replay, &mut forced] {
+                ClockScenario::step(state, &[], Duration::from_nanos(16_666_667));
+            }
+        }
+        assert!(mixed.duck_state().is_none());
+        assert_eq!(mixed.body_count(), 0);
+    }
+    assert!(
+        counts.iter().all(|count| *count > 0),
+        "both personalities should appear: {counts:?}"
+    );
+    eprintln!(
+        "mixed spawn replay: 32 visits, Careful={}, Flowing={}",
+        counts[0], counts[1]
+    );
+}
+
+#[test]
+fn failed_running_takeoff_brakes_and_finishes_with_careful_fallback() {
+    let mut event = DuckEvent::new_platforms(Layout::new(800.0 / 480.0), 42);
+    event.select_jump_profile(Some(engine_common::ClockDuckJumpProfile::Flowing));
+    // Find an approach with enough lead to inject a lost-speed disturbance.
+    loop {
+        assert!(event.tick < 600);
+        event.step();
+        if event
+            .controller
+            .navigator
+            .plan
+            .is_some_and(|plan| plan.running)
+            && event.controller.navigator.flight_tick.is_none()
+            && event.grounded()
+        {
+            break;
+        }
+    }
+    let plan = event.controller.navigator.plan.unwrap();
+    let before = event.controller.navigator.flowing_fallbacks;
+    let world = event.world.as_mut().unwrap();
+    let motion = world.motion(DUCK_BODY).unwrap();
+    world.set_pose(
+        DUCK_BODY,
+        Vec2::new(plan.takeoff.x, motion.position.y),
+        0.0,
+        true,
+    );
+    world.apply_velocity_delta(DUCK_BODY, -motion.linear_velocity, true);
+    world.step(DT);
+    event.step();
+    assert_eq!(event.controller.navigator.flowing_fallbacks, before + 1);
+    assert!(!event.controller.navigator.plan.unwrap().running);
+    run_stats(event, "lost-speed takeoff fallback");
+}
+
+#[test]
+fn planner_rejects_unreachable_narrow_and_obstructed_landings() {
+    let capabilities = Capabilities {
+        height: 36.0,
+        flight: 0.86,
+        speed: 160.0,
+        acceleration: 960.0,
+    };
+    let base = Surface {
+        start: 0.0,
+        end: 100.0,
+        height: 0.0,
+    };
+    for (target, expected) in [
+        (
+            Surface {
+                start: 120.0,
+                end: 180.0,
+                height: 40.0,
+            },
+            Rejection::High,
+        ),
+        (
+            Surface {
+                start: 120.0,
+                end: 130.0,
+                height: 0.0,
+            },
+            Rejection::Narrow,
+        ),
+        (
+            Surface {
+                start: 600.0,
+                end: 680.0,
+                height: 0.0,
+            },
+            Rejection::Range,
+        ),
+    ] {
+        let course = Course {
+            surfaces: vec![base, target],
+            attempts: 0,
+            fallback: false,
+        };
+        assert_eq!(
+            planner::plan(&course, 0, 1, 8.0, capabilities).unwrap_err(),
+            expected
+        );
+    }
+    let course = Course {
+        surfaces: vec![
+            base,
+            Surface {
+                start: 105.0,
+                end: 110.0,
+                height: 100.0,
+            },
+            Surface {
+                start: 120.0,
+                end: 180.0,
+                height: 0.0,
+            },
+        ],
+        attempts: 0,
+        fallback: false,
+    };
+    assert_eq!(
+        planner::plan(&course, 0, 2, 8.0, capabilities).unwrap_err(),
+        Rejection::Obstructed
+    );
+}

--- a/scenarios/clock/src/events/duck/tests.rs
+++ b/scenarios/clock/src/events/duck/tests.rs
@@ -23,6 +23,13 @@ fn ready(aspect: f32, seed: u64) -> ClockState {
         ],
         Duration::ZERO,
     );
+    // Keep the first wall-tag/hurdle course as a frozen geometry/controller
+    // regression baseline; platform tests exercise the new default separately.
+    let event_seed = state.duck_state().unwrap().navigation.unwrap().course_seed;
+    state.active_event = Some(crate::events::ActiveEvent::Duck(Box::new(DuckEvent::new(
+        Layout::new(aspect),
+        event_seed,
+    ))));
     state
 }
 
@@ -33,9 +40,43 @@ fn ticks(state: &mut ClockState, count: u64) {
 }
 
 #[test]
+fn duck_stays_in_the_course_and_tags_both_walls_before_the_exit_is_due() {
+    let mut state = ready(800.0 / 480.0, 42);
+    ticks(&mut state, OPENING_TICKS);
+    let entrance_on_left = state.duck_state().unwrap().left_to_right;
+    let mut touched = [false; 2];
+    for tick in 0..20 * 60 {
+        let duck = state.duck_state().expect("duck must still be playing tag");
+        assert_eq!(duck.outcome, None, "premature exit at tick {tick}");
+        assert_eq!(duck.exit_open_milli, 0, "exit opened at tick {tick}");
+        let x = duck.position_milli.unwrap()[0] as f32 / 1000.0;
+        // Ignore the initial warm-up near the entrance: both ends must be
+        // visited after a complete outward crossing.
+        if x * (if entrance_on_left { 1.0 } else { -1.0 }) > 320.0 {
+            touched[1] = true;
+        }
+        if touched[1] && x * (if entrance_on_left { 1.0 } else { -1.0 }) < -320.0 {
+            touched[0] = true;
+        }
+        ticks(&mut state, 1);
+    }
+    assert_eq!(touched, [true; 2]);
+}
+
+#[test]
 fn seeded_courses_jump_all_obstacles_exit_and_release_every_body() {
     let mut directions = [false; 2];
-    for aspect in [0.25, 0.75, 800.0 / 480.0, 4.0] {
+    let mut cases = 0;
+    let mut exit_range = [u64::MAX, 0];
+    for aspect in [
+        0.25,
+        0.6,
+        0.75,
+        1024.0 / 768.0,
+        800.0 / 480.0,
+        1280.0 / 720.0,
+        4.0,
+    ] {
         for seed in 0..32 {
             let mut state = ready(aspect, seed);
             let mut phases = Vec::new();
@@ -43,6 +84,14 @@ fn seeded_courses_jump_all_obstacles_exit_and_release_every_body() {
             let mut outcome = None;
             for tick in 0..DUCK_TICKS {
                 let stats = state.duck_state().unwrap();
+                let navigation = stats.navigation.unwrap();
+                assert_eq!(
+                    navigation.exit_visible,
+                    tick >= OPENING_TICKS + EXIT_DELAY_TICKS
+                );
+                if !navigation.exit_visible {
+                    assert_eq!(stats.exit_open_milli, 0);
+                }
                 directions[usize::from(stats.left_to_right)] = true;
                 if phases.last().copied() != state.event_phase() {
                     phases.push(state.event_phase().unwrap());
@@ -79,9 +128,22 @@ fn seeded_courses_jump_all_obstacles_exit_and_release_every_body() {
                         "aspect={aspect} seed={seed} tick={tick} {stats:?}"
                     );
                     assert_eq!(stats.cleared_obstacles, 3);
-                    assert_eq!(stats.jumps, 3);
+                    assert_eq!(navigation.calibrated_jumps, 2);
+                    assert_eq!(navigation.speed_samples, 9);
+                    assert!(
+                        navigation.wall_tags.iter().all(|tags| *tags >= 1),
+                        "{navigation:?}"
+                    );
+                    assert_eq!(
+                        stats.jumps,
+                        2 + 3 * (navigation.wall_tags.iter().sum::<u32>() + 1)
+                    );
                     assert_eq!(state.body_count(), 0);
                     assert_eq!(stats.position_milli, None);
+                    if outcome.is_none() {
+                        exit_range[0] = exit_range[0].min(tick);
+                        exit_range[1] = exit_range[1].max(tick);
+                    }
                     outcome = Some(result);
                 }
                 ticks(&mut state, 1);
@@ -111,9 +173,181 @@ fn seeded_courses_jump_all_obstacles_exit_and_release_every_body() {
             assert_eq!(state.lifecycle(), EventLifecycle::Cooldown);
             assert_eq!(state.duck_state(), None);
             assert_eq!((state.body_count(), state.collider_count()), (0, 0));
+            cases += 1;
         }
     }
     assert_eq!(directions, [true, true]);
+    eprintln!(
+        "duck matrix: {cases} seeded courses, all tagged both walls and exited; exit ticks {}..{}; no falls/timeouts",
+        exit_range[0], exit_range[1]
+    );
+}
+
+#[test]
+fn warmup_measures_real_jump_and_running_motion_instead_of_assuming_tuning() {
+    for aspect in [0.25, 800.0 / 480.0, 4.0] {
+        for scale in [0.85, 1.0, 1.15] {
+            let mut event = DuckEvent::new(Layout::new(aspect), 42);
+            event.movement.run_speed *= scale;
+            event.movement.jump_height *= scale;
+            event.movement.gravity *= 1.1;
+            let expected_speed = event.movement.run_speed;
+            let expected_height = event.movement.jump_height;
+            let expected_flight =
+                2.0 * (2.0 * expected_height / event.movement.gravity).sqrt() / DT;
+            for _ in 0..300 {
+                event.step();
+                let navigation = event.diagnostics().navigation.unwrap();
+                if navigation.calibrated_jumps < 2 {
+                    if let Some(position) = event.position() {
+                        assert!((position.x - event.radius * 6.0).abs() < event.radius * 0.05);
+                    }
+                    assert_eq!(navigation.run_speed_milli, None);
+                }
+                if navigation.speed_samples == 9 {
+                    let height = navigation.jump_height_milli.unwrap() as f32 / 1000.0;
+                    let speed = navigation.run_speed_milli.unwrap() as f32 / 1000.0;
+                    assert!(
+                        (height / expected_height - 1.0).abs() < 0.06,
+                        "{navigation:?}"
+                    );
+                    assert!(
+                        (speed / expected_speed - 1.0).abs() < 0.02,
+                        "{navigation:?}"
+                    );
+                    assert!(
+                        (navigation.flight_ticks.unwrap() as f32 - expected_flight).abs() < 4.0
+                    );
+                    break;
+                }
+            }
+            assert_eq!(event.controller.heights.count, 2);
+            assert_eq!(event.controller.speeds.count, 9);
+        }
+    }
+}
+
+#[test]
+fn sample_window_rejects_invalid_values_and_does_not_retain_speed_spikes() {
+    let mut samples = controller::Samples::default();
+    assert_eq!(samples.median(), None);
+    for value in [f32::NAN, f32::INFINITY, -1.0, 0.0] {
+        samples.push(value);
+    }
+    assert_eq!(samples.count, 0);
+    for value in [
+        100.0, 101.0, 99.0, 100.0, 10000.0, 100.0, 101.0, 99.0, 100.0,
+    ] {
+        samples.push(value);
+    }
+    assert_eq!(samples.median(), Some(100.0));
+    for _ in 0..20 {
+        samples.push(80.0);
+    }
+    assert_eq!(samples.count, 9);
+    assert_eq!(samples.median(), Some(80.0));
+}
+
+#[test]
+fn a_disturbed_warmup_is_discarded_and_retried() {
+    let mut event = DuckEvent::new(Layout::new(800.0 / 480.0), 42);
+    while event.jumps == 0 {
+        assert!(event.tick < 100);
+        event.step();
+    }
+    // Disturb the real body during its first flight. Even if it returns to
+    // the same floor, this is not an uncontaminated vertical calibration.
+    event.world.as_mut().unwrap().apply_velocity_delta(
+        DUCK_BODY,
+        Vec2::new(event.radius * 20.0, 0.0),
+        true,
+    );
+    while event.controller.heights.count < 2 {
+        assert!(event.tick < 300, "warm-up never recovered");
+        event.step();
+    }
+    assert_eq!(event.jumps, 3);
+}
+
+#[test]
+fn speed_measurement_excludes_airborne_blocked_and_accelerating_motion() {
+    for (grounded, blocked, accelerating) in [
+        (false, false, false),
+        (true, true, false),
+        (true, false, true),
+    ] {
+        let mut controller = Controller::new();
+        for _ in 0..2 {
+            controller.heights.push(35.0);
+            controller.flight_ticks.push(51.0);
+        }
+        let event = DuckEvent::new(Layout::new(800.0 / 480.0), 42);
+        for tick in 0..15 {
+            controller.decide(
+                Observation {
+                    position: Vec2::new(128.0, event.layout.floor_y + event.radius),
+                    velocity: Vec2::new(
+                        if accelerating {
+                            10.0 * tick as f32
+                        } else {
+                            160.0
+                        },
+                        0.0,
+                    ),
+                    grounded,
+                    blocked,
+                    support: None,
+                },
+                &event.obstacles,
+                event.width,
+                event.radius,
+                false,
+            );
+        }
+        assert_eq!(controller.speeds.count, 0);
+    }
+}
+
+#[test]
+fn movement_accelerates_and_brakes_without_instantly_reversing_or_air_jumping() {
+    use controller::{Command, Gait};
+    let movement = Movement::new(800.0, 8.0);
+    let mut observed = Observation {
+        position: Vec2::ZERO,
+        velocity: Vec2::new(movement.run_speed, -10.0),
+        grounded: false,
+        blocked: false,
+        support: None,
+    };
+    let turn = Command {
+        gait: Gait::Run,
+        direction: -1.0,
+        jump: true,
+    };
+    let delta = movement.velocity_delta(observed, &turn);
+    assert!(delta.x < 0.0 && observed.velocity.x + delta.x > 0.0);
+    assert_eq!(delta.y, 0.0);
+    observed.grounded = true;
+    let jump = movement.velocity_delta(observed, &turn).y + observed.velocity.y;
+    assert!((jump * jump / (2.0 * movement.gravity) - 8.0 * 4.5).abs() < 0.001);
+    for gait in [Gait::Walk, Gait::Still] {
+        let command = Command {
+            gait,
+            direction: 1.0,
+            jump: false,
+        };
+        for _ in 0..60 {
+            observed.velocity += movement.velocity_delta(observed, &command);
+        }
+        assert_eq!(
+            observed.velocity.x,
+            if matches!(gait, Gait::Walk) {
+                movement.walk_speed
+            } else {
+                0.0
+            }
+        );
+    }
 }
 
 #[test]
@@ -167,7 +401,15 @@ fn a_fall_and_a_blocked_runner_recover_within_the_catalog_bound() {
 
 #[test]
 fn live_time_pause_resize_and_preview_replacement_preserve_the_clock() {
-    for at in [0, 100, 430, 580] {
+    for at in [
+        0,
+        100,
+        430,
+        580,
+        OPENING_TICKS + EXIT_DELAY_TICKS - 1,
+        OPENING_TICKS + EXIT_DELAY_TICKS,
+        DUCK_TICKS - 10,
+    ] {
         let mut state = ready(800.0 / 480.0, 42);
         ticks(&mut state, at);
         let stats = state.duck_state();

--- a/scenarios/clock/src/events/tests.rs
+++ b/scenarios/clock/src/events/tests.rs
@@ -11,7 +11,12 @@ fn catalog_covers_every_kind_once_and_has_bounded_timing() {
     for (kind, definition) in ClockEventKind::ALL.into_iter().zip(EVENT_CATALOG.iter()) {
         assert_eq!(definition.kind, kind);
         assert_eq!(EVENT_CATALOG[kind as usize].kind, kind);
-        assert!(definition.duration_ticks > 0 && definition.duration_ticks <= 12 * 60);
+        let max_duration = if definition.kind == ClockEventKind::Duck {
+            35 * 60
+        } else {
+            12 * 60
+        };
+        assert!(definition.duration_ticks > 0 && definition.duration_ticks <= max_duration);
         assert!(definition.cooldown_ticks >= COOLDOWN_TICKS);
     }
 }

--- a/scenarios/clock/src/lib.rs
+++ b/scenarios/clock/src/lib.rs
@@ -186,6 +186,9 @@ impl ClockAction {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ClockConfig {
     pub aspect_ratio: f32,
+    pub duck_debug_overlay: bool,
+    /// None chooses a seeded personality once per Duck event.
+    pub duck_jump_profile: Option<engine_common::ClockDuckJumpProfile>,
     pub time_format: ClockTimeFormat,
     pub event_profile: ClockEventProfile,
     pub events: ClockEvents,
@@ -197,6 +200,8 @@ impl Default for ClockConfig {
     fn default() -> Self {
         Self {
             aspect_ratio: DEFAULT_ASPECT_RATIO,
+            duck_debug_overlay: false,
+            duck_jump_profile: None,
             time_format: ClockTimeFormat::TwentyFourHour,
             event_profile: ClockEventProfile::default(),
             events: ClockEvents::default(),
@@ -210,6 +215,8 @@ impl ClockConfig {
     fn normalized(self) -> Self {
         Self {
             aspect_ratio: normalize_aspect_ratio(self.aspect_ratio),
+            duck_debug_overlay: self.duck_debug_overlay,
+            duck_jump_profile: self.duck_jump_profile,
             time_format: self.time_format,
             event_profile: self.event_profile,
             events: self.events,
@@ -398,6 +405,7 @@ impl ClockState {
             self.config.marquee_preset,
             self.config.marquee_message,
             previous_display,
+            self.config.duck_jump_profile,
         ));
     }
 

--- a/scenarios/clock/src/lib.rs
+++ b/scenarios/clock/src/lib.rs
@@ -189,6 +189,8 @@ pub struct ClockConfig {
     pub duck_debug_overlay: bool,
     /// None chooses a seeded personality once per Duck event.
     pub duck_jump_profile: Option<engine_common::ClockDuckJumpProfile>,
+    /// None selects a seeded course pattern, independently of personality.
+    pub duck_course_pattern: Option<engine_common::ClockDuckCoursePattern>,
     pub time_format: ClockTimeFormat,
     pub event_profile: ClockEventProfile,
     pub events: ClockEvents,
@@ -202,6 +204,7 @@ impl Default for ClockConfig {
             aspect_ratio: DEFAULT_ASPECT_RATIO,
             duck_debug_overlay: false,
             duck_jump_profile: None,
+            duck_course_pattern: None,
             time_format: ClockTimeFormat::TwentyFourHour,
             event_profile: ClockEventProfile::default(),
             events: ClockEvents::default(),
@@ -217,6 +220,7 @@ impl ClockConfig {
             aspect_ratio: normalize_aspect_ratio(self.aspect_ratio),
             duck_debug_overlay: self.duck_debug_overlay,
             duck_jump_profile: self.duck_jump_profile,
+            duck_course_pattern: self.duck_course_pattern,
             time_format: self.time_format,
             event_profile: self.event_profile,
             events: self.events,
@@ -402,10 +406,8 @@ impl ClockState {
                 layout,
             },
             seed,
-            self.config.marquee_preset,
-            self.config.marquee_message,
+            self.config,
             previous_display,
-            self.config.duck_jump_profile,
         ));
     }
 

--- a/scenarios/clock/src/render.rs
+++ b/scenarios/clock/src/render.rs
@@ -67,7 +67,7 @@ pub fn render_frame(state: &ClockState) -> RenderFrame {
         render_meltdown(&mut frame, event, layout);
     }
     if let Some(crate::events::ActiveEvent::Duck(event)) = &state.active_event {
-        duck::render(&mut frame, event);
+        duck::render(&mut frame, event, state.config.duck_debug_overlay);
     }
     render_colon(&mut frame, state, layout);
     render_meridiem(&mut frame, state, layout);

--- a/scenarios/clock/src/render/duck.rs
+++ b/scenarios/clock/src/render/duck.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::events::duck::DuckEvent;
 
-pub(super) fn render(frame: &mut RenderFrame, event: &DuckEvent) {
+pub(super) fn render(frame: &mut RenderFrame, event: &DuckEvent, debug: bool) {
     let opacity = event.course_opacity();
     if opacity <= 0.0 {
         return;
@@ -18,53 +18,118 @@ pub(super) fn render(frame: &mut RenderFrame, event: &DuckEvent) {
         ARENA_LAYER,
         opacity,
     );
-    let pit = event.obstacles[1];
-    for (start, end) in [(0.0, pit.start), (pit.end, event.width)] {
-        rect(
-            frame,
-            event,
-            Vec2::new(start, layout.bounds_min.y),
-            Vec2::new(end, layout.floor_y),
-            FLOOR_COLOR,
-            ARENA_LAYER,
-            opacity,
-        );
-        rect(
-            frame,
-            event,
-            Vec2::new(start, layout.floor_y - 2.0),
-            Vec2::new(end, layout.floor_y),
-            FLOOR_EDGE_COLOR,
-            ARENA_LAYER,
-            opacity,
-        );
-    }
     let orange = RenderColor::rgb(1.0, 0.48, 0.08);
-    for obstacle in event.obstacles.iter().filter(|o| o.height > 0.0) {
-        rect(
-            frame,
-            event,
-            Vec2::new(obstacle.start, layout.floor_y),
-            Vec2::new(obstacle.end, layout.floor_y + obstacle.height),
-            orange,
-            ACTIVE_CELL_LAYER,
-            opacity,
-        );
-        rect(
-            frame,
-            event,
-            Vec2::new(
-                obstacle.start,
-                layout.floor_y + obstacle.height - radius * 0.3,
-            ),
-            Vec2::new(obstacle.end, layout.floor_y + obstacle.height),
-            RenderColor::rgb(1.0, 0.85, 0.45),
-            ACTIVE_CELL_LAYER,
-            opacity,
-        );
+    if let Some(course) = &event.course {
+        for surface in &course.surfaces {
+            let left = surface.start.max(0.0);
+            let right = surface.end.min(event.width);
+            let top = layout.floor_y + surface.height;
+            rect(
+                frame,
+                event,
+                Vec2::new(left, layout.bounds_min.y),
+                Vec2::new(right, layout.floor_y),
+                FLOOR_COLOR,
+                ARENA_LAYER,
+                opacity,
+            );
+            if surface.height > 0.0 {
+                rect(
+                    frame,
+                    event,
+                    Vec2::new(left, layout.floor_y),
+                    Vec2::new(right, top),
+                    orange,
+                    ARENA_LAYER,
+                    opacity,
+                );
+            }
+            rect(
+                frame,
+                event,
+                Vec2::new(left, top - event.radius * 0.25),
+                Vec2::new(right, top),
+                if surface.height > 0.0 {
+                    RenderColor::rgb(1.0, 0.85, 0.45)
+                } else {
+                    FLOOR_EDGE_COLOR
+                },
+                ACTIVE_CELL_LAYER,
+                opacity,
+            );
+        }
+    } else {
+        let pit = event.obstacles[1];
+        for (start, end) in [(0.0, pit.start), (pit.end, event.width)] {
+            rect(
+                frame,
+                event,
+                Vec2::new(start, layout.bounds_min.y),
+                Vec2::new(end, layout.floor_y),
+                FLOOR_COLOR,
+                ARENA_LAYER,
+                opacity,
+            );
+            rect(
+                frame,
+                event,
+                Vec2::new(start, layout.floor_y - 2.0),
+                Vec2::new(end, layout.floor_y),
+                FLOOR_EDGE_COLOR,
+                ARENA_LAYER,
+                opacity,
+            );
+        }
+        for obstacle in event.obstacles.iter().filter(|o| o.height > 0.0) {
+            rect(
+                frame,
+                event,
+                Vec2::new(obstacle.start, layout.floor_y),
+                Vec2::new(obstacle.end, layout.floor_y + obstacle.height),
+                orange,
+                ACTIVE_CELL_LAYER,
+                opacity,
+            );
+            rect(
+                frame,
+                event,
+                Vec2::new(
+                    obstacle.start,
+                    layout.floor_y + obstacle.height - radius * 0.3,
+                ),
+                Vec2::new(obstacle.end, layout.floor_y + obstacle.height),
+                RenderColor::rgb(1.0, 0.85, 0.45),
+                ACTIVE_CELL_LAYER,
+                opacity,
+            );
+        }
+    }
+    if debug && let Some(arc) = event.debug_arc() {
+        for (index, point) in arc.into_iter().enumerate() {
+            let size = radius * if index == 0 || index == 24 { 0.5 } else { 0.15 };
+            let color = if index == 24 {
+                RenderColor::rgb(0.15, 1.0, 0.4)
+            } else if index == 0 {
+                RenderColor::rgb(0.15, 0.85, 1.0)
+            } else {
+                RenderColor::rgb(0.85, 0.4, 1.0)
+            };
+            rect(
+                frame,
+                event,
+                point - Vec2::splat(size),
+                point + Vec2::splat(size),
+                color,
+                LABEL_LAYER,
+                opacity,
+            );
+        }
     }
     let (entrance, exit) = event.door_openness();
     for (x, open) in [(radius * 2.0, entrance), (event.width - radius * 2.0, exit)] {
+        if x > event.width * 0.5 && !event.exit_visible() {
+            continue;
+        }
         let bottom = layout.floor_y;
         let top = bottom + radius * 4.0;
         let half = radius * 1.5;
@@ -124,9 +189,14 @@ pub(super) fn render(frame: &mut RenderFrame, event: &DuckEvent) {
                 b'K' => BACKGROUND_COLOR,
                 _ => continue,
             };
+            let offset_x = (column as f32 - 6.0) * pixel;
             let min = position
                 + Vec2::new(
-                    (column as f32 - 6.0) * pixel,
+                    if event.facing() > 0.0 {
+                        offset_x
+                    } else {
+                        -offset_x - pixel
+                    },
                     -radius + (8 - row) as f32 * pixel,
                 );
             rect(
@@ -146,7 +216,16 @@ pub(super) fn render(frame: &mut RenderFrame, event: &DuckEvent) {
         0.0
     };
     for (x, offset) in [(-2.0, stride), (1.0, -stride)] {
-        let min = position + Vec2::new(x * pixel + offset, -radius);
+        let offset_x = x * pixel + offset;
+        let min = position
+            + Vec2::new(
+                if event.facing() > 0.0 {
+                    offset_x
+                } else {
+                    -offset_x - pixel * 2.0
+                },
+                -radius,
+            );
         rect(
             frame,
             event,


### PR DESCRIPTION
## Summary

Upgrade the existing Clock scenario's Duck event into a calibrated, repeatable platform-running playground. This does not add another scenario.

Closes #69.

- Hide the exit for 20 seconds after spawn while the duck repeatedly tags both walls. Add distinct walking/running speeds and a 50% higher jump, with bounded exit/reset and complete physics cleanup.
- Measure jump height, airtime, running speed, and acceleration from actual motion. Reject disturbed/outlier samples and plan from those measurements rather than consulting actuator tuning.
- Preserve two seeded, per-spawn personalities: **Careful** keeps the deliberate stop-and-hop style; **Flowing** uses running takeoffs, moving landings, and bounded two-link lookahead, falling back to careful hops when needed.
- Generate a seeded mix of **Platforms**, **Terraces**, **Two-jump**, and **Shortcut** courses. Validate adjacent routes in both directions, cap generation attempts, and retain a safe fallback. Authored patterns preserve runway/gap widths and vary raised heights by ±10%.
- Let Flowing skip one intermediate platform when the complete arc and landing are safe and its estimated cost is worthwhile. Confirm success from real target contact, not predicted arrival. Linked jumps require a real touchdown between them—no midair double jump.
- Add course/profile overrides, optional trajectory rendering, and additive CLI/JSON telemetry for calibration, plans, actual support, confirmed landings, misses, fallbacks, and platform skips. Document the model, reproducible test commands, and playtesting workflow.

## Implementation boundaries

- One dynamic Rapier body plus fixed course colliders; at most seven surfaces plus the duck.
- At most 108 candidate arcs per Flowing planning decision, each with bounded clearance sampling. No extra physics rollout, global path search, or per-frame replanning.
- Revalidate the actual takeoff and replan after confirmed contact. Landing candidates reserve room for braking and slightly early launches.
- Personality and course selection use independent seeded streams. Standard benchmarks remain pinned to Careful on the original Platforms generator.
- Existing diagnostic payloads remain readable through additive serde defaults. No persistent menu settings or unrelated gameplay changes.

## Validation

- **418 focused tests passed:** 128 Clock/common/control/CLI tests and 290 client tests. Extended sweeps and display-dependent workflows are run explicitly, not silently counted as passing ignored tests.
- **1,792 authored/generated pattern runs** across four patterns, seven aspect ratios, 32 seeds, and both personalities: **21,418 confirmed landings**, no missed landings, falls, or timeouts. Flowing completed **7,066 running-jump pairs** and **958 platform skips**; Careful skipped none.
- A fixed one-jump-planner comparison proves why the first landing matters for the second jump. Real-solver tests require linked jumps and shortcuts in both directions at the HyperPixel and Picade aspect ratios; blocked and too-narrow shortcuts must be rejected.
- Raster/vector render checks cover all four patterns and both personalities at four resolutions. Reviewed captures at 800×480 and 1024×768.
- The real-client Duck workflow passed under Xvfb with Flowing, the Shortcut course, and the trajectory overlay: controls, diagnostics, pause, preview replacement, exit, cleanup, restart, and relaunch.
- Formatting, whitespace checks, strict scoped Clippy (`--no-deps`), and the host `pi-kiosk` feature check passed. No deployment to the Pi for this upgrade.
- User playtesting approved the movement/personality work; the final authored-course additions also received the automated checks above. Full notes and earlier baseline measurements are in `docs/clock.md`.

## Try it

```sh
SPACEWARS_CLOCK_DUCK_PROFILE=flowing \
SPACEWARS_CLOCK_DUCK_COURSE=two-jump \
SPACEWARS_CLOCK_DUCK_DEBUG=1 \
cargo run --release -p engine-client -- --scenario clock --seed 42
```

Open **Clock Controls → Preview Event → Duck → Preview & Resume**. Change the course to `shortcut` to watch platform skipping, or the profile to `careful` to compare the adjacent stop-and-hop route. Unset overrides select a reproducible seeded mix.
